### PR TITLE
Enable all of the supported native platforms

### DIFF
--- a/treehouse/compose/runtime/build.gradle
+++ b/treehouse/compose/runtime/build.gradle
@@ -11,11 +11,19 @@ kotlin {
   android {
     publishAllLibraryVariants()
   }
-  ios()
+  iosArm32()
+  iosArm64()
+  iosX64()
   js {
     browser()
   }
   jvm()
+  macosX64()
+  mingwX64()
+  tvosX64()
+  tvosArm64()
+  watchosArm32()
+  watchosArm64()
 
   sourceSets {
     commonMain {
@@ -57,7 +65,17 @@ kotlin {
     }
   }
 
-  configure([targets.iosX64, targets.iosArm64]) {
+  configure([
+    targets.iosArm32,
+    targets.iosArm64,
+    targets.iosX64,
+    targets.macosX64,
+    targets.mingwX64,
+    targets.tvosArm64,
+    targets.tvosX64,
+    targets.watchosArm32,
+    targets.watchosArm64,
+  ]) {
     compilations.main.source(sourceSets.nativeMain)
     compilations.test.source(sourceSets.nativeTest)
   }

--- a/treehouse/treehouse-compose/build.gradle
+++ b/treehouse/treehouse-compose/build.gradle
@@ -9,11 +9,19 @@ kotlin {
   android {
     publishAllLibraryVariants()
   }
-  ios()
+  iosArm32()
+  iosArm64()
+  iosX64()
   js {
     browser()
   }
   jvm()
+  macosX64()
+  mingwX64()
+  tvosX64()
+  tvosArm64()
+  watchosArm32()
+  watchosArm64()
 
   sourceSets {
     commonMain {
@@ -41,7 +49,17 @@ kotlin {
     }
   }
 
-  configure([targets.iosX64, targets.iosArm64]) {
+  configure([
+    targets.iosArm32,
+    targets.iosArm64,
+    targets.iosX64,
+    targets.macosX64,
+    targets.mingwX64,
+    targets.tvosArm64,
+    targets.tvosX64,
+    targets.watchosArm32,
+    targets.watchosArm64,
+  ]) {
     compilations.test.source(sourceSets.nativeTest)
   }
 }

--- a/treehouse/treehouse-protocol/build.gradle
+++ b/treehouse/treehouse-protocol/build.gradle
@@ -4,11 +4,19 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
+  iosArm32()
+  iosArm64()
+  iosX64()
   js {
     browser()
   }
   jvm()
-  ios()
+  macosX64()
+  mingwX64()
+  tvosX64()
+  tvosArm64()
+  watchosArm32()
+  watchosArm64()
 
   sourceSets {
     commonMain {

--- a/treehouse/treehouse-test-schema/compose/build.gradle
+++ b/treehouse/treehouse-test-schema/compose/build.gradle
@@ -5,11 +5,19 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 def generatedDir = 'build/generated/treehouse'
 
 kotlin {
-  ios()
-  jvm()
+  iosArm32()
+  iosArm64()
+  iosX64()
   js {
     browser()
   }
+  jvm()
+  macosX64()
+  mingwX64()
+  tvosX64()
+  tvosArm64()
+  watchosArm32()
+  watchosArm64()
 
   sourceSets {
     commonMain {

--- a/treehouse/treehouse-widget/build.gradle
+++ b/treehouse/treehouse-widget/build.gradle
@@ -7,11 +7,19 @@ kotlin {
   android {
     publishAllLibraryVariants()
   }
+  iosArm32()
+  iosArm64()
+  iosX64()
   js {
     browser()
   }
   jvm()
-  ios()
+  macosX64()
+  mingwX64()
+  tvosX64()
+  tvosArm64()
+  watchosArm32()
+  watchosArm64()
 
   sourceSets {
     commonMain {


### PR DESCRIPTION
Omitted is watchosX64 which is not supported by our version of serialization and coroutines. I will bump them separately and add it in a later change.