### PR TITLE
Supply the event sink to the diff callback

### DIFF
--- a/example/android/src/main/java/example/android/MainActivity.kt
+++ b/example/android/src/main/java/example/android/MainActivity.kt
@@ -24,7 +24,6 @@ import android.widget.LinearLayout.LayoutParams
 import android.widget.LinearLayout.VERTICAL
 import app.cash.treehouse.compose.AndroidUiDispatcher
 import app.cash.treehouse.compose.TreehouseComposition
-import app.cash.treehouse.protocol.Event
 import app.cash.treehouse.widget.WidgetDisplay
 import example.android.sunspot.AndroidSunspotBox
 import example.android.sunspot.AndroidSunspotWidgetFactory
@@ -49,19 +48,12 @@ class MainActivity : Activity() {
       factory = AndroidSunspotWidgetFactory(this),
     )
 
-    lateinit var events: (Event) -> Unit
     val composition = TreehouseComposition(
       scope = scope,
-      diffs = { diff ->
-        Log.d("TreehouseDiff", diff.toString())
-        display.apply(diff, events)
-      }
+      display = display::apply,
+      onDiff = { Log.d("TreehouseDiff", it.toString()) },
+      onEvent = { Log.d("TreehouseEvent", it.toString()) },
     )
-
-    events = { event ->
-      Log.d("TreehouseEvent", event.toString())
-      composition.sendEvent(event)
-    }
 
     composition.setContent {
       Counter()

--- a/example/browser/src/main/kotlin/example/browser/main.kt
+++ b/example/browser/src/main/kotlin/example/browser/main.kt
@@ -17,7 +17,6 @@ package example.browser
 
 import app.cash.treehouse.compose.TreehouseComposition
 import app.cash.treehouse.compose.WindowAnimationFrameClock
-import app.cash.treehouse.protocol.Event
 import app.cash.treehouse.widget.WidgetDisplay
 import example.browser.sunspot.HtmlSunspotBox
 import example.browser.sunspot.HtmlSunspotNodeFactory
@@ -34,18 +33,12 @@ fun main() {
     factory = HtmlSunspotNodeFactory(document),
   )
 
-  lateinit var events: (Event) -> Unit
   val composition = TreehouseComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
-    diffs = { diff ->
-      console.log("TreehouseDiff", diff.toString())
-      display.apply(diff, events)
-    }
+    display = display::apply,
+    onDiff = { console.log("TreehouseDiff", it.toString()) },
+    onEvent = { console.log("TreehouseEvent", it.toString()) },
   )
-  events = { event ->
-    console.log("TreehouseEvent", event.toString())
-    composition.sendEvent(event)
-  }
 
   composition.setContent {
     Counter()

--- a/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/TreehouseCompositionTest.kt
+++ b/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/TreehouseCompositionTest.kt
@@ -42,7 +42,10 @@ class TreehouseCompositionTest {
   @Test fun childrenInheritIdFromSyntheticParent() = runTest {
     val clock = BroadcastFrameClock()
     val diffs = ArrayDeque<Diff>()
-    val composition = TreehouseComposition(this + clock, diffs::add)
+    val composition = TreehouseComposition(
+      scope = this + clock,
+      display = { diff, _ -> diffs += diff },
+    )
 
     composition.setContent {
       Box {
@@ -76,7 +79,10 @@ class TreehouseCompositionTest {
   @Test fun protocolSkipsLambdaChangeOfSamePresence() = runTest {
     val clock = BroadcastFrameClock()
     val diffs = ArrayDeque<Diff>()
-    val composition = TreehouseComposition(this + clock, diffs::add)
+    val composition = TreehouseComposition(
+      scope = this + clock,
+      display = { diff, _ -> diffs += diff },
+    )
 
     var state by mutableStateOf(0)
     composition.setContent {

--- a/treehouse-gradle-plugin/src/test/fixture/counter/android/src/main/java/example/android/MainActivity.kt
+++ b/treehouse-gradle-plugin/src/test/fixture/counter/android/src/main/java/example/android/MainActivity.kt
@@ -17,14 +17,12 @@ package example.android
 
 import android.app.Activity
 import android.os.Bundle
-import android.util.Log
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.LinearLayout
 import android.widget.LinearLayout.LayoutParams
 import android.widget.LinearLayout.VERTICAL
 import app.cash.treehouse.compose.AndroidUiDispatcher
 import app.cash.treehouse.compose.TreehouseComposition
-import app.cash.treehouse.protocol.Event
 import app.cash.treehouse.widget.WidgetDisplay
 import example.android.counter.AndroidCounterBox
 import example.android.counter.AndroidCounterWidgetFactory
@@ -49,19 +47,10 @@ class MainActivity : Activity() {
       factory = AndroidCounterWidgetFactory(this),
     )
 
-    lateinit var events: (Event) -> Unit
     val composition = TreehouseComposition(
       scope = scope,
-      diffs = { diff ->
-        Log.d("TreehouseDiff", diff.toString())
-        display.apply(diff, events)
-      }
+      display = display::apply,
     )
-
-    events = { event ->
-      Log.d("TreehouseEvent", event.toString())
-      composition.sendEvent(event)
-    }
 
     composition.setContent {
       Counter()

--- a/treehouse-gradle-plugin/src/test/fixture/counter/browser/src/main/kotlin/example/browser/main.kt
+++ b/treehouse-gradle-plugin/src/test/fixture/counter/browser/src/main/kotlin/example/browser/main.kt
@@ -17,7 +17,6 @@ package example.browser
 
 import app.cash.treehouse.compose.TreehouseComposition
 import app.cash.treehouse.compose.WindowAnimationFrameClock
-import app.cash.treehouse.protocol.Event
 import app.cash.treehouse.widget.WidgetDisplay
 import example.browser.counter.HtmlSunspotBox
 import example.browser.counter.HtmlSunspotNodeFactory
@@ -34,18 +33,10 @@ fun main() {
     factory = HtmlSunspotNodeFactory,
   )
 
-  lateinit var events: (Event) -> Unit
   val composition = TreehouseComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
-    diffs = { diff ->
-      console.log("TreehouseDiff", diff.toString())
-      display.apply(diff, events)
-    }
+    display = display::apply,
   )
-  events = { event ->
-    console.log("TreehouseEvent", event.toString())
-    composition.sendEvent(event)
-  }
 
   composition.setContent {
     Counter()


### PR DESCRIPTION
I think this was my original intent in the previous refactor of this area, I just forgot to draw the rest of the owl. In order to keep the bound function reference usage while also supporting logging I have also added little side-channel callbacks.