### PR TITLE
Use dependency substitution to prefer Jetpack Compose runtime for Android builds

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ buildscript {
       ],
       'core': 'androidx.core:core-ktx:1.2.0',
     ],
-    'androidGradlePlugin': 'com.android.tools.build:gradle:4.1.3',
+    'androidGradlePlugin': 'com.android.tools.build:gradle:7.0.0-beta05',
     'kotlinPoet': 'com.squareup:kotlinpoet:1.7.2',
     'clikt': 'com.github.ajalt.clikt:clikt:3.1.0',
     'exhaustiveAnnotation': "app.cash.exhaustive:exhaustive-annotation:${versions.exhaustive}",

--- a/treehouse/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehousePlugin.kt
+++ b/treehouse/treehouse-gradle-plugin/src/main/kotlin/app/cash/treehouse/gradle/TreehousePlugin.kt
@@ -16,6 +16,7 @@
 package app.cash.treehouse.gradle
 
 import app.cash.exhaustive.Exhaustive
+import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -29,6 +30,27 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
 public class TreehousePlugin : KotlinCompilerPluginSupportPlugin {
+  override fun apply(project: Project) {
+    super.apply(project)
+
+    project.configurations.all { configuration ->
+      configuration.resolutionStrategy.dependencySubstitution { it ->
+        val composeRuntime = it.module("androidx.compose.runtime:runtime:$composeVersion")
+        val justification =
+          "Our Android jar includes the same types in the same package as AndroidX. " +
+            "This prevents using other Compose-based libraries such as Compose UI in an app. " +
+            "Prefer the canonical version so that dependency resolution will de-duplicate them."
+
+        it.substitute(it.module("app.cash.treehouse:compose-runtime-android"))
+          .using(composeRuntime)
+          .because(justification)
+        it.substitute(it.module("app.cash.treehouse:compose-runtime-android-debug"))
+          .using(composeRuntime)
+          .because(justification)
+      }
+    }
+  }
+
   override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
 
   override fun getCompilerPluginId(): String = "app.cash.treehouse"

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/app/build.gradle
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/app/build.gradle
@@ -1,0 +1,38 @@
+apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'app.cash.treehouse'
+
+dependencies {
+  implementation project(':schema:compose')
+  implementation "androidx.compose.ui:ui:${versions.compose}"
+}
+
+android {
+  compileSdkVersion 30
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+  kotlinOptions {
+    jvmTarget = '1.8'
+  }
+
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 30
+  }
+
+  buildFeatures {
+    compose true
+  }
+
+  composeOptions {
+    kotlinCompilerExtensionVersion versions.compose
+  }
+
+  lintOptions {
+    checkReleaseBuilds false
+  }
+}

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/app/src/main/AndroidManifest.xml
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/app/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="example.android" />

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/build.gradle
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/build.gradle
@@ -1,0 +1,27 @@
+buildscript {
+  apply from: '../../../../../../gradle/dependencies.gradle'
+
+  dependencies {
+    classpath "app.cash.treehouse:treehouse-gradle-plugin:$treehouseVersion"
+    classpath deps.androidGradlePlugin
+    classpath deps.kotlin.gradlePlugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/gradle.properties
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/gradle.properties
@@ -1,0 +1,9 @@
+android.useAndroidX=true
+android.enableJetifier=false
+android.defaults.buildfeatures.buildconfig=false
+android.defaults.buildfeatures.aidl=false
+android.defaults.buildfeatures.renderscript=false
+android.defaults.buildfeatures.resvalues=false
+android.defaults.buildfeatures.shaders=false
+
+kotlin.mpp.stability.nowarn=true

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/schema/build.gradle
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/schema/build.gradle
@@ -1,0 +1,2 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.treehouse.schema'

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/schema/compose/build.gradle
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/schema/compose/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'app.cash.treehouse.schema.compose'
+
+kotlin {
+  jvm()
+}
+
+treehouseSchema {
+  source = project(':schema')
+  type = 'example.counter.Counter'
+}

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/schema/src/main/kotlin/example/counter/schema.kt
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/schema/src/main/kotlin/example/counter/schema.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.counter
+
+import app.cash.treehouse.schema.Children
+import app.cash.treehouse.schema.Default
+import app.cash.treehouse.schema.Property
+import app.cash.treehouse.schema.Schema
+import app.cash.treehouse.schema.Widget
+
+@Schema(
+  [
+    CounterBox::class,
+    CounterText::class,
+    CounterButton::class,
+  ]
+)
+interface Counter
+
+@Widget(1)
+data class CounterBox(
+  @Children(1) val children: List<Any>,
+)
+
+@Widget(2)
+data class CounterText(
+  @Property(1) val text: String?,
+  @Property(2) @Default("\"black\"") val color: String,
+)
+
+@Widget(3)
+data class CounterButton(
+  @Property(1) val text: String?,
+  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(3) val onClick: () -> Unit,
+)

--- a/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/settings.gradle
+++ b/treehouse/treehouse-gradle-plugin/src/test/fixture/compose-ui/settings.gradle
@@ -1,0 +1,3 @@
+include ':app'
+include ':schema'
+include ':schema:compose'

--- a/treehouse/treehouse-gradle-plugin/src/test/kotlin/app/cash/treehouse/gradle/FixtureTest.kt
+++ b/treehouse/treehouse-gradle-plugin/src/test/kotlin/app/cash/treehouse/gradle/FixtureTest.kt
@@ -42,14 +42,22 @@ class FixtureTest {
     )
   }
 
-  private fun fixtureGradleRunner(name: String): GradleRunner {
+  @Test fun composeUiAppPackagingSucceeds() {
+    // If our dependency substitution did not work the D8 step would fail with duplicate classes.
+    fixtureGradleRunner("compose-ui", "assemble").build()
+  }
+
+  private fun fixtureGradleRunner(
+    name: String,
+    task: String = "build",
+  ): GradleRunner {
     val fixtureDir = File("src/test/fixture", name)
     val gradleRoot = File(fixtureDir, "gradle").also { it.mkdir() }
     File("../../gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
 
     return GradleRunner.create()
       .withProjectDir(fixtureDir)
-      .withArguments("clean", "build", "--stacktrace", "-PtreehouseVersion=$treehouseVersion")
+      .withArguments("clean", task, "--stacktrace", "-PtreehouseVersion=$treehouseVersion")
       .withDebug(true) // Do not use a daemon.
   }
 }


### PR DESCRIPTION
Since we publish the same types in the same package, using Treehouse and Compose UI or any other Compose-based library in a single app would result in a packaging error.

Closes #124. Closes #121 (as infeasible).