### PR TITLE
Remove toolchain, set source/target compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-java@v2.1.0
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 14
 
       - run: ./gradlew -p treehouse build dokkaHtmlMultiModule
       - run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,8 @@ allprojects {
 
   plugins.withId('java-base') {
     java {
-      toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
-      }
+      sourceCompatibility = JavaVersion.VERSION_1_8
+      targetCompatibility = JavaVersion.VERSION_1_8
     }
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/treehouse/build.gradle
+++ b/treehouse/build.gradle
@@ -48,9 +48,8 @@ allprojects {
 
   plugins.withId('java-base') {
     java {
-      toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
-      }
+      sourceCompatibility = JavaVersion.VERSION_1_8
+      targetCompatibility = JavaVersion.VERSION_1_8
     }
   }
 


### PR DESCRIPTION
This has the same desired effect of the original change in that the artifacts are built with Java 8 bytecode, but does so in a way that allows using a modern JVM to build. With any luck, the new JVM will use less memory and make Windows builds less resource intensive.