### PR TITLE
Create event lambdas when property is set

### DIFF
--- a/example/android/src/main/java/example/android/sunspot/AndroidSunspotButton.kt
+++ b/example/android/src/main/java/example/android/sunspot/AndroidSunspotButton.kt
@@ -6,9 +6,7 @@ import example.sunspot.widget.SunspotButton
 
 class AndroidSunspotButton(
   override val value: Button,
-  private val onClick: () -> Unit,
-) : SunspotButton<View>,
-    View.OnClickListener {
+) : SunspotButton<View> {
   override fun text(text: String?) {
     value.text = text
   }
@@ -17,11 +15,11 @@ class AndroidSunspotButton(
     value.isEnabled = enabled
   }
 
-  override fun onClick(onClick: Boolean) {
-    value.setOnClickListener(if (onClick) this else null)
-  }
-
-  override fun onClick(v: View?) {
-    onClick.invoke()
+  override fun onClick(onClick: (() -> Unit)?) {
+    value.setOnClickListener(if (onClick != null) {
+      { onClick() }
+    } else {
+      null
+    })
   }
 }

--- a/example/android/src/main/java/example/android/sunspot/AndroidSunspotWidgetFactory.kt
+++ b/example/android/src/main/java/example/android/sunspot/AndroidSunspotWidgetFactory.kt
@@ -24,9 +24,8 @@ object AndroidSunspotWidgetFactory : SunspotWidgetFactory<View> {
 
   override fun SunspotButton(
     parent: View,
-    onClick: () -> Unit,
   ): SunspotButton<View> {
     val view = Button(parent.context)
-    return AndroidSunspotButton(view, onClick)
+    return AndroidSunspotButton(view)
   }
 }

--- a/example/web/src/main/kotlin/example/web/sunspot/widgetFactory.kt
+++ b/example/web/src/main/kotlin/example/web/sunspot/widgetFactory.kt
@@ -24,9 +24,8 @@ object HtmlSunspotNodeFactory : SunspotWidgetFactory<HTMLElement> {
 
   override fun SunspotButton(
     parent: HTMLElement,
-    onClick: () -> Unit,
   ): SunspotButton<HTMLElement> {
     val button = parent.ownerDocument!!.createElement("button") as HTMLButtonElement
-    return HtmlSunspotButton(button, onClick)
+    return HtmlSunspotButton(button)
   }
 }

--- a/example/web/src/main/kotlin/example/web/sunspot/widgets.kt
+++ b/example/web/src/main/kotlin/example/web/sunspot/widgets.kt
@@ -31,7 +31,6 @@ class HtmlSunspotText(
 
 class HtmlSunspotButton(
   override val value: HTMLButtonElement,
-  private val onClick: () -> Unit,
 ) : SunspotButton<HTMLElement> {
   override fun text(text: String?) {
     value.textContent = text
@@ -41,9 +40,9 @@ class HtmlSunspotButton(
     value.disabled = !enabled
   }
 
-  override fun onClick(onClick: Boolean) {
-    value.onclick = if (onClick) {
-      { this.onClick.invoke() }
+  override fun onClick(onClick: (() -> Unit)?) {
+    value.onclick = if (onClick != null) {
+      { onClick() }
     } else {
       null
     }

--- a/treehouse-gradle/src/test/fixture/counter/android/src/main/java/example/android/counter/AndroidCounterButton.kt
+++ b/treehouse-gradle/src/test/fixture/counter/android/src/main/java/example/android/counter/AndroidCounterButton.kt
@@ -6,9 +6,7 @@ import example.counter.widget.CounterButton
 
 class AndroidCounterButton(
   override val value: Button,
-  private val onClick: () -> Unit,
-) : CounterButton<View>,
-    View.OnClickListener {
+) : CounterButton<View> {
   override fun text(text: String?) {
     value.text = text
   }
@@ -17,11 +15,11 @@ class AndroidCounterButton(
     value.isEnabled = enabled
   }
 
-  override fun onClick(onClick: Boolean) {
-    value.setOnClickListener(if (onClick) this else null)
-  }
-
-  override fun onClick(v: View?) {
-    onClick.invoke()
+  override fun onClick(onClick: (() -> Unit)?) {
+    value.setOnClickListener(if (onClick != null) {
+      { onClick() }
+    } else {
+      null
+    })
   }
 }

--- a/treehouse-gradle/src/test/fixture/counter/android/src/main/java/example/android/counter/AndroidCounterWidgetFactory.kt
+++ b/treehouse-gradle/src/test/fixture/counter/android/src/main/java/example/android/counter/AndroidCounterWidgetFactory.kt
@@ -24,9 +24,8 @@ object AndroidCounterWidgetFactory : CounterWidgetFactory<View> {
 
   override fun CounterButton(
     parent: View,
-    onClick: () -> Unit,
   ): CounterButton<View> {
     val view = Button(parent.context)
-    return AndroidCounterButton(view, onClick)
+    return AndroidCounterButton(view)
   }
 }

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeGeneration.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeGeneration.kt
@@ -6,7 +6,6 @@ import app.cash.treehouse.schema.parser.Event
 import app.cash.treehouse.schema.parser.Property
 import app.cash.treehouse.schema.parser.Schema
 import app.cash.treehouse.schema.parser.Widget
-import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -14,12 +13,10 @@ import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.LONG
-import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.jvm.jvmField
@@ -80,17 +77,12 @@ fun generateComposeNode(schema: Schema, widget: Widget): FileSpec {
                 .build()
             }
             is Event -> {
-              val type = LambdaTypeName.get(returnType = UNIT).copy(nullable = true)
-              ParameterSpec.builder(trait.name, type)
+              ParameterSpec.builder(trait.name, eventLambda.copy(nullable = true))
                 .defaultValue("null")
                 .build()
             }
             is Children -> {
-              val type = LambdaTypeName.get(returnType = UNIT)
-                .copy(annotations = listOf(
-                  AnnotationSpec.builder(composable).build(),
-                ))
-              ParameterSpec.builder(trait.name, type)
+              ParameterSpec.builder(trait.name, composableLambda)
                 .build()
             }
           })
@@ -181,8 +173,7 @@ fun generateComposeNode(schema: Schema, widget: Widget): FileSpec {
           .addSuperclassConstructorParameter("%L", widget.tag)
           .apply {
             for (event in events) {
-              val type = LambdaTypeName.get(returnType = UNIT).copy(nullable = true)
-              addProperty(PropertySpec.builder(event.name, type)
+              addProperty(PropertySpec.builder(event.name, eventLambda.copy(nullable = true))
                 .mutable(true)
                 .initializer("null")
                 .jvmField() // Method count optimization as this is implementation detail.

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
@@ -1,5 +1,6 @@
 package app.cash.treehouse.schema.generator
 
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
@@ -8,7 +9,9 @@ import com.squareup.kotlinpoet.UNIT
 internal val eventType = ClassName("app.cash.treehouse.protocol", "Event")
 internal val propertyDiff = ClassName("app.cash.treehouse.protocol", "PropertyDiff")
 
-internal val eventSink = LambdaTypeName.get(eventType, returnType = UNIT)
+internal val eventSink = LambdaTypeName.get(receiver = null, eventType, returnType = UNIT)
+internal val eventLambda = LambdaTypeName.get(returnType = UNIT).copy(nullable = true)
+
 internal val widget = ClassName("app.cash.treehouse.widget", "Widget")
 internal val widgetChildren = widget.nestedClass("Children")
 internal val widgetFactory = widget.nestedClass("Factory")
@@ -20,5 +23,10 @@ internal val treehouseScope = ClassName("app.cash.treehouse.compose", "Treehouse
 internal val applier = ClassName("androidx.compose.runtime", "Applier")
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val composeNodeReference = MemberName("androidx.compose.runtime", "ComposeNode")
+
+internal val composableLambda = LambdaTypeName.get(returnType = UNIT)
+  .copy(annotations = listOf(
+    AnnotationSpec.builder(composable).build(),
+  ))
 
 internal val iae = ClassName("kotlin", "IllegalArgumentException")

--- a/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/Widget.kt
+++ b/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/Widget.kt
@@ -6,7 +6,7 @@ import app.cash.treehouse.protocol.PropertyDiff
 interface Widget<T : Any> {
   val value: T
 
-  fun apply(diff: PropertyDiff)
+  fun apply(diff: PropertyDiff, events: (Event) -> Unit)
 
   fun children(tag: Int): Children<T> {
     throw IllegalArgumentException("Widget does not support children")
@@ -20,6 +20,6 @@ interface Widget<T : Any> {
   }
 
   interface Factory<T : Any> {
-    fun create(parent: T, kind: Int, id: Long, events: (Event) -> Unit): Widget<T>
+    fun create(parent: T, kind: Int, id: Long): Widget<T>
   }
 }

--- a/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/WidgetDisplay.kt
+++ b/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/WidgetDisplay.kt
@@ -31,7 +31,7 @@ class WidgetDisplay<T : Any>(
 
       when (childrenDiff) {
         is ChildrenDiff.Insert -> {
-          val childWidget = factory.create(widget.value, childrenDiff.kind, childrenDiff.childId, events)
+          val childWidget = factory.create(widget.value, childrenDiff.kind, childrenDiff.childId)
           widgets[childrenDiff.childId] = childWidget
           children.insert(childrenDiff.index, childWidget.value)
         }
@@ -55,7 +55,7 @@ class WidgetDisplay<T : Any>(
         "Unknown widget ID ${propertyDiff.id}"
       }
 
-      widget.apply(propertyDiff)
+      widget.apply(propertyDiff, events)
     }
   }
 }

--- a/treehouse-widget/src/commonTest/kotlin/app/cash/treehouse/widget/WidgetDisplayTest.kt
+++ b/treehouse-widget/src/commonTest/kotlin/app/cash/treehouse/widget/WidgetDisplayTest.kt
@@ -17,13 +17,13 @@ class WidgetDisplayTest {
 
   private object BadRootWidget : Widget<Unit> {
     override val value get() = Unit
-    override fun apply(diff: PropertyDiff) = throw UnsupportedOperationException()
+    override fun apply(diff: PropertyDiff, events: (Event) -> Unit) = throw UnsupportedOperationException()
     override fun children(tag: Int) = throw IllegalArgumentException()
   }
 
   private object GoodRootWidget : Widget<Unit> {
     override val value get() = Unit
-    override fun apply(diff: PropertyDiff) = throw UnsupportedOperationException()
+    override fun apply(diff: PropertyDiff, events: (Event) -> Unit) = throw UnsupportedOperationException()
     override fun children(tag: Int) = when (tag) {
       RootChildrenTag -> NullWidgetChildren
       else -> throw IllegalArgumentException()
@@ -31,8 +31,7 @@ class WidgetDisplayTest {
   }
 
   private object NullWidgetFactory : Widget.Factory<Unit> {
-    override fun create(parent: Unit, kind: Int, id: Long, events: (Event) -> Unit) =
-      throw UnsupportedOperationException()
+    override fun create(parent: Unit, kind: Int, id: Long) = throw UnsupportedOperationException()
   }
 
   private object NullWidgetChildren : Widget.Children<Unit> {


### PR DESCRIPTION
This has two nice effects. The first is that it defers a bunch of lambda creation until needed. If you toggle an event property we will create two lambda instances instead of one, but that should be rare. The second advantage is that likely makes the widget interface viable as an indirection the generated compose code can talk through. This will enable compose to talk directly to widgets (#14) or produce diffs. Or perhaps produce schema instances for testing (#1).