### PR TITLE
Fail schema plugin if there is no JVM target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
     'clikt': 'com.github.ajalt.clikt:clikt:3.1.0',
     'exhaustiveAnnotation': "app.cash.exhaustive:exhaustive-annotation:${versions.exhaustive}",
     'junit': 'junit:junit:4.13.1',
+    'testParameterInjector': 'com.google.testparameterinjector:test-parameter-injector:1.1',
     'truth': 'com.google.truth:truth:1.1',
   ]
 

--- a/treehouse-gradle-plugin/build.gradle
+++ b/treehouse-gradle-plugin/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compileOnly deps.kotlin.gradlePlugin
 
   testImplementation deps.junit
+  testImplementation deps.testParameterInjector
   testImplementation deps.truth
   testImplementation gradleTestKit()
 }

--- a/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehouseSchemaPlugin.kt
+++ b/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehouseSchemaPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
 class TreehouseSchemaPlugin : Plugin<Project> {
@@ -22,7 +23,11 @@ class TreehouseSchemaPlugin : Plugin<Project> {
       val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
       kotlin.targets.all { it.applySchemaAnnotationDependency() }
 
-      // TODO check there is a JVM target in an afterEvaluate
+      project.afterEvaluate {
+        check(kotlin.targets.any { it.platformType == KotlinPlatformType.jvm }) {
+          "Treehouse schema plugin requires a jvm() target when used with Kotlin multiplatform"
+        }
+      }
     }
 
     project.afterEvaluate {

--- a/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/build.gradle
+++ b/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.treehouse:treehouse-gradle-plugin:$treehouseVersion"
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31'
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+  }
+}

--- a/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/gradle.properties
+++ b/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.mpp.stability.nowarn=true

--- a/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/schema/build.gradle
+++ b/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/schema/build.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'app.cash.treehouse.schema'
+
+kotlin {
+  js {
+    nodejs()
+  }
+}

--- a/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/schema/src/main/kotlin/example/counter/schema.kt
+++ b/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/schema/src/main/kotlin/example/counter/schema.kt
@@ -1,0 +1,34 @@
+package example.counter
+
+import app.cash.treehouse.schema.Children
+import app.cash.treehouse.schema.Default
+import app.cash.treehouse.schema.Property
+import app.cash.treehouse.schema.Schema
+import app.cash.treehouse.schema.Widget
+
+@Schema(
+  [
+    CounterBox::class,
+    CounterText::class,
+    CounterButton::class,
+  ]
+)
+interface Counter
+
+@Widget(1)
+data class CounterBox(
+  @Children(1) val children: List<Any>,
+)
+
+@Widget(2)
+data class CounterText(
+  @Property(1) val text: String?,
+  @Property(2) @Default("\"black\"") val color: String,
+)
+
+@Widget(3)
+data class CounterButton(
+  @Property(1) val text: String?,
+  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(3) val onClick: () -> Unit,
+)

--- a/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/settings.gradle
+++ b/treehouse-gradle-plugin/src/test/fixture/schema-no-jvm/settings.gradle
@@ -1,0 +1,1 @@
+include ':schema'


### PR DESCRIPTION
Currently we rely on JVM-based "full" reflection to parse the schema in downstream modules.

Closes #50 