### PR TITLE
Fix two kinds of name collisions

### DIFF
--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeGeneration.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeGeneration.kt
@@ -58,8 +58,8 @@ fun generateComposeNode(schema: Schema, node: Node): FileSpec {
     schema.composeNodeType(node)
   }
   val applierOfServerNode = applier.parameterizedBy(composeNode)
-  return FileSpec.builder(schema.composePackage, node.name)
-    .addFunction(FunSpec.builder(node.name)
+  return FileSpec.builder(schema.composePackage, node.flatName)
+    .addFunction(FunSpec.builder(node.flatName)
       .addModifiers(PUBLIC)
       .addAnnotation(composable)
       .receiver(treehouseScope)
@@ -117,7 +117,7 @@ fun generateComposeNode(schema: Schema, node: Node): FileSpec {
                 is Property -> {
                   add("set(%N) {\n", trait.name)
                   indent()
-                  add("appendDiff(%T(id, %L, %N))\n", propertyDiff, trait.tag, trait.name)
+                  add("appendDiff(%T(this.id, %L, %N))\n", propertyDiff, trait.tag, trait.name)
                   unindent()
                   add("}\n")
                 }
@@ -125,7 +125,7 @@ fun generateComposeNode(schema: Schema, node: Node): FileSpec {
                   add("set(%N) {\n", trait.name)
                   indent()
                   add("this.%1N = %1N\n", trait.name)
-                  add("appendDiff(%T(id, %L, %N != null))\n", propertyDiff, trait.tag, trait.name)
+                  add("appendDiff(%T(this.id, %L, %N != null))\n", propertyDiff, trait.tag, trait.name)
                   unindent()
                   add("}\n")
                 }

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/displayGeneration.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/displayGeneration.kt
@@ -42,7 +42,7 @@ fun generateDisplayNodeFactory(schema: Schema): FileSpec {
       .addSuperinterface(treeNodeFactory.parameterizedBy(typeVariableT))
       .apply {
         for (node in schema.nodes) {
-          addFunction(FunSpec.builder(node.name)
+          addFunction(FunSpec.builder(node.flatName)
             .addModifiers(PUBLIC, ABSTRACT)
             .addParameter("parent", typeVariableT)
             .apply {
@@ -68,7 +68,7 @@ fun generateDisplayNodeFactory(schema: Schema): FileSpec {
             for (event in node.traits.filterIsInstance<Event>()) {
               factoryArguments += CodeBlock.of("{ events.send(%T(id, %L, null)) }", eventType, event.tag)
             }
-            addStatement("%L -> %N(%L)", node.tag, node.name, factoryArguments.joinToCode())
+            addStatement("%L -> %N(%L)", node.tag, node.flatName, factoryArguments.joinToCode())
           }
         }
         .addStatement("else -> throw %T(\"Unknown kind \$kind\")", iae)
@@ -97,8 +97,8 @@ interface SunspotButton<out T: Any> : SunspotNode<T> {
 fun generateDisplayNode(schema: Schema, node: Node): FileSpec {
   val typeVariableT = TypeVariableName("T", listOf(ANY))
   val childrenOfT = treeNodeChildren.parameterizedBy(typeVariableT)
-  return FileSpec.builder(schema.displayPackage, node.name)
-    .addType(TypeSpec.interfaceBuilder(node.name)
+  return FileSpec.builder(schema.displayPackage, node.flatName)
+    .addType(TypeSpec.interfaceBuilder(node.flatName)
       .addModifiers(PUBLIC)
       .addTypeVariable(typeVariableT)
       .addSuperinterface(treeNode.parameterizedBy(typeVariableT))

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schema.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schema.kt
@@ -14,19 +14,26 @@ data class Schema(
   internal val nodeFactoryType = ClassName(displayPackage, "${name}NodeFactory")
 
   fun displayNodeType(node: Node): ClassName {
-    return ClassName(displayPackage, node.name)
+    return ClassName(displayPackage, node.flatName)
   }
 
   fun composeNodeType(node: Node): ClassName {
-    return ClassName(composePackage, node.name + "Node")
+    return ClassName(composePackage, node.flatName + "Node")
   }
 }
 
 data class Node(
   val tag: Int,
-  val name: String,
+  private val className: ClassName,
   val traits: List<Trait>,
-)
+) {
+  /**
+   * Returns a single string that is likely to be unique within a schema, like `MapEntry` or
+   * `NavigationBarButton`.
+   */
+  val flatName: String
+    get() = className.simpleNames.joinToString(separator = "")
+}
 
 sealed class Trait {
   abstract val name: String

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schemaParser.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schemaParser.kt
@@ -1,5 +1,6 @@
 package app.cash.treehouse.schema.generator
 
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubtypeOf
@@ -48,8 +49,7 @@ fun parseSchema(schemaFqcn: String): Schema {
       "Only a single @Children property is supported at this time"
     }
 
-    val entityClassName = entity.simpleName!!
-    nodes += Node(nodeAnnotation.value, entityClassName, traits)
+    nodes += Node(nodeAnnotation.value, entity.asClassName(), traits)
   }
 
   // TODO ensure node values are unique inside a node

--- a/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateComposeNodeTest.kt
+++ b/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateComposeNodeTest.kt
@@ -1,0 +1,74 @@
+package app.cash.treehouse.schema.generator
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.asTypeName
+import org.junit.Test
+
+class GenerateComposeNodeTest {
+  @Test
+  internal fun `happy path`() {
+    val node = Node(
+      tag = 1,
+      className = ClassName("com.example", "Button"),
+      traits = listOf(
+        Property("label", tag = 2, type = String::class.asTypeName(), defaultExpression = null),
+        Property("color", tag = 3, type = String::class.asTypeName(), defaultExpression = null)
+      )
+    )
+
+    val schema = Schema("TestSchema", "com.example", nodes = listOf(node))
+
+    val fileSpec = generateComposeNode(schema, node)
+    assertThat(fileSpec.toString()).isEqualTo("""
+        |package com.example.compose
+        |
+        |import androidx.compose.runtime.Applier
+        |import androidx.compose.runtime.Composable
+        |import androidx.compose.runtime.ComposeNode
+        |import app.cash.treehouse.compose.Node
+        |import app.cash.treehouse.compose.TreehouseScope
+        |import app.cash.treehouse.protocol.PropertyDiff
+        |import kotlin.String
+        |import kotlin.Unit
+        |
+        |@Composable
+        |public fun TreehouseScope.Button(label: String, color: String): Unit {
+        |  ComposeNode<Node, Applier<Node>>(
+        |      factory = {
+        |        Node(nextId(), 1)
+        |      },
+        |      update = {
+        |        set(label) {
+        |          appendDiff(PropertyDiff(this.id, 2, label))
+        |        }
+        |        set(color) {
+        |          appendDiff(PropertyDiff(this.id, 3, color))
+        |        }
+        |      },
+        |      )
+        |}
+        |""".trimMargin())
+  }
+
+  @Test
+  internal fun `id property does not collide`() {
+    val node = Node(
+      tag = 1,
+      className = ClassName("com.example", "Button"),
+      traits = listOf(
+        Property("label", tag = 2, type = String::class.asTypeName(), defaultExpression = null),
+        Property("id", tag = 3, type = String::class.asTypeName(), defaultExpression = null)
+      )
+    )
+
+    val schema = Schema("TestSchema", "com.example", nodes = listOf(node))
+
+    val fileSpec = generateComposeNode(schema, node)
+    assertThat(fileSpec.toString()).contains("""
+        |        set(id) {
+        |          appendDiff(PropertyDiff(this.id, 3, id))
+        |        }
+        |""".trimMargin())
+  }
+}

--- a/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateDisplayNodeFactoryTest.kt
+++ b/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateDisplayNodeFactoryTest.kt
@@ -1,0 +1,40 @@
+package app.cash.treehouse.schema.generator
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.asTypeName
+import org.junit.Test
+
+class GenerateDisplayNodeFactoryTest {
+  @Test
+  internal fun `simple names do not collide`() {
+    val navigationBarButton = Node(
+      tag = 1,
+      className = ClassName("com.example.sunspot", "NavigationBar", "Button"),
+      traits = listOf(
+        Property("label", tag = 2, type = String::class.asTypeName(), defaultExpression = null)
+      )
+    )
+    val mooncakeButton = Node(
+      tag = 3,
+      className = ClassName("com.example.sunspot", "Button"),
+      traits = listOf(
+        Property("label", tag = 4, type = String::class.asTypeName(), defaultExpression = null)
+      )
+    )
+
+    val schema = Schema(
+      name = "TestSchema",
+      `package` = "com.example",
+      nodes = listOf(
+        navigationBarButton, mooncakeButton
+      )
+    )
+
+    val fileSpec = generateDisplayNodeFactory(schema)
+    assertThat(fileSpec.toString()).contains("""
+        |    1 -> NavigationBarButton(parent)
+        |    3 -> Button(parent)
+        |""".trimMargin())
+  }
+}


### PR DESCRIPTION
We had collisions between properties named 'id' and Treehouse Nodes.

We also had collisions between simple names in the schema.

This fixes both.