### PR TITLE
Support running the treehouse plugin on Java 8

### DIFF
--- a/treehouse-schema-generator/build.gradle
+++ b/treehouse-schema-generator/build.gradle
@@ -8,4 +8,7 @@ dependencies {
   implementation deps.kotlin.reflect
   implementation deps.kotlinPoet
   implementation deps.clikt
+
+  testImplementation deps.junit
+  testImplementation deps.truth
 }

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schemaParser.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schemaParser.kt
@@ -54,5 +54,5 @@ fun parseSchema(schemaFqcn: String): Schema {
 
   // TODO ensure node values are unique inside a node
 
-  return Schema(schemaType.simpleName, schemaType.packageName, nodes)
+  return Schema(schemaType.simpleName, packageName(schemaType), nodes)
 }

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
@@ -23,3 +23,9 @@ internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val emitReference = MemberName("androidx.compose.runtime", "emit")
 
 internal val iae = ClassName("kotlin", "IllegalArgumentException")
+
+/** [Class.packageName] isn't available until Java 9. */
+internal fun packageName(schemaType: Class<*>): String {
+  require(!schemaType.isPrimitive && !schemaType.isArray)
+  return schemaType.name.substringBeforeLast(".", missingDelimiterValue = "")
+}

--- a/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/TypesTest.kt
+++ b/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/TypesTest.kt
@@ -1,0 +1,23 @@
+package app.cash.treehouse.schema.generator
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
+import org.junit.Test
+
+class TypesTest {
+  @Test
+  fun packageName() {
+    assertThat(packageName(String::class.java)).isEqualTo("java.lang")
+    assertThat(packageName(TypesTest::class.java)).isEqualTo("app.cash.treehouse.schema.generator")
+    try {
+      packageName(arrayOf<String>()::class.java)
+      fail()
+    } catch (_: IllegalArgumentException) {
+    }
+    try {
+      packageName(Int::class.java)
+      fail()
+    } catch (_: IllegalArgumentException) {
+    }
+  }
+}


### PR DESCRIPTION
We were using an API that required Java 9. This was causing problems
with other builds that assumed Gradle was running on Java 8.