### PR TITLE
Resume publishing variants of Android artifacts

### DIFF
--- a/treehouse/compose/runtime/build.gradle
+++ b/treehouse/compose/runtime/build.gradle
@@ -8,7 +8,9 @@ apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 archivesBaseName = 'treehouse-jetpack-compose'
 
 kotlin {
-  android()
+  android {
+    publishAllLibraryVariants()
+  }
   iosArm32()
   iosArm64()
   iosX64()

--- a/treehouse/treehouse-compose/build.gradle
+++ b/treehouse/treehouse-compose/build.gradle
@@ -6,7 +6,9 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  android()
+  android {
+    publishAllLibraryVariants()
+  }
   iosArm32()
   iosArm64()
   iosX64()

--- a/treehouse/treehouse-widget/build.gradle
+++ b/treehouse/treehouse-widget/build.gradle
@@ -4,7 +4,9 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  android()
+  android {
+    publishAllLibraryVariants()
+  }
   iosArm32()
   iosArm64()
   iosX64()


### PR DESCRIPTION
Lost in c41cd4f6459c05000f64bfff5ba5c10f91b820ad. No variants are published by default (per https://kotlinlang.org/docs/mpp-publish-lib.html#publish-an-android-library) and we cannot get away with only publishing release, sadly.