### PR TITLE
Remove the big display lambda from TreehouseComposition

### DIFF
--- a/samples/counter/android/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android/src/main/java/example/android/MainActivity.kt
@@ -24,12 +24,14 @@ import android.widget.LinearLayout.LayoutParams
 import android.widget.LinearLayout.VERTICAL
 import app.cash.treehouse.compose.AndroidUiDispatcher
 import app.cash.treehouse.compose.TreehouseComposition
+import app.cash.treehouse.widget.applyAll
 import app.cash.treehouse.widget.WidgetDisplay
 import example.android.sunspot.AndroidSunspotBox
 import example.android.sunspot.AndroidSunspotWidgetFactory
 import example.shared.Counter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 class MainActivity : Activity() {
   private val scope = CoroutineScope(AndroidUiDispatcher.Main)
@@ -43,20 +45,24 @@ class MainActivity : Activity() {
     }
     setContentView(root)
 
-    val display = WidgetDisplay(
-      root = AndroidSunspotBox(root),
-      factory = AndroidSunspotWidgetFactory(this),
-    )
-
     val composition = TreehouseComposition(
       scope = scope,
-      display = display::apply,
       onDiff = { Log.d("TreehouseDiff", it.toString()) },
       onEvent = { Log.d("TreehouseEvent", it.toString()) },
     )
 
     composition.setContent {
       Counter()
+    }
+
+    val display = WidgetDisplay(
+      root = AndroidSunspotBox(root),
+      factory = AndroidSunspotWidgetFactory(this),
+      events = composition::sendEvent
+    )
+
+    scope.launch {
+      display.applyAll(composition.diffs)
     }
   }
 

--- a/samples/counter/browser/src/main/kotlin/example/browser/main.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/main.kt
@@ -18,29 +18,36 @@ package example.browser
 import app.cash.treehouse.compose.TreehouseComposition
 import app.cash.treehouse.compose.WindowAnimationFrameClock
 import app.cash.treehouse.widget.WidgetDisplay
+import app.cash.treehouse.widget.applyAll
 import example.browser.sunspot.HtmlSunspotBox
 import example.browser.sunspot.HtmlSunspotNodeFactory
 import example.shared.Counter
 import kotlinx.browser.document
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import org.w3c.dom.HTMLElement
 
 fun main() {
   val content = document.getElementById("content")!! as HTMLElement
-  val display = WidgetDisplay(
-    root = HtmlSunspotBox(content),
-    factory = HtmlSunspotNodeFactory(document),
-  )
 
   val composition = TreehouseComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
-    display = display::apply,
     onDiff = { console.log("TreehouseDiff", it.toString()) },
     onEvent = { console.log("TreehouseEvent", it.toString()) },
   )
 
   composition.setContent {
     Counter()
+  }
+
+  val display = WidgetDisplay(
+    root = HtmlSunspotBox(content),
+    factory = HtmlSunspotNodeFactory(document),
+    events = composition::sendEvent,
+  )
+
+  GlobalScope.launch {
+    display.applyAll(composition.diffs)
   }
 }

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/CounterViewControllerDelegate.kt
@@ -18,6 +18,7 @@ package example.ios
 import androidx.compose.runtime.BroadcastFrameClock
 import app.cash.treehouse.compose.TreehouseComposition
 import app.cash.treehouse.widget.WidgetDisplay
+import app.cash.treehouse.widget.applyAll
 import example.ios.sunspot.IosSunspotBox
 import example.ios.sunspot.IosSunspotNodeFactory
 import example.shared.Counter
@@ -34,20 +35,24 @@ class CounterViewControllerDelegate(
   private val scope = MainScope() + clock
 
   init {
-    val display = WidgetDisplay(
-      root = IosSunspotBox(root),
-      factory = IosSunspotNodeFactory,
-    )
-
     val composition = TreehouseComposition(
       scope = scope,
-      display = display::apply,
       onDiff = { NSLog("TreehouseDiff: $it") },
       onEvent = { NSLog("TreehouseEvent: $it") }
     )
 
     composition.setContent {
       Counter()
+    }
+
+    val display = WidgetDisplay(
+      root = IosSunspotBox(root),
+      factory = IosSunspotNodeFactory,
+      events = composition::sendEvent,
+    )
+
+    scope.launch {
+      display.applyAll(composition.diffs)
     }
   }
 

--- a/samples/counter/shared/src/commonTest/kotlin/example/shared/CounterTest.kt
+++ b/samples/counter/shared/src/commonTest/kotlin/example/shared/CounterTest.kt
@@ -17,6 +17,7 @@ package example.shared
 
 import androidx.compose.runtime.BroadcastFrameClock
 import app.cash.treehouse.compose.TreehouseComposition
+import app.cash.treehouse.widget.applyAll
 import app.cash.treehouse.widget.WidgetDisplay
 import example.sunspot.SunspotBox
 import example.sunspot.SunspotButton
@@ -32,21 +33,27 @@ import kotlin.test.Test
 class CounterTest {
   @Test fun basic() = runTest {
     val root = SchemaSunspotBox()
-    val display = WidgetDisplay(
-      root = root,
-      factory = SchemaSunspotWidgetFactory,
-    )
 
     val clock = BroadcastFrameClock()
+
     val composition = TreehouseComposition(
       scope = this + clock,
-      display = display::apply,
       onDiff = { println(it) },
       onEvent = { println(it) },
     )
 
     composition.setContent {
       Counter()
+    }
+
+    val display = WidgetDisplay(
+      root = root,
+      factory = SchemaSunspotWidgetFactory,
+      events = composition::sendEvent,
+    )
+
+    launch {
+      display.applyAll(composition.diffs)
     }
 
     clock.advanceFrame()

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/TodoActivity.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/TodoActivity.kt
@@ -25,15 +25,27 @@ import androidx.compose.ui.platform.ComposeView
 import app.cash.treehouse.compose.AndroidUiDispatcher.Companion.Main
 import app.cash.treehouse.compose.TreehouseComposition
 import app.cash.treehouse.widget.WidgetDisplay
+import app.cash.treehouse.widget.applyAll
 import example.presenters.TodoPresenter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 class TodoActivity : ComponentActivity() {
   private val scope = CoroutineScope(Main)
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    val composition = TreehouseComposition(
+      scope = scope,
+      onDiff = { Log.d("TreehouseDiff", it.toString()) },
+      onEvent = { Log.d("TreehouseEvent", it.toString()) },
+    )
+
+    composition.setContent {
+      TodoPresenter()
+    }
 
     val root = ComposeUiColumn()
     val composeView = ComposeView(this).apply {
@@ -45,17 +57,11 @@ class TodoActivity : ComponentActivity() {
     val display = WidgetDisplay(
       root = root,
       factory = ComposeUiWidgetFactory,
+      events = composition::sendEvent,
     )
 
-    val composition = TreehouseComposition(
-      scope = scope,
-      display = display::apply,
-      onDiff = { Log.d("TreehouseDiff", it.toString()) },
-      onEvent = { Log.d("TreehouseEvent", it.toString()) },
-    )
-
-    composition.setContent {
-      TodoPresenter()
+    scope.launch {
+      display.applyAll(composition.diffs)
     }
   }
 

--- a/treehouse/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/ProtocolTest.kt
+++ b/treehouse/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/ProtocolTest.kt
@@ -37,10 +37,8 @@ import kotlin.test.fail
 class ProtocolTest {
   @Test fun childrenInheritIdFromSyntheticParent() = runTest {
     val clock = BroadcastFrameClock()
-    val diffs = ArrayDeque<Diff>()
     val composition = TreehouseComposition(
       scope = this + clock,
-      display = { diff, _ -> diffs += diff },
     )
 
     composition.setContent {
@@ -66,7 +64,7 @@ class ProtocolTest {
           PropertyDiff(4L, 1 /* text */, "hello"),
         ),
       ),
-      diffs.removeFirst()
+      composition.diffs.receive()
     )
 
     composition.cancel()
@@ -74,10 +72,8 @@ class ProtocolTest {
 
   @Test fun protocolSkipsLambdaChangeOfSamePresence() = runTest {
     val clock = BroadcastFrameClock()
-    val diffs = ArrayDeque<Diff>()
     val composition = TreehouseComposition(
       scope = this + clock,
-      display = { diff, _ -> diffs += diff },
     )
 
     var state by mutableStateOf(0)
@@ -105,7 +101,7 @@ class ProtocolTest {
           PropertyDiff(1L, 2 /* onClick */, true),
         ),
       ),
-      diffs.removeFirst()
+      composition.diffs.receive()
     )
 
     // Invoke the onClick lambda to move the state from 0 to 1.
@@ -119,7 +115,7 @@ class ProtocolTest {
           PropertyDiff(1L, 1 /* text */, "state: 1"),
         ),
       ),
-      diffs.removeFirst()
+      composition.diffs.receive()
     )
 
     // Invoke the onClick lambda to move the state from 1 to 2.
@@ -134,7 +130,7 @@ class ProtocolTest {
           PropertyDiff(1L, 2 /* text */, false),
         ),
       ),
-      diffs.removeFirst()
+      composition.diffs.receive()
     )
 
     // Manually advance state from 2 to 3 to test null to null case.
@@ -148,7 +144,7 @@ class ProtocolTest {
           PropertyDiff(1L, 1 /* text */, "state: 3"),
         ),
       ),
-      diffs.removeFirst()
+      composition.diffs.receive()
     )
 
     composition.cancel()

--- a/treehouse/treehouse-widget/build.gradle
+++ b/treehouse/treehouse-widget/build.gradle
@@ -25,6 +25,7 @@ kotlin {
     commonMain {
       dependencies {
         api project(':treehouse-protocol')
+        api deps.kotlinx.coroutines.core
       }
     }
     commonTest {

--- a/treehouse/treehouse-widget/src/commonTest/kotlin/app/cash/treehouse/widget/WidgetDisplayTest.kt
+++ b/treehouse/treehouse-widget/src/commonTest/kotlin/app/cash/treehouse/widget/WidgetDisplayTest.kt
@@ -23,10 +23,10 @@ import kotlin.test.assertFailsWith
 
 class WidgetDisplayTest {
   @Test fun rootWidgetMustHaveRootChildrenTag() {
-    WidgetDisplay(GoodRootWidget, NullWidgetFactory)
+    WidgetDisplay(GoodRootWidget, NullWidgetFactory, events = {})
 
     assertFailsWith<IllegalArgumentException> {
-      WidgetDisplay(BadRootWidget, NullWidgetFactory)
+      WidgetDisplay(BadRootWidget, NullWidgetFactory, events = {})
     }
   }
 


### PR DESCRIPTION
This introduces a new channel, TreehouseComposition.diffs that must be
manually connected to the display.