### PR TITLE
Remove obsolete TODO comment

### DIFF
--- a/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
+++ b/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
@@ -129,7 +129,6 @@ internal class ProtocolApplier(
 
   val scope: TreehouseScope = RealTreehouseScope()
   inner class RealTreehouseScope : TreehouseScope {
-    // TODO atomics if compose becomes multithreaded?
     private var nextId = RootId + 1
     override fun nextId() = nextId++
 


### PR DESCRIPTION
This is from before multi-threaded composition was a thing in Compose and its semantics were not defined. Now we know (thanks to adamp) that this case will never happen.

Closes #93.