### PR TITLE
Only publish a single Android variant

### DIFF
--- a/treehouse/compose/runtime/build.gradle
+++ b/treehouse/compose/runtime/build.gradle
@@ -33,7 +33,7 @@ tasks.named("generateMetadataFileForKotlinMultiplatformPublication").configure {
 
     int start = text.indexOf(find)
     if (start == -1) {
-      throw new RuntimeException("Unable to locate module_find.txt contents in module JSON")
+      throw new RuntimeException("Unable to locate module_find.txt contents in module JSON ($file)")
     }
     int end = start + find.length()
 
@@ -44,7 +44,7 @@ tasks.named("generateMetadataFileForKotlinMultiplatformPublication").configure {
 
 kotlin {
   android {
-    publishAllLibraryVariants()
+    publishLibraryVariants('release')
   }
   iosArm32()
   iosArm64()

--- a/treehouse/compose/runtime/module_find.txt
+++ b/treehouse/compose/runtime/module_find.txt
@@ -1,32 +1,4 @@
     {
-      "name": "debugApiElements-published",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../compose-runtime-android-debug/{TREEHOUSE_VERSION}/compose-runtime-android-debug-{TREEHOUSE_VERSION}.module",
-        "group": "app.cash.treehouse",
-        "module": "compose-runtime-android-debug",
-        "version": "{TREEHOUSE_VERSION}"
-      }
-    },
-    {
-      "name": "debugRuntimeElements-published",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../compose-runtime-android-debug/{TREEHOUSE_VERSION}/compose-runtime-android-debug-{TREEHOUSE_VERSION}.module",
-        "group": "app.cash.treehouse",
-        "module": "compose-runtime-android-debug",
-        "version": "{TREEHOUSE_VERSION}"
-      }
-    },
-    {
       "name": "releaseApiElements-published",
       "attributes": {
         "org.gradle.usage": "java-api",

--- a/treehouse/compose/runtime/module_replace.txt
+++ b/treehouse/compose/runtime/module_replace.txt
@@ -1,38 +1,4 @@
     {
-      "name": "debugApiElements-published",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "dependencies": [
-        {
-          "group": "androidx.compose.runtime",
-          "module": "runtime",
-          "version": {
-            "prefers": "{COMPOSE_VERSION}"
-          }
-        }
-      ]
-    },
-    {
-      "name": "debugRuntimeElements-published",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "dependencies": [
-        {
-          "group": "androidx.compose.runtime",
-          "module": "runtime",
-          "version": {
-            "prefers": "{COMPOSE_VERSION}"
-          }
-        }
-      ]
-    },
-    {
       "name": "releaseApiElements-published",
       "attributes": {
         "org.gradle.usage": "java-api",

--- a/treehouse/treehouse-compose/build.gradle
+++ b/treehouse/treehouse-compose/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
   android {
-    publishAllLibraryVariants()
+    publishLibraryVariants('release')
   }
   iosArm32()
   iosArm64()

--- a/treehouse/treehouse-widget/build.gradle
+++ b/treehouse/treehouse-widget/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
   android {
-    publishAllLibraryVariants()
+    publishLibraryVariants('release')
   }
   iosArm32()
   iosArm64()


### PR DESCRIPTION
As of Kotlin 1.5.30 the release variant no longer contains the 'release' attribute allowing it to be used by all variants on the consumer side.