### PR TITLE
Track parent node ID in synthetic child nodes

### DIFF
--- a/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
+++ b/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
@@ -32,9 +32,11 @@ interface TreehouseScope {
  * @suppress
  */
 @Composable
-fun `$SyntheticChildren`(tag: Int, content: @Composable () -> Unit) {
+fun `$SyntheticChildren`(parentId: Long, tag: Int, content: @Composable () -> Unit) {
   ComposeNode<ChildrenNode.Intermediate, Applier<Node>>(
-    factory = ChildrenNode::Intermediate,
+    factory = {
+      ChildrenNode.Intermediate(parentId)
+    },
     update = {
       set(tag) {
         this.tag = tag
@@ -46,12 +48,13 @@ fun `$SyntheticChildren`(tag: Int, content: @Composable () -> Unit) {
 
 /**
  * A node which exists in the tree to emulate supporting multiple children sets but which does not
- * appear directly in the protocol.
+ * appear directly in the protocol. The ID of these nodes mirrors that of its parent to simplify
+ * creation of the protocol diffs. This is safe because these types never appears in the node map.
  */
-private sealed class ChildrenNode(id: Long) : Node(id, -1) {
+private sealed class ChildrenNode(parentId: Long) : Node(parentId, -1) {
   abstract val tag: Int
 
-  class Intermediate : ChildrenNode(-1) {
+  class Intermediate(parentId: Long) : ChildrenNode(parentId) {
     override var tag = -1
   }
 

--- a/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
+++ b/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
@@ -23,6 +23,7 @@ internal val treehouseScope = ClassName("app.cash.treehouse.compose", "Treehouse
 internal val applier = ClassName("androidx.compose.runtime", "Applier")
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
 internal val composeNodeReference = MemberName("androidx.compose.runtime", "ComposeNode")
+internal val rememberReference = MemberName("androidx.compose.runtime", "remember")
 
 internal val composableLambda = LambdaTypeName.get(returnType = UNIT)
   .copy(


### PR DESCRIPTION
Because changes to children will occur beneath our synthetic children node, their IDs are the ones which end up in the protocol. Mirror the actual widget node's ID to the synthetic node so that it is reflected correctly in the protocol.