### PR TITLE
Remove TreehouseScope receiver

### DIFF
--- a/samples/counter/shared/src/commonMain/kotlin/example/shared/counter.kt
+++ b/samples/counter/shared/src/commonMain/kotlin/example/shared/counter.kt
@@ -20,12 +20,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import app.cash.treehouse.compose.TreehouseScope
 import example.sunspot.compose.SunspotButton
 import example.sunspot.compose.SunspotText
 
 @Composable
-fun TreehouseScope.Counter(value: Int = 0) {
+fun Counter(value: Int = 0) {
   var count by remember { mutableStateOf(value) }
 
   SunspotButton("-1", onClick = { count-- })

--- a/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/composition.kt
+++ b/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/composition.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 
 public interface TreehouseComposition {
   public fun sendEvent(event: Event)
-  public fun setContent(content: @Composable TreehouseScope.() -> Unit)
+  public fun setContent(content: @Composable () -> Unit)
   public fun cancel()
 }
 
@@ -101,10 +101,8 @@ private class RealTreehouseComposition(
     node.sendEvent(event)
   }
 
-  override fun setContent(content: @Composable TreehouseScope.() -> Unit) {
-    composition.setContent {
-      applier.scope.content()
-    }
+  override fun setContent(content: @Composable () -> Unit) {
+    composition.setContent(content)
   }
 
   override fun cancel() {

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
@@ -32,9 +32,9 @@ internal val widgetChildren = widget.nestedClass("Children")
 internal val widgetFactory = widget.nestedClass("Factory")
 internal val mutableListChildren = ClassName("app.cash.treehouse.widget", "MutableListChildren")
 
+internal val protocolApplier = ClassName("app.cash.treehouse.compose", "ProtocolApplier")
 internal val protocolNode = ClassName("app.cash.treehouse.compose", "ProtocolNode")
 internal val syntheticChildren = MemberName("app.cash.treehouse.compose", "\$SyntheticChildren")
-internal val treehouseScope = ClassName("app.cash.treehouse.compose", "TreehouseScope")
 
 internal val applier = ClassName("androidx.compose.runtime", "Applier")
 internal val composable = ClassName("androidx.compose.runtime", "Composable")


### PR DESCRIPTION
IDs are now generated on tree insertion rather than in the generated code. Rather than appending diffs to the scope, the node now holds a reference to its applier (set on insertion) which accepts property diffs.

Closes #90. Also one step closer to #14.