### PR TITLE
Normalize some protocol/widget/compose naming

### DIFF
--- a/treehouse-protocol/src/commonMain/kotlin/app/cash/treehouse/protocol/protocol.kt
+++ b/treehouse-protocol/src/commonMain/kotlin/app/cash/treehouse/protocol/protocol.kt
@@ -5,63 +5,69 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Event(
-  val nodeId: Long,
+  /** Identifier for the widget from which this event originated. */
+  val id: Long,
+  /** Identifies which event occurred on the widget with [id]. */
   val tag: Int,
   @Polymorphic val value: Any?,
 )
 
 @Serializable
 data class Diff(
-  val widgetDiffs: List<WidgetDiff> = emptyList(),
+  val childrenDiffs: List<ChildrenDiff> = emptyList(),
   val propertyDiffs: List<PropertyDiff> = emptyList()
-) {
-  companion object {
-    const val RootId = 0L
-    const val RootChildrenIndex = 1
-  }
-}
+)
 
 @Serializable
 data class PropertyDiff(
+  /** Identifier for the widget whose property has changed. */
   val id: Long,
+  /** Identifies which property changed on the widget with [id]. */
   val tag: Int,
   @Polymorphic val value: Any?,
 )
 
 @Serializable
-sealed class WidgetDiff {
+sealed class ChildrenDiff {
+  /** Identifier for the widget whose children have changed. */
   abstract val id: Long
-  abstract val childrenIndex: Int
+  /** Identifies which group of children changed on the widget with [id]. */
+  abstract val tag: Int
 
   @Serializable
-  object Clear : WidgetDiff() {
-    override val id get() = Diff.RootId
-    override val childrenIndex get() = throw UnsupportedOperationException()
+  object Clear : ChildrenDiff() {
+    override val id get() = RootId
+    override val tag get() = RootChildrenTag
   }
 
   @Serializable
   data class Insert(
     override val id: Long,
-    override val childrenIndex: Int,
+    override val tag: Int,
     val childId: Long,
     val kind: Int,
     val index: Int,
-  ) : WidgetDiff()
+  ) : ChildrenDiff()
 
   @Serializable
   data class Move(
     override val id: Long,
-    override val childrenIndex: Int,
+    override val tag: Int,
     val fromIndex: Int,
     val toIndex: Int,
     val count: Int,
-  ) : WidgetDiff()
+  ) : ChildrenDiff()
 
   @Serializable
   data class Remove(
     override val id: Long,
-    override val childrenIndex: Int,
+    override val tag: Int,
     val index: Int,
     val count: Int,
-  ) : WidgetDiff()
+  ) : ChildrenDiff()
+
+  companion object {
+    const val RootId = 0L
+    const val RootChildrenTag = 1
+  }
 }

--- a/treehouse-schema-annotations/src/commonMain/kotlin/app/cash/treehouse/schema/annotations.kt
+++ b/treehouse-schema-annotations/src/commonMain/kotlin/app/cash/treehouse/schema/annotations.kt
@@ -19,7 +19,7 @@ annotation class Schema(val widgets: Array<KClass<*>>)
 
 /**
  * Annotates a data class which represents a widget in a UI tree. Each widget in a [Schema] must
- * have a unique [value] among all [@Widget][Widget] annotations in the [Schema].
+ * have a unique [tag] among all [@Widget][Widget] annotations in the [Schema].
  *
  * All of the properties in the class must be annotated with either [Property] or [Children].
  *
@@ -31,11 +31,11 @@ annotation class Schema(val widgets: Array<KClass<*>>)
  * )
  * ```
  */
-annotation class Widget(val value: Int)
+annotation class Widget(val tag: Int)
 
 /**
  * Annotates a [Widget] property which represents a property on the associated UI widget. Properties
- * in a [Widget] class must have a unique [value] among all [@Property][Property] annotations in
+ * in a [Widget] class must have a unique [tag] among all [@Property][Property] annotations in
  * the class.
  *
  * ```
@@ -45,11 +45,11 @@ annotation class Widget(val value: Int)
  * )
  * ```
  */
-annotation class Property(val value: Int)
+annotation class Property(val tag: Int)
 
 /**
  * Annotates a [Widget] property as representing child widgets which are contained within the
- * enclosing widget. Children in a [Widget] class must have a unique [value] among all
+ * enclosing widget. Children in a [Widget] class must have a unique [tag] among all
  * [@Children][Children] annotations in the class. The type of the property must be `List<Any>`.
  *
  * ```
@@ -59,7 +59,7 @@ annotation class Property(val value: Int)
  * )
  * ```
  */
-annotation class Children(val value: Int)
+annotation class Children(val tag: Int)
 
 /**
  * Annotates a [Property] with an associated default expression. The [expression] is not

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetGeneration.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetGeneration.kt
@@ -134,15 +134,15 @@ fun generateWidget(schema: Schema, widget: Widget): FileSpec {
         if (childrens.isNotEmpty()) {
           addFunction(FunSpec.builder("children")
             .addModifiers(PUBLIC, OVERRIDE)
-            .addParameter("index", INT)
+            .addParameter("tag", INT)
             .returns(childrenOfT)
-            .beginControlFlow("return when (index)")
+            .beginControlFlow("return when (tag)")
             .apply {
               for (children in childrens) {
                 addStatement("%L -> %N", children.tag, children.name)
               }
             }
-            .addStatement("else -> throw %T(\"Unknown index \$index\")", iae)
+            .addStatement("else -> throw %T(\"Unknown tag \$tag\")", iae)
             .endControlFlow()
             .build())
         }

--- a/treehouse-schema/src/main/kotlin/app/cash/treehouse/schema/parser/schema.kt
+++ b/treehouse-schema/src/main/kotlin/app/cash/treehouse/schema/parser/schema.kt
@@ -16,28 +16,28 @@ data class Widget(
 )
 
 sealed class Trait {
-  abstract val name: String
   abstract val tag: Int
+  abstract val name: String
   abstract val defaultExpression: String?
 }
 
 data class Property(
-  override val name: String,
   override val tag: Int,
+  override val name: String,
   val type: KType,
   override val defaultExpression: String?,
 ) : Trait()
 
 data class Event(
-  override val name: String,
   override val tag: Int,
+  override val name: String,
   // TODO parameter type list?
   override val defaultExpression: String?,
 ) : Trait()
 
 data class Children(
-  override val name: String,
   override val tag: Int,
+  override val name: String,
 ) : Trait() {
   override val defaultExpression: String? get() = null
 }

--- a/treehouse-schema/src/main/kotlin/app/cash/treehouse/schema/parser/schemaParser.kt
+++ b/treehouse-schema/src/main/kotlin/app/cash/treehouse/schema/parser/schemaParser.kt
@@ -50,15 +50,15 @@ fun parseSchema(schemaType: KClass<*>): Schema {
 
       if (property != null) {
         if (it.type.isSubtypeOf(Function::class.starProjectedType)) {
-          Event(it.name!!, property.value, defaultExpression)
+          Event(property.tag, it.name!!, defaultExpression)
         } else {
-          Property(it.name!!, property.value, it.type, defaultExpression)
+          Property(property.tag, it.name!!, it.type, defaultExpression)
         }
       } else if (children != null) {
         require(it.type == LIST_OF_ANY_TYPE) {
           "@Children ${widgetType.qualifiedName}#${it.name} must be of type 'List<Any>'"
         }
-        Children(it.name!!, children.value)
+        Children(children.tag, it.name!!)
       } else {
         throw IllegalArgumentException("Unannotated parameter \"${it.name}\" on ${widgetType.qualifiedName}")
       }
@@ -88,7 +88,7 @@ fun parseSchema(schemaType: KClass<*>): Schema {
       })
     }
 
-    widgets += Widget(widgetAnnotation.value, widgetType, traits)
+    widgets += Widget(widgetAnnotation.tag, widgetType, traits)
   }
 
   val badWidgets = widgets.groupBy(Widget::tag).filterValues { it.size > 1 }

--- a/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/Widget.kt
+++ b/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/Widget.kt
@@ -8,7 +8,7 @@ interface Widget<T : Any> {
 
   fun apply(diff: PropertyDiff)
 
-  fun children(index: Int): Children<T> {
+  fun children(tag: Int): Children<T> {
     throw IllegalArgumentException("Widget does not support children")
   }
 

--- a/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/WidgetDisplay.kt
+++ b/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/WidgetDisplay.kt
@@ -1,8 +1,9 @@
 package app.cash.treehouse.widget
 
+import app.cash.treehouse.protocol.ChildrenDiff
+import app.cash.treehouse.protocol.ChildrenDiff.Companion.RootId
 import app.cash.treehouse.protocol.Diff
 import app.cash.treehouse.protocol.Event
-import app.cash.treehouse.protocol.WidgetDiff
 
 interface Display {
   fun apply(diff: Diff, events: (Event) -> Unit)
@@ -12,31 +13,32 @@ class WidgetDisplay<T : Any>(
   private val root: Widget<T>,
   private val factory: Widget.Factory<T>,
 ) : Display {
-  private val widgets = mutableMapOf(Diff.RootId to root)
+  private val widgets = mutableMapOf(RootId to root)
 
   override fun apply(diff: Diff, events: (Event) -> Unit) {
-    for (widgetDiff in diff.widgetDiffs) {
-      val widget = checkNotNull(widgets[widgetDiff.id]) {
-        "Unknown widget ID ${widgetDiff.id}"
+    for (childrenDiff in diff.childrenDiffs) {
+      val widget = checkNotNull(widgets[childrenDiff.id]) {
+        "Unknown widget ID ${childrenDiff.id}"
       }
+      val children = widget.children(childrenDiff.tag)
 
-      when (widgetDiff) {
-        is WidgetDiff.Insert -> {
-          val childWidget = factory.create(widget.value, widgetDiff.kind, widgetDiff.childId, events)
-          widgets[widgetDiff.childId] = childWidget
-          widget.children(widgetDiff.childrenIndex).insert(widgetDiff.index, childWidget.value)
+      when (childrenDiff) {
+        is ChildrenDiff.Insert -> {
+          val childWidget = factory.create(widget.value, childrenDiff.kind, childrenDiff.childId, events)
+          widgets[childrenDiff.childId] = childWidget
+          children.insert(childrenDiff.index, childWidget.value)
         }
-        is WidgetDiff.Move -> {
-          widget.children(widgetDiff.childrenIndex).move(widgetDiff.fromIndex, widgetDiff.toIndex, widgetDiff.count)
+        is ChildrenDiff.Move -> {
+          children.move(childrenDiff.fromIndex, childrenDiff.toIndex, childrenDiff.count)
         }
-        is WidgetDiff.Remove -> {
-          widget.children(widgetDiff.childrenIndex).remove(widgetDiff.index, widgetDiff.count)
+        is ChildrenDiff.Remove -> {
+          children.remove(childrenDiff.index, childrenDiff.count)
           // TODO we need to remove widgets from our map!
         }
-        WidgetDiff.Clear -> {
-          widget.children(Diff.RootChildrenIndex).clear()
+        ChildrenDiff.Clear -> {
+          children.clear()
           widgets.clear()
-          widgets[Diff.RootId] = root
+          widgets[RootId] = root
         }
       }
     }


### PR DESCRIPTION
An 'id' is a generated value for uniquely identifying a widget instance or its assodicated compose node instance.
A 'tag' is a user-supplied value from the schema which is a discriminator that differentiates widget types, properties, events, and groups of children.