### PR TITLE
Disable cocoapod podspec generation

### DIFF
--- a/samples/counter/ios/shared/build.gradle
+++ b/samples/counter/ios/shared/build.gradle
@@ -42,6 +42,10 @@ kotlin {
       }
     }
   }
+
+  cocoapods {
+    noPodspec()
+  }
 }
 
 // TODO Remove disabling release https://github.com/square/treehouse/issues/119


### PR DESCRIPTION
We have a custom podspec in order to add a prepare_command.