### PR TITLE
Enable Compose for native targets

### DIFF
--- a/treehouse/build.gradle
+++ b/treehouse/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+
 buildscript {
   apply from: '../gradle/dependencies.gradle'
 
@@ -88,6 +90,15 @@ allprojects {
         "-P", "plugin:androidx.compose.compiler.plugins.kotlin:generateDecoys=true",
       ]
     }
+  }
+
+  // Kotlin/Native compiler reports its version like 1.4.21-344 whereas Kotlin/JVM and Kotlin/JS say
+  // only 1.4.21. The Compose compiler checks this version and fails for the Kotlin/Native variant.
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.AbstractKotlinNativeCompile).configureEach {
+    it.compilerPluginOptions.addPluginArgument(
+      'androidx.compose.compiler.plugins.kotlin',
+      new SubpluginOption('suppressKotlinVersionCompatibilityCheck', 'true')
+    )
   }
 
   plugins.withType(com.android.build.gradle.BasePlugin).configureEach { plugin ->

--- a/treehouse/compose/compiler-hosted/build.gradle
+++ b/treehouse/compose/compiler-hosted/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.vanniktech.maven.publish'
 
 sourceSets {
   main {

--- a/treehouse/compose/compiler-hosted/gradle.properties
+++ b/treehouse/compose/compiler-hosted/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=compose-compiler-hosted
+POM_NAME=Jetpack Compose compiler (non-shadowed, for Treehouse)

--- a/treehouse/compose/runtime/build.gradle
+++ b/treehouse/compose/runtime/build.gradle
@@ -11,6 +11,7 @@ kotlin {
   android {
     publishAllLibraryVariants()
   }
+  ios()
   js {
     browser()
   }
@@ -44,12 +45,21 @@ kotlin {
         api 'androidx.annotation:annotation:1.1.0'
       }
     }
+    nativeMain {
+    }
+    nativeTest {
+    }
     jvmMain {
       kotlin {
         srcDir '../upstream/compose/runtime/runtime/src/jvmMain/kotlin'
         srcDir '../upstream/compose/runtime/runtime/src/desktopMain/kotlin'
       }
     }
+  }
+
+  configure([targets.iosX64, targets.iosArm64]) {
+    compilations.main.source(sourceSets.nativeMain)
+    compilations.test.source(sourceSets.nativeTest)
   }
 }
 
@@ -67,4 +77,5 @@ android {
 
 dependencies {
   add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler'))
+  add(KotlinPluginKt.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler-hosted'))
 }

--- a/treehouse/compose/runtime/src/nativeMain/kotlin/androidx/compose/runtime/ActualNative.native.kt
+++ b/treehouse/compose/runtime/src/nativeMain/kotlin/androidx/compose/runtime/ActualNative.native.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+import androidx.compose.runtime.snapshots.SnapshotMutableState
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.yield
+import kotlin.native.identityHashCode
+import kotlin.system.getTimeNanos
+import kotlin.time.ExperimentalTime
+
+// TODO actual thread local lol
+internal actual open class ThreadLocal<T> actual constructor(
+  initialValue: () -> T
+) {
+  private var value: T = initialValue()
+
+  actual fun get(): T = value
+
+  actual fun set(value: T) {
+    this.value = value
+  }
+}
+
+actual class AtomicReference<V> actual constructor(value: V) {
+  private val delegate = atomic(value)
+
+  actual fun get(): V = delegate.value
+
+  actual fun set(value: V) {
+    delegate.value = value
+  }
+
+  actual fun getAndSet(value: V): V =
+    delegate.getAndSet(value)
+
+  actual fun compareAndSet(expect: V, newValue: V): Boolean =
+    delegate.compareAndSet(expect, newValue)
+}
+
+internal actual fun identityHashCode(instance: Any?): Int =
+  instance.identityHashCode()
+
+actual annotation class TestOnly
+
+actual inline fun <R> synchronized(lock: Any, block: () -> R): R =
+  block()
+
+actual val DefaultMonotonicFrameClock: MonotonicFrameClock = MonotonicClockImpl()
+
+@OptIn(ExperimentalTime::class)
+private class MonotonicClockImpl : MonotonicFrameClock {
+  override suspend fun <R> withFrameNanos(
+    onFrame: (Long) -> R
+  ): R {
+    yield()
+    return onFrame(getTimeNanos())
+  }
+}
+
+internal actual object Trace {
+  actual fun beginSection(name: String): Any? {
+    return null
+  }
+
+  actual fun endSection(token: Any?) {
+  }
+}
+
+actual annotation class CheckResult actual constructor(actual val suggest: String)
+
+internal actual fun <T> createSnapshotMutableState(
+  value: T,
+  policy: SnapshotMutationPolicy<T>
+): SnapshotMutableState<T> =
+  SnapshotMutableStateImpl(value, policy)
+
+//fixme: not actually thread local
+internal actual class SnapshotThreadLocal<T> actual constructor() {
+  private var value: T? = null
+
+  actual fun get(): T? = value
+  actual fun set(value: T?) {
+    this.value = value
+  }
+}

--- a/treehouse/compose/runtime/src/nativeMain/kotlin/androidx/compose/runtime/internal/ComposableLambda.native.kt
+++ b/treehouse/compose/runtime/src/nativeMain/kotlin/androidx/compose/runtime/internal/ComposableLambda.native.kt
@@ -1,0 +1,1169 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(InternalComposeApi::class)
+package androidx.compose.runtime.internal
+
+import androidx.compose.runtime.ComposeCompilerApi
+import androidx.compose.runtime.Composer
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.Stable
+
+/**
+ * A Restart is created to hold composable lambdas to track when they are invoked allowing
+ * the invocations to be invalidated when a new composable lambda is created during composition.
+ *
+ * This allows much of the call-graph to be skipped when a composable function is passed through
+ * multiple levels of composable functions.
+ */
+@Suppress("NAME_SHADOWING")
+@Stable
+@OptIn(ComposeCompilerApi::class)
+/* ktlint-disable parameter-list-wrapping */ // TODO(https://github.com/pinterest/ktlint/issues/921): reenable
+internal actual class ComposableLambdaImpl actual constructor(
+  val key: Int,
+  private val tracked: Boolean
+) : ComposableLambda {
+  private var _block: Any? = null
+  private var scope: RecomposeScope? = null
+  private var scopes: MutableList<RecomposeScope>? = null
+
+  private fun trackWrite() {
+    if (tracked) {
+      val scope = this.scope
+      if (scope != null) {
+        scope.invalidate()
+        this.scope = null
+      }
+      val scopes = this.scopes
+      if (scopes != null) {
+        for (index in 0 until scopes.size) {
+          val item = scopes[index]
+          item.invalidate()
+        }
+        scopes.clear()
+      }
+    }
+  }
+
+  private fun trackRead(composer: Composer) {
+    if (tracked) {
+      val scope = composer.recomposeScope
+      if (scope != null) {
+        // Find the first invalid scope and replace it or record it if no scopes are invalid
+        composer.recordUsed(scope)
+        val lastScope = this.scope
+        if (lastScope.replacableWith(scope)) {
+          this.scope = scope
+        } else {
+          val lastScopes = scopes
+          if (lastScopes == null) {
+            val newScopes = mutableListOf<RecomposeScope>()
+            scopes = newScopes
+            newScopes.add(scope)
+          } else {
+            for (index in 0 until lastScopes.size) {
+              val scopeAtIndex = lastScopes[index]
+              if (scopeAtIndex.replacableWith(scope)) {
+                lastScopes[index] = scope
+                return
+              }
+            }
+            lastScopes.add(scope)
+          }
+        }
+      }
+    }
+  }
+
+  actual fun update(block: Any) {
+    if (_block != block) {
+      val oldBlockNull = _block == null
+      _block = block
+      if (!oldBlockNull) {
+        trackWrite()
+      }
+    }
+  }
+
+  override operator fun invoke(c: Composer, changed: Int): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(0) else sameBits(0)
+    val result = (_block as (c: Composer, changed: Int) -> Any?)(c, dirty)
+    c.endRestartGroup()?.updateScope(this as (Composer, Int) -> Unit)
+    return result
+  }
+
+  override operator fun invoke(p1: Any?, c: Composer, changed: Int): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(1) else sameBits(1)
+    val result = (
+      _block as (
+        p1: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ -> this(p1, nc, changed or 0b1) }
+    return result
+  }
+
+  override operator fun invoke(p1: Any?, p2: Any?, c: Composer, changed: Int): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(2) else sameBits(2)
+    val result = (_block as (p1: Any?, p2: Any?, c: Composer, changed: Int) -> Any?)(
+      p1,
+      p2,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ -> this(p1, p2, nc, changed or 0b1) }
+    return result
+  }
+
+  override operator fun invoke(p1: Any?, p2: Any?, p3: Any?, c: Composer, changed: Int): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(3) else sameBits(3)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ -> this(p1, p2, p3, nc, changed or 0b1) }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    c: Composer,
+    changed: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(4) else sameBits(4)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, nc, changed or 0b1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    c: Composer,
+    changed: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(5) else sameBits(5)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, nc, changed or 0b1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    c: Composer,
+    changed: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(6) else sameBits(6)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, p6, nc, changed or 0b1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    c: Composer,
+    changed: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(7) else sameBits(7)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, p6, p7, nc, changed or 0b1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    c: Composer,
+    changed: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(8) else sameBits(8)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, p6, p7, p8, nc, changed or 0b1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    c: Composer,
+    changed: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed or if (c.changed(this)) differentBits(9) else sameBits(9)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        c: Composer,
+        changed: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      c,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, p6, p7, p8, p9, nc, changed or 0b1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(10) else sameBits(10)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, nc, changed or 0b1, changed)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(11) else sameBits(11)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, nc, changed or 0b1, changed1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    p12: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(12) else sameBits(12)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        p12: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      p12,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, nc, changed or 0b1, changed1)
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    p12: Any?,
+    p13: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(13) else sameBits(13)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        p12: Any?,
+        p13: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      p12,
+      p13,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        nc,
+        changed or 0b1,
+        changed1
+      )
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    p12: Any?,
+    p13: Any?,
+    p14: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(14) else sameBits(14)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        p12: Any?,
+        p13: Any?,
+        p14: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      p12,
+      p13,
+      p14,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        nc,
+        changed or 0b1,
+        changed1
+      )
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    p12: Any?,
+    p13: Any?,
+    p14: Any?,
+    p15: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(15) else sameBits(15)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        p12: Any?,
+        p13: Any?,
+        p14: Any?,
+        p15: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      p12,
+      p13,
+      p14,
+      p15,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        nc,
+        changed or 0b1,
+        changed1
+      )
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    p12: Any?,
+    p13: Any?,
+    p14: Any?,
+    p15: Any?,
+    p16: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(16) else sameBits(16)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        p12: Any?,
+        p13: Any?,
+        p14: Any?,
+        p15: Any?,
+        p16: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      p12,
+      p13,
+      p14,
+      p15,
+      p16,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        nc,
+        changed or 0b1,
+        changed1
+      )
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    p12: Any?,
+    p13: Any?,
+    p14: Any?,
+    p15: Any?,
+    p16: Any?,
+    p17: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(17) else sameBits(17)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        p12: Any?,
+        p13: Any?,
+        p14: Any?,
+        p15: Any?,
+        p16: Any?,
+        p17: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      p12,
+      p13,
+      p14,
+      p15,
+      p16,
+      p17,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        p17,
+        nc,
+        changed or 0b1,
+        changed1
+      )
+    }
+    return result
+  }
+
+  override operator fun invoke(
+    p1: Any?,
+    p2: Any?,
+    p3: Any?,
+    p4: Any?,
+    p5: Any?,
+    p6: Any?,
+    p7: Any?,
+    p8: Any?,
+    p9: Any?,
+    p10: Any?,
+    p11: Any?,
+    p12: Any?,
+    p13: Any?,
+    p14: Any?,
+    p15: Any?,
+    p16: Any?,
+    p17: Any?,
+    p18: Any?,
+    c: Composer,
+    changed: Int,
+    changed1: Int
+  ): Any? {
+    val c = c.startRestartGroup(key)
+    trackRead(c)
+    val dirty = changed1 or if (c.changed(this)) differentBits(18) else sameBits(18)
+    val result = (
+      _block as (
+        p1: Any?,
+        p2: Any?,
+        p3: Any?,
+        p4: Any?,
+        p5: Any?,
+        p6: Any?,
+        p7: Any?,
+        p8: Any?,
+        p9: Any?,
+        p10: Any?,
+        p11: Any?,
+        p12: Any?,
+        p13: Any?,
+        p14: Any?,
+        p15: Any?,
+        p16: Any?,
+        p17: Any?,
+        p18: Any?,
+        c: Composer,
+        changed: Int,
+        changed1: Int
+      ) -> Any?
+      )(
+      p1,
+      p2,
+      p3,
+      p4,
+      p5,
+      p6,
+      p7,
+      p8,
+      p9,
+      p10,
+      p11,
+      p12,
+      p13,
+      p14,
+      p15,
+      p16,
+      p17,
+      p18,
+      c,
+      changed,
+      dirty
+    )
+    c.endRestartGroup()?.updateScope { nc, _ ->
+      this(
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+        p16,
+        p17,
+        p18,
+        nc,
+        changed or 0b1,
+        changed1
+      )
+    }
+    return result
+  }
+}
+
+@ComposeCompilerApi
+@Stable
+actual interface ComposableLambda :
+  Function2<Composer, Int, Any?>,
+  Function3<Any?, Composer, Int, Any?>,
+  Function4<Any?, Any?, Composer, Int, Any?>,
+  Function5<Any?, Any?, Any?, Composer, Int, Any?>,
+  Function6<Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+  Function7<Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+  Function8<Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+  Function9<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+  Function10<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+  Function11<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+  Function13<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Int,
+    Any?>,
+  Function14<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Int,
+    Any?>,
+  Function15<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer,
+    Int, Int, Any?>,
+  Function16<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+    Composer, Int, Int, Any?>,
+  Function17<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+    Composer, Int,
+    Int, Any?>,
+  Function18<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+    Any?, Composer, Int, Int, Any?>,
+  Function19<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+    Any?, Any?, Composer, Int, Int, Any?>,
+  Function20<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+    Any?, Any?, Any?, Composer, Int, Int, Any?>,
+  Function21<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+    Any?, Any?, Any?, Any?, Composer, Int, Int, Any?>

--- a/treehouse/gradle.properties
+++ b/treehouse/gradle.properties
@@ -1,8 +1,6 @@
 kotlin.js.compiler=ir
 
 kotlin.mpp.stability.nowarn=true
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 org.gradle.jvmargs=-Xmx4096m
 

--- a/treehouse/treehouse-compose/build.gradle
+++ b/treehouse/treehouse-compose/build.gradle
@@ -9,6 +9,7 @@ kotlin {
   android {
     publishAllLibraryVariants()
   }
+  ios()
   js {
     browser()
   }
@@ -36,6 +37,12 @@ kotlin {
     androidTest {
       dependsOn jvmTest
     }
+    nativeTest {
+    }
+  }
+
+  configure([targets.iosX64, targets.iosArm64]) {
+    compilations.test.source(sourceSets.nativeTest)
   }
 }
 
@@ -47,6 +54,7 @@ android {
 
 dependencies {
   add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler'))
+  add(KotlinPluginKt.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler-hosted'))
 }
 
 spotless {

--- a/treehouse/treehouse-compose/src/nativeTest/kotlin/app/cash/treehouse/compose/runTest.kt
+++ b/treehouse/treehouse-compose/src/nativeTest/kotlin/app/cash/treehouse/compose/runTest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.treehouse.compose
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+
+actual fun runTest(body: suspend CoroutineScope.() -> Unit) = runBlocking { body() }

--- a/treehouse/treehouse-gradle-plugin/build.gradle
+++ b/treehouse/treehouse-gradle-plugin/build.gradle
@@ -50,6 +50,7 @@ gradlePlugin {
 
 test {
   dependsOn(':compose:compiler:installArchives')
+  dependsOn(':compose:compiler-hosted:installArchives')
   dependsOn(':compose:runtime:installArchives')
   dependsOn(':treehouse-compose:installArchives')
   dependsOn(':treehouse-gradle-plugin:installArchives')

--- a/treehouse/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehousePlugin.kt
+++ b/treehouse/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehousePlugin.kt
@@ -39,6 +39,12 @@ public class TreehousePlugin : KotlinCompilerPluginSupportPlugin {
     treehouseVersion,
   )
 
+  override fun getPluginArtifactForNative(): SubpluginArtifact = SubpluginArtifact(
+    "app.cash.treehouse",
+    "compose-compiler-hosted",
+    treehouseVersion,
+  )
+
   override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
     kotlinCompilation.dependencies {
       implementation("app.cash.treehouse:treehouse-compose:$treehouseVersion")

--- a/treehouse/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehouseSchemaGeneratorPlugin.kt
+++ b/treehouse/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehouseSchemaGeneratorPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.attributes.Usage.JAVA_RUNTIME
 import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
 import org.gradle.api.tasks.JavaExec
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import java.io.File
 
 @Suppress("unused") // Invoked reflectively by Gradle.
@@ -65,6 +66,7 @@ public abstract class TreehouseSchemaGeneratorPlugin(
       // Ensure we get JVM artifacts from any multiplatform dependencies for use with JavaExec.
       val runtimeUsage = project.objects.named(Usage::class.java, JAVA_RUNTIME)
       it.attributes.attribute(USAGE_ATTRIBUTE, runtimeUsage)
+      it.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
     }
     project.dependencies.add(
       configuration.name,

--- a/treehouse/treehouse-test-schema/compose/build.gradle
+++ b/treehouse/treehouse-test-schema/compose/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 def generatedDir = 'build/generated/treehouse'
 
 kotlin {
+  ios()
   jvm()
   js {
     browser()
@@ -28,6 +29,7 @@ configurations {
 
 dependencies {
   add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler'))
+  add(KotlinPluginKt.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler-hosted'))
 
   generator project(':treehouse-schema-generator')
   generator project(':treehouse-test-schema')


### PR DESCRIPTION
This is possible now that we switched back to AOSP for Compose and support for native has landed upstream in AOSP. Once again we have to carry our own actuals for the runtime, but they are few (and sourced from the JetBrains fork).

For simplicity I have only enabled iOS, but I will follow up and enable all possible native targets for Treehouse artifacts.

Closes #21 