### PR TITLE
Remove ExperimentalComposeApi opt-in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ allprojects {
     kotlin.sourceSets.all {
       languageSettings {
         useExperimentalAnnotation('kotlin.RequiresOptIn')
-        useExperimentalAnnotation('androidx.compose.runtime.ExperimentalComposeApi')
       }
     }
   }
@@ -60,7 +59,6 @@ allprojects {
       useIR = true
       freeCompilerArgs += [
         '-Xopt-in=kotlin.RequiresOptIn',
-        '-Xopt-in=androidx.compose.runtime.ExperimentalComposeApi',
       ]
     }
   }


### PR DESCRIPTION
We no longer use any APIs that are annotated with this.

Closes #69