### PR TITLE
Force the JDK toolchain to 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,14 @@ allprojects {
     }
   }
 
+  plugins.withId('java-base') {
+    java {
+      toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+      }
+    }
+  }
+
   plugins.withId('org.jetbrains.kotlin.jvm') {
     kotlin {
       if (project.path.startsWith(':treehouse-')) {


### PR DESCRIPTION
This has the underlying and intended side-effect of changing the requirements which are propagated through the Gradle module metadata.

Before:

    $ rm -r build/localMaven && gw -q insArch && cat build/localMaven/app/cash/treehouse/treehouse-gradle-plugin/0.2.0-SNAPSHOT/*.module | grep jvm.version
    23:        "org.gradle.jvm.version": 11,
    55:        "org.gradle.jvm.version": 11,

After:

    $ rm -r build/localMaven && gw -q insArch && cat build/localMaven/app/cash/treehouse/treehouse-gradle-plugin/0.2.0-SNAPSHOT/*.module | grep jvm.version
    23:        "org.gradle.jvm.version": 8,
    55:        "org.gradle.jvm.version": 8,