### PR TITLE
Do not send redundant property diffs for lambdas

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,8 @@ include ':treehouse-protocol'
 include ':treehouse-schema'
 include ':treehouse-schema-annotations'
 include ':treehouse-schema-generator'
+include ':treehouse-test-schema'
+include ':treehouse-test-schema:compose'
 include ':treehouse-widget'
 
 include ':example:android'

--- a/treehouse-compose/build.gradle
+++ b/treehouse-compose/build.gradle
@@ -22,11 +22,26 @@ kotlin {
         api project(':compose:runtime')
       }
     }
+    commonTest {
+      dependencies {
+        implementation deps.kotlin.test
+        implementation project(':treehouse-test-schema:compose')
+      }
+    }
     androidMain {
       dependencies {
         implementation deps.androidx.core
       }
     }
+    androidTest {
+      dependsOn jvmTest
+    }
+  }
+}
+
+android {
+  testOptions {
+    unitTests.returnDefaultValues = true
   }
 }
 

--- a/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/TreehouseCompositionTest.kt
+++ b/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/TreehouseCompositionTest.kt
@@ -1,0 +1,122 @@
+package app.cash.treehouse.compose
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import app.cash.treehouse.protocol.ChildrenDiff
+import app.cash.treehouse.protocol.ChildrenDiff.Companion.RootChildrenTag
+import app.cash.treehouse.protocol.ChildrenDiff.Companion.RootId
+import app.cash.treehouse.protocol.Diff
+import app.cash.treehouse.protocol.Event
+import app.cash.treehouse.protocol.PropertyDiff
+import example.treehouse.compose.Button
+import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class TreehouseCompositionTest {
+  @Test fun protocolSkipsLambdaChangeOfSamePresence() = runTest {
+    val clock = BroadcastFrameClock()
+    val diffs = ArrayDeque<Diff>()
+    val composition = TreehouseComposition(this + clock, diffs::add)
+
+    var state by mutableStateOf(0)
+    composition.setContent {
+      Button(
+        "state: $state",
+        onClick = when (state) {
+          0 -> { { state = 1 } }
+          1 -> { { state = 2 } }
+          2 -> { null }
+          3 -> { null }
+          else -> fail()
+        }
+      )
+    }
+
+    clock.awaitFrame()
+    assertEquals(
+      Diff(
+        childrenDiffs = listOf(
+          ChildrenDiff.Insert(RootId, RootChildrenTag, 1L, 3 /* button */, 0),
+        ),
+        propertyDiffs = listOf(
+          PropertyDiff(1L, 1 /* text */, "state: 0"),
+          PropertyDiff(1L, 2 /* onClick */, true),
+        ),
+      ),
+      diffs.removeFirst()
+    )
+
+    // Invoke the onClick lambda to move the state from 0 to 1.
+    composition.sendEvent(Event(1L, 2, null))
+    yield() // Allow state change to be handled.
+
+    clock.awaitFrame()
+    assertEquals(
+      Diff(
+        childrenDiffs = listOf(),
+        propertyDiffs = listOf(
+          PropertyDiff(1L, 1 /* text */, "state: 1"),
+        ),
+      ),
+      diffs.removeFirst()
+    )
+
+    // Invoke the onClick lambda to move the state from 1 to 2.
+    composition.sendEvent(Event(1L, 2, null))
+    yield() // Allow state change to be handled.
+
+    clock.awaitFrame()
+    assertEquals(
+      Diff(
+        childrenDiffs = listOf(),
+        propertyDiffs = listOf(
+          PropertyDiff(1L, 1 /* text */, "state: 2"),
+          PropertyDiff(1L, 2 /* text */, false),
+        ),
+      ),
+      diffs.removeFirst()
+    )
+
+    // Manually advance state from 2 to 3 to test null to null case.
+    state = 3
+    yield() // Allow state change to be handled.
+
+    clock.awaitFrame()
+    assertEquals(
+      Diff(
+        childrenDiffs = listOf(),
+        propertyDiffs = listOf(
+          PropertyDiff(1L, 1 /* text */, "state: 3"),
+        ),
+      ),
+      diffs.removeFirst()
+    )
+
+    composition.cancel()
+  }
+
+  private suspend fun BroadcastFrameClock.awaitFrame() {
+    // TODO Remove the need for two frames to happen!
+    //  I think this is because of the diff-sender is a hot loop that immediately reschedules
+    //  itself on the clock. This schedules it ahead of the coroutine which applies changes and
+    //  so we need to trigger an additional frame to actually emit the change's diffs.
+    repeat(2) {
+      coroutineScope {
+        launch(start = UNDISPATCHED) {
+          withFrameMillis {
+          }
+        }
+        sendFrame(0L)
+      }
+    }
+  }
+}

--- a/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/runTest.kt
+++ b/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/runTest.kt
@@ -1,0 +1,5 @@
+package app.cash.treehouse.compose
+
+import kotlinx.coroutines.CoroutineScope
+
+expect fun runTest(body: suspend CoroutineScope.() -> Unit)

--- a/treehouse-compose/src/jsTest/kotlin/app/cash/treehouse/compose/runTest.kt
+++ b/treehouse-compose/src/jsTest/kotlin/app/cash/treehouse/compose/runTest.kt
@@ -1,0 +1,7 @@
+package app.cash.treehouse.compose
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+
+actual fun runTest(body: suspend CoroutineScope.() -> Unit): dynamic = GlobalScope.promise { body() }

--- a/treehouse-compose/src/jvmTest/kotlin/app/cash/treehouse/compose/runTest.kt
+++ b/treehouse-compose/src/jvmTest/kotlin/app/cash/treehouse/compose/runTest.kt
@@ -1,0 +1,6 @@
+package app.cash.treehouse.compose
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+
+actual fun runTest(body: suspend CoroutineScope.() -> Unit) = runBlocking { body() }

--- a/treehouse-test-schema/build.gradle
+++ b/treehouse-test-schema/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+dependencies {
+  implementation project(':treehouse-schema-annotations')
+}

--- a/treehouse-test-schema/compose/build.gradle
+++ b/treehouse-test-schema/compose/build.gradle
@@ -1,0 +1,54 @@
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginKt
+
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+
+def generatedDir = 'build/generated/treehouse'
+
+kotlin {
+  jvm()
+  js {
+    browser()
+  }
+
+  sourceSets {
+    commonMain {
+      kotlin {
+        srcDir generatedDir
+      }
+      dependencies {
+        api project(':treehouse-compose')
+      }
+    }
+  }
+}
+
+configurations {
+  generator
+}
+
+dependencies {
+  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler'))
+
+  generator project(':treehouse-schema-generator')
+  generator project(':treehouse-test-schema')
+}
+
+def generate = tasks.register('treehouseGenerate', JavaExec) {
+  it.classpath(configurations.generator)
+  it.main('app.cash.treehouse.schema.generator.Main')
+  it.args(
+    '--compose',
+    '--out', generatedDir,
+    'example.treehouse.ExampleSchema',
+  )
+
+  it.doFirst {
+    file(generatedDir).deleteDir()
+  }
+}
+
+kotlin.targets.all { target ->
+  target.compilations.all { compilation ->
+    compilation.compileKotlinTask.dependsOn(generate.get())
+  }
+}

--- a/treehouse-test-schema/compose/src/main/AndroidManifest.xml
+++ b/treehouse-test-schema/compose/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="example.treehouse.compose" />

--- a/treehouse-test-schema/src/main/kotlin/example/treehouse/schema.kt
+++ b/treehouse-test-schema/src/main/kotlin/example/treehouse/schema.kt
@@ -1,0 +1,31 @@
+package example.treehouse
+
+import app.cash.treehouse.schema.Children
+import app.cash.treehouse.schema.Property
+import app.cash.treehouse.schema.Schema
+import app.cash.treehouse.schema.Widget
+
+@Schema(
+  [
+    Box::class,
+    Text::class,
+    Button::class,
+  ]
+)
+interface ExampleSchema
+
+@Widget(1)
+data class Box(
+  @Children(1) val children: List<Any>,
+)
+
+@Widget(2)
+data class Text(
+  @Property(1) val text: String?,
+)
+
+@Widget(3)
+data class Button(
+  @Property(1) val text: String?,
+  @Property(2) val onClick: () -> Unit,
+)


### PR DESCRIPTION
Prior to this change, modifying a lambda from one non-null instance to another non-null instance would result in a PropertyDiff that redundantly notifies the widget layer that a lambda is attached. With this change, the diff only appears when the value changed from null to non-null or vise-versa.

Closes #48 