### PR TITLE
Next version is 0.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 
 GROUP=app.cash.treehouse
-VERSION_NAME=0.4.0-SNAPSHOT
+VERSION_NAME=0.2.0-SNAPSHOT
 
 POM_DESCRIPTION=Multiplatform tree management
 


### PR DESCRIPTION
0.1.0 went out to Maven Central. There were 0.2.0 and 0.3.0 releases internally, but we switched versioning to not conflict with open source.