### PR TITLE
Fix widget leak in protocol-based display

### DIFF
--- a/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
+++ b/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
@@ -180,13 +180,19 @@ internal class ProtocolApplier(
   override fun remove(index: Int, count: Int) {
     // Children instances are never removed from their parents.
     val current = current as ProtocolChildrenNode
-
     val children = current.children
+
+    // TODO We should not have to track this and send it as part of the protocol.
+    //  Ideally this would be entirely encapsulated on the display-side with additional bookkeeping.
+    //  For now, we track it here and send it in the protocol as a simple solution.
+    val removedIds = ArrayList<Long>(count)
     for (i in index until index + count) {
-      nodes.remove(children[i].id)
+      removedIds.add(children[i].id)
     }
+
+    nodes.keys.removeAll(removedIds)
     children.remove(index, count)
-    childrenDiffs.add(ChildrenDiff.Remove(current.id, current.tag, index, count))
+    childrenDiffs.add(ChildrenDiff.Remove(current.id, current.tag, index, count, removedIds))
   }
 
   override fun move(from: Int, to: Int, count: Int) {

--- a/treehouse/treehouse-protocol/src/commonMain/kotlin/app/cash/treehouse/protocol/protocol.kt
+++ b/treehouse/treehouse-protocol/src/commonMain/kotlin/app/cash/treehouse/protocol/protocol.kt
@@ -84,7 +84,14 @@ public sealed class ChildrenDiff {
     override val tag: Int,
     val index: Int,
     val count: Int,
-  ) : ChildrenDiff()
+    val removedIds: List<Long>,
+  ) : ChildrenDiff() {
+    init {
+      require(count == removedIds.size) {
+        "Count $count != Removed ID list size ${removedIds.size}"
+      }
+    }
+  }
 
   public companion object {
     public const val RootId: Long = 0L

--- a/treehouse/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/WidgetDisplay.kt
+++ b/treehouse/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/WidgetDisplay.kt
@@ -55,7 +55,7 @@ public class WidgetDisplay<T : Any>(
         }
         is ChildrenDiff.Remove -> {
           children.remove(childrenDiff.index, childrenDiff.count)
-          // TODO we need to remove widgets from our map!
+          widgets.keys.removeAll(childrenDiff.removedIds)
         }
         ChildrenDiff.Clear -> {
           children.clear()


### PR DESCRIPTION
Unfortunately we do this by tracking removed widgets on the applier-side and sending the information in the protocol. Ideally the display-side has abstractions which track IDs long enough to perform this operation without assistance in the protocol.

Closes #40.