### PR TITLE
Accept KClass as schema parsing input and improve its exceptions

### DIFF
--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/main.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/main.kt
@@ -35,7 +35,10 @@ private class TreehouseGenerator : CliktCommand() {
 
   private val schemaType by argument("schema")
     .help("Fully-qualified class name for the @Schema-annotated interface")
-    .convert { Class.forName(it) as Class<*> }
+    .convert {
+      // Replace with https://youtrack.jetbrains.com/issue/KT-10440 once it ships.
+      Class.forName(it).kotlin
+    }
 
   override fun run() {
     val schema = parseSchema(schemaType)

--- a/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateComposeNodeTest.kt
+++ b/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateComposeNodeTest.kt
@@ -19,7 +19,7 @@ class GenerateComposeNodeTest {
   )
 
   @Test fun `id property does not collide`() {
-    val schema = parseSchema(IdPropertyNameCollisionSchema::class.java)
+    val schema = parseSchema(IdPropertyNameCollisionSchema::class)
 
     val fileSpec = generateComposeNode(schema, schema.nodes.single())
     assertThat(fileSpec.toString()).contains("""

--- a/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateDisplayNodeFactoryTest.kt
+++ b/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateDisplayNodeFactoryTest.kt
@@ -21,7 +21,7 @@ class GenerateDisplayNodeFactoryTest {
   data class Button(@Property(1) val text: String)
 
   @Test fun `simple names do not collide`() {
-    val schema = parseSchema(SimpleNameCollisionSchema::class.java)
+    val schema = parseSchema(SimpleNameCollisionSchema::class)
 
     val fileSpec = generateDisplayNodeFactory(schema)
     assertThat(fileSpec.toString()).contains("""
@@ -47,7 +47,7 @@ class GenerateDisplayNodeFactoryTest {
   data class Node12(@Property(1) val text: String)
 
   @Test fun `names are sorted by their node tags`() {
-    val schema = parseSchema(SortedByTagSchema::class.java)
+    val schema = parseSchema(SortedByTagSchema::class)
 
     val fileSpec = generateDisplayNodeFactory(schema)
     assertThat(fileSpec.toString()).contains("""

--- a/treehouse-schema-parser/src/main/kotlin/app/cash/treehouse/schema/parser/types.kt
+++ b/treehouse-schema-parser/src/main/kotlin/app/cash/treehouse/schema/parser/types.kt
@@ -1,7 +1,12 @@
 package app.cash.treehouse.schema.parser
 
-/** [Class.packageName] isn't available until Java 9. */
-internal fun packageName(schemaType: Class<*>): String {
-  require(!schemaType.isPrimitive && !schemaType.isArray)
-  return schemaType.name.substringBeforeLast(".", missingDelimiterValue = "")
-}
+import kotlin.reflect.KClass
+
+internal val KClass<*>.packageName: String
+  get() {
+    // Replace with https://youtrack.jetbrains.com/issue/KT-18104 once it ships.
+    // Note: Class.packageName isn't available until Java 9.
+    val javaClass = java
+    require(!javaClass.isPrimitive && !javaClass.isArray)
+    return javaClass.name.substringBeforeLast(".", missingDelimiterValue = "")
+  }

--- a/treehouse-schema-parser/src/test/kotlin/app/cash/treehouse/schema/parser/SchemaParserTest.kt
+++ b/treehouse-schema-parser/src/test/kotlin/app/cash/treehouse/schema/parser/SchemaParserTest.kt
@@ -11,9 +11,9 @@ class SchemaParserTest {
 
   @Test fun nonAnnotatedSchemaThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(NonAnnotationSchema::class.java)
+      parseSchema(NonAnnotationSchema::class)
     }.hasMessageThat().isEqualTo(
-      "Schema app.cash.treehouse.schema.parser.SchemaParserTest\$NonAnnotationSchema missing @Schema annotation")
+      "Schema app.cash.treehouse.schema.parser.SchemaParserTest.NonAnnotationSchema missing @Schema annotation")
   }
 
   @Schema([
@@ -26,9 +26,9 @@ class SchemaParserTest {
 
   @Test fun nonAnnotatedNodeThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(NonAnnotatedNodeSchema::class.java)
+      parseSchema(NonAnnotatedNodeSchema::class)
     }.hasMessageThat().isEqualTo(
-      "app.cash.treehouse.schema.parser.SchemaParserTest\$NonAnnotatedNode missing @Node annotation")
+      "app.cash.treehouse.schema.parser.SchemaParserTest.NonAnnotatedNode missing @Node annotation")
   }
 
   @Schema([
@@ -52,12 +52,12 @@ class SchemaParserTest {
 
   @Test fun duplicateNodeTagThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(DuplicateNodeTagSchema::class.java)
+      parseSchema(DuplicateNodeTagSchema::class)
     }.hasMessageThat().isEqualTo(
       """
       |Schema @Node tags must be unique
       |
-      |- @Node(1): app.cash.treehouse.schema.parser.SchemaParserTest${'$'}DuplicateNodeTagA, app.cash.treehouse.schema.parser.SchemaParserTest${'$'}DuplicateNodeTagB
+      |- @Node(1): app.cash.treehouse.schema.parser.SchemaParserTest.DuplicateNodeTagA, app.cash.treehouse.schema.parser.SchemaParserTest.DuplicateNodeTagB
       """.trimMargin())
   }
 
@@ -73,12 +73,12 @@ class SchemaParserTest {
 
   @Test fun repeatedNodeTypeThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(RepeatedNodeTypeSchema::class.java)
+      parseSchema(RepeatedNodeTypeSchema::class)
     }.hasMessageThat().isEqualTo(
       """
       |Schema contains repeated node
       |
-      |- app.cash.treehouse.schema.parser.SchemaParserTest${'$'}RepeatedNode
+      |- app.cash.treehouse.schema.parser.SchemaParserTest.RepeatedNode
       """.trimMargin())
   }
 
@@ -96,10 +96,10 @@ class SchemaParserTest {
 
   @Test fun duplicatePropertyTagThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(DuplicatePropertyTagSchema::class.java)
+      parseSchema(DuplicatePropertyTagSchema::class)
     }.hasMessageThat().isEqualTo(
       """
-      |Node app.cash.treehouse.schema.parser.SchemaParserTest${'$'}DuplicatePropertyTagNode's @Property tags must be unique
+      |Node app.cash.treehouse.schema.parser.SchemaParserTest.DuplicatePropertyTagNode's @Property tags must be unique
       |
       |- @Property(1): name, nickname
       """.trimMargin())
@@ -118,10 +118,10 @@ class SchemaParserTest {
 
   @Test fun duplicateChildrenTagThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(DuplicateChildrenTagSchema::class.java)
+      parseSchema(DuplicateChildrenTagSchema::class)
     }.hasMessageThat().isEqualTo(
       """
-      |Node app.cash.treehouse.schema.parser.SchemaParserTest${'$'}DuplicateChildrenTagNode's @Children tags must be unique
+      |Node app.cash.treehouse.schema.parser.SchemaParserTest.DuplicateChildrenTagNode's @Children tags must be unique
       |
       |- @Children(1): childrenA, childrenB
       """.trimMargin())
@@ -140,9 +140,9 @@ class SchemaParserTest {
 
   @Test fun unannotatedPrimaryParameterThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(UnannotatedPrimaryParameterSchema::class.java)
+      parseSchema(UnannotatedPrimaryParameterSchema::class)
     }.hasMessageThat().isEqualTo(
-      "Unannotated parameter \"unannotated\" on app.cash.treehouse.schema.parser.SchemaParserTest\$UnannotatedPrimaryParameterNode")
+      "Unannotated parameter \"unannotated\" on app.cash.treehouse.schema.parser.SchemaParserTest.UnannotatedPrimaryParameterNode")
   }
 
   @Schema([
@@ -156,9 +156,9 @@ class SchemaParserTest {
 
   @Test fun nonDataClassThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(NonDataClassSchema::class.java)
+      parseSchema(NonDataClassSchema::class)
     }.hasMessageThat().isEqualTo(
-      "@Node app.cash.treehouse.schema.parser.SchemaParserTest\$NonDataClassNode must be 'data' class")
+      "@Node app.cash.treehouse.schema.parser.SchemaParserTest.NonDataClassNode must be 'data' class")
   }
 
   @Schema([
@@ -172,8 +172,8 @@ class SchemaParserTest {
 
   @Test fun invalidChildrenTypeThrows() {
     assertThrows<IllegalArgumentException> {
-      parseSchema(InvalidChildrenTypeSchema::class.java)
+      parseSchema(InvalidChildrenTypeSchema::class)
     }.hasMessageThat().isEqualTo(
-      "@Children app.cash.treehouse.schema.parser.SchemaParserTest\$InvalidChildrenTypeNode#children must be of type 'List<Any>'")
+      "@Children app.cash.treehouse.schema.parser.SchemaParserTest.InvalidChildrenTypeNode#children must be of type 'List<Any>'")
   }
 }

--- a/treehouse-schema-parser/src/test/kotlin/app/cash/treehouse/schema/parser/TypesTest.kt
+++ b/treehouse-schema-parser/src/test/kotlin/app/cash/treehouse/schema/parser/TypesTest.kt
@@ -6,13 +6,13 @@ import org.junit.Test
 class TypesTest {
   @Test
   fun packageName() {
-    assertThat(packageName(String::class.java)).isEqualTo("java.lang")
-    assertThat(packageName(TypesTest::class.java)).isEqualTo("app.cash.treehouse.schema.parser")
+    assertThat(String::class.packageName).isEqualTo("java.lang")
+    assertThat(TypesTest::class.packageName).isEqualTo("app.cash.treehouse.schema.parser")
     assertThrows<IllegalArgumentException> {
-      packageName(arrayOf<String>()::class.java)
+      arrayOf<String>()::class.packageName
     }
     assertThrows<IllegalArgumentException> {
-      packageName(Int::class.java)
+      Int::class.packageName
     }
   }
 }


### PR DESCRIPTION
Prefer to use dot-delimited qualified names rather than ones which include a dollar-sign ($) which is an implementation detail of the JVM backend.

Closes #31 