### PR TITLE
Switch to using abstract classes for many types

### DIFF
--- a/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotBox.kt
+++ b/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotBox.kt
@@ -22,6 +22,6 @@ import example.sunspot.widget.SunspotBox
 
 class AndroidSunspotBox(
   override val value: LinearLayout,
-) : SunspotBox<View> {
+) : SunspotBox<View>() {
   override val children = ViewGroupChildren(value)
 }

--- a/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotButton.kt
+++ b/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotButton.kt
@@ -21,7 +21,7 @@ import example.sunspot.widget.SunspotButton
 
 class AndroidSunspotButton(
   override val value: Button,
-) : SunspotButton<View> {
+) : SunspotButton<View>() {
   override fun text(text: String?) {
     value.text = text
   }

--- a/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotText.kt
+++ b/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotText.kt
@@ -22,7 +22,7 @@ import example.sunspot.widget.SunspotText
 
 class AndroidSunspotText(
   override val value: TextView,
-) : SunspotText<View> {
+) : SunspotText<View>() {
   override fun text(text: String?) {
     value.text = text
   }

--- a/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotWidgetFactory.kt
+++ b/samples/counter/android/src/main/java/example/android/sunspot/AndroidSunspotWidgetFactory.kt
@@ -27,7 +27,7 @@ import example.sunspot.widget.SunspotWidgetFactory
 
 class AndroidSunspotWidgetFactory(
   private val context: Context,
-) : SunspotWidgetFactory<View> {
+) : SunspotWidgetFactory<View>() {
   override fun SunspotBox(): SunspotBox<View> {
     val view = LinearLayout(context)
     return AndroidSunspotBox(view)

--- a/samples/counter/browser/src/main/kotlin/example/browser/sunspot/widgetFactory.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/sunspot/widgetFactory.kt
@@ -27,7 +27,7 @@ import org.w3c.dom.HTMLSpanElement
 
 class HtmlSunspotNodeFactory(
   private val document: Document,
-) : SunspotWidgetFactory<HTMLElement> {
+) : SunspotWidgetFactory<HTMLElement>() {
   override fun SunspotBox(): SunspotBox<HTMLElement> {
     val div = document.createElement("div") as HTMLDivElement
     return HtmlSunspotBox(div)

--- a/samples/counter/browser/src/main/kotlin/example/browser/sunspot/widgets.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/sunspot/widgets.kt
@@ -25,13 +25,13 @@ import org.w3c.dom.HTMLSpanElement
 
 class HtmlSunspotBox(
   override val value: HTMLElement,
-) : SunspotBox<HTMLElement> {
+) : SunspotBox<HTMLElement>() {
   override val children = HTMLElementChildren(value)
 }
 
 class HtmlSunspotText(
   override val value: HTMLSpanElement,
-) : SunspotText<HTMLElement> {
+) : SunspotText<HTMLElement>() {
   override fun text(text: String?) {
     value.textContent = text
   }
@@ -43,7 +43,7 @@ class HtmlSunspotText(
 
 class HtmlSunspotButton(
   override val value: HTMLButtonElement,
-) : SunspotButton<HTMLElement> {
+) : SunspotButton<HTMLElement>() {
   override fun text(text: String?) {
     value.textContent = text
   }

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotBox.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotBox.kt
@@ -26,6 +26,6 @@ class IosSunspotBox(
     distribution = UIStackViewDistributionFillEqually
     axis = UILayoutConstraintAxisHorizontal
   }
-) : SunspotBox<UIView> {
+) : SunspotBox<UIView>() {
   override val children = UIStackViewChildren(value)
 }

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotButton.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotButton.kt
@@ -23,7 +23,7 @@ import platform.UIKit.UIControlStateNormal
 import platform.UIKit.UIView
 import platform.objc.sel_registerName
 
-class IosSunspotButton : SunspotButton<UIView> {
+class IosSunspotButton : SunspotButton<UIView>() {
   override val value = UIButton()
 
   override fun text(text: String?) {

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotNodeFactory.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotNodeFactory.kt
@@ -18,7 +18,7 @@ package example.ios.sunspot
 import example.sunspot.widget.SunspotWidgetFactory
 import platform.UIKit.UIView
 
-object IosSunspotNodeFactory : SunspotWidgetFactory<UIView> {
+object IosSunspotNodeFactory : SunspotWidgetFactory<UIView>() {
   override fun SunspotBox() = IosSunspotBox()
   override fun SunspotText() = IosSunspotText()
   override fun SunspotButton() = IosSunspotButton()

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotText.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/IosSunspotText.kt
@@ -21,7 +21,7 @@ import platform.UIKit.UIColor
 import platform.UIKit.UILabel
 import platform.UIKit.UIView
 
-class IosSunspotText : SunspotText<UIView> {
+class IosSunspotText : SunspotText<UIView>() {
   override val value = UILabel().apply {
     textColor = UIColor.whiteColor // TODO why is this needed?
     textAlignment = NSTextAlignmentCenter

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/UIStackViewChildren.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/UIStackViewChildren.kt
@@ -24,7 +24,7 @@ import platform.UIKit.subviews
 
 class UIStackViewChildren(
   private val root: UIStackView,
-) : Widget.Children<UIView> {
+) : Widget.Children<UIView>() {
   override fun insert(index: Int, widget: UIView) {
     root.insertArrangedSubview(widget, index.convert())
   }

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiColumn.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiColumn.kt
@@ -20,11 +20,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import example.schema.widget.Column
 
-class ComposeUiColumn : Column<@Composable () -> Unit> {
+class ComposeUiColumn : Column<@Composable () -> Unit>() {
   override val children = ComposeUiWidgetChildren()
   override val value = @Composable {
     Column {
-      children.render()
+      children.Render()
     }
   }
 }

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiItem.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiItem.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import example.schema.widget.Item
 
-class ComposeUiItem : Item<@Composable () -> Unit> {
+class ComposeUiItem : Item<@Composable () -> Unit>() {
   private var content by mutableStateOf("")
   private var onComplete: (() -> Unit)? = null
 

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiScrollableColumn.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiScrollableColumn.kt
@@ -23,11 +23,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import example.schema.widget.ScrollableColumn
 
-class ComposeUiScrollableColumn : ScrollableColumn<@Composable () -> Unit> {
+class ComposeUiScrollableColumn : ScrollableColumn<@Composable () -> Unit>() {
   override val children = ComposeUiWidgetChildren()
   override val value = @Composable {
     Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-      children.render()
+      children.Render()
     }
   }
 }

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiToolbar.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiToolbar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import example.schema.widget.Toolbar
 
-class ComposeUiToolbar : Toolbar<@Composable () -> Unit> {
+class ComposeUiToolbar : Toolbar<@Composable () -> Unit>() {
   private var title by mutableStateOf("")
 
   override val value = @Composable {

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiWidgetChildren.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiWidgetChildren.kt
@@ -20,11 +20,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import app.cash.treehouse.widget.Widget
 
-class ComposeUiWidgetChildren : Widget.Children<@Composable () -> Unit> {
+class ComposeUiWidgetChildren : Widget.Children<@Composable () -> Unit>() {
   private val children = mutableStateListOf<@Composable () -> Unit>()
 
   @Composable
-  fun render() {
+  fun Render() {
     for (child in children) {
       child()
     }

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiWidgetFactory.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiWidgetFactory.kt
@@ -19,7 +19,7 @@ package example.android.composeui
 import androidx.compose.runtime.Composable
 import example.schema.widget.TodoWidgetFactory
 
-object ComposeUiWidgetFactory : TodoWidgetFactory<@Composable () -> Unit> {
+object ComposeUiWidgetFactory : TodoWidgetFactory<@Composable () -> Unit>() {
   override fun Toolbar() = ComposeUiToolbar()
   override fun ScrollableColumn() = ComposeUiScrollableColumn()
   override fun Item() = ComposeUiItem()

--- a/samples/todo-list/android-views/src/main/java/example/android/views/ViewColumn.kt
+++ b/samples/todo-list/android-views/src/main/java/example/android/views/ViewColumn.kt
@@ -23,7 +23,7 @@ import example.schema.widget.Column
 
 class ViewColumn(
   linearLayout: LinearLayout,
-) : Column<View> {
+) : Column<View>() {
   override val value = linearLayout
   override val children = ViewGroupChildren(linearLayout)
 }

--- a/samples/todo-list/android-views/src/main/java/example/android/views/ViewItem.kt
+++ b/samples/todo-list/android-views/src/main/java/example/android/views/ViewItem.kt
@@ -20,7 +20,7 @@ import android.view.View
 import example.android.views.databinding.ItemBinding
 import example.schema.widget.Item
 
-class ViewItem(private val binding: ItemBinding) : Item<View> {
+class ViewItem(private val binding: ItemBinding) : Item<View>() {
   override val value get() = binding.root
 
   override fun content(content: String) {

--- a/samples/todo-list/android-views/src/main/java/example/android/views/ViewScrollableColumn.kt
+++ b/samples/todo-list/android-views/src/main/java/example/android/views/ViewScrollableColumn.kt
@@ -21,7 +21,7 @@ import app.cash.treehouse.widget.ViewGroupChildren
 import example.android.views.databinding.ScrollableColumnBinding
 import example.schema.widget.ScrollableColumn
 
-class ViewScrollableColumn(binding: ScrollableColumnBinding) : ScrollableColumn<View> {
+class ViewScrollableColumn(binding: ScrollableColumnBinding) : ScrollableColumn<View>() {
   override val value = binding.root
   override val children = ViewGroupChildren(binding.children)
 }

--- a/samples/todo-list/android-views/src/main/java/example/android/views/ViewToolbar.kt
+++ b/samples/todo-list/android-views/src/main/java/example/android/views/ViewToolbar.kt
@@ -20,7 +20,7 @@ import android.view.View
 import example.android.views.databinding.ToolbarBinding
 import example.schema.widget.Toolbar
 
-class ViewToolbar(private val binding: ToolbarBinding) : Toolbar<View> {
+class ViewToolbar(private val binding: ToolbarBinding) : Toolbar<View>() {
   override val value get() = binding.root
 
   override fun title(title: String) {

--- a/samples/todo-list/android-views/src/main/java/example/android/views/ViewWidgetFactory.kt
+++ b/samples/todo-list/android-views/src/main/java/example/android/views/ViewWidgetFactory.kt
@@ -27,7 +27,7 @@ import example.schema.widget.TodoWidgetFactory
 
 class ViewWidgetFactory(
   private val context: Context,
-) : TodoWidgetFactory<View> {
+) : TodoWidgetFactory<View>() {
   private val inflater = LayoutInflater.from(context)
 
   override fun Toolbar() = ViewToolbar(ToolbarBinding.inflate(inflater))

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schemaGeneration.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/schemaGeneration.kt
@@ -39,7 +39,7 @@ import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.joinToCode
 
 /*
-class SchemaSunspotWidgetFactory : SunspotWidgetFactory<Nothing> {
+class SchemaSunspotWidgetFactory : SunspotWidgetFactory<Nothing>() {
   override fun SunspotBox(): SunspotBox<Nothing> = SchemaSunspotBox(scope)
   // ...
 }
@@ -56,7 +56,7 @@ internal fun generateSchemaWidgetFactory(schema: Schema): FileSpec {
   return FileSpec.builder(schema.testPackage, widgetFactoryType.simpleName)
     .addType(
       TypeSpec.objectBuilder(widgetFactoryType)
-        .addSuperinterface(schema.getWidgetFactoryType().parameterizedBy(schemaWidgetType))
+        .superclass(schema.getWidgetFactoryType().parameterizedBy(schemaWidgetType))
         .apply {
           for (widget in schema.widgets) {
             addFunction(
@@ -91,7 +91,7 @@ internal fun generateSchemaWidgetFactory(schema: Schema): FileSpec {
 }
 
 /*
-private class SchemaSunspotBox : SunspotBox<SchemaWidget>, SchemaWidget {
+private class SchemaSunspotBox : SunspotBox<SchemaWidget>(), SchemaWidget {
   // ...
 }
  */
@@ -102,7 +102,7 @@ internal fun generateSchemaWidget(schema: Schema, widget: Widget): FileSpec {
   return FileSpec.builder(schema.testPackage, className.simpleName)
     .addType(
       TypeSpec.classBuilder(className)
-        .addSuperinterface(schema.widgetType(widget).parameterizedBy(schemaWidgetType))
+        .superclass(schema.widgetType(widget).parameterizedBy(schemaWidgetType))
         .addSuperinterface(schemaWidgetType)
         .addProperty(
           PropertySpec.builder("value", schemaWidgetType, OVERRIDE)

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetGeneration.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetGeneration.kt
@@ -36,25 +36,30 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asTypeName
 
-/*
-interface SunspotWidgetFactory<T : Any> : Widget.Factory<T> {
-  fun SunspotText(): SunspotText<T>
-  fun SunspotButton(): SunspotButton<T>
-
-  override fun create(, kind: Int, id: Long): TreeNode<T> {
-    return when (kind) {
-      1 -> SunspotText()
-      2 -> SunspotButton()
-      else -> throw IllegalArgumentException("Unknown kind $kind")
-    }
-  }
-}
-*/
+/**
+ * ```kotlin
+ * abstract class SunspotWidgetFactory<T : Any> : Widget.Factory<T> {
+ *   abstract fun SunspotText(): SunspotText<T>
+ *   abstract fun SunspotButton(): SunspotButton<T>
+ *
+ *   override fun create(kind: Int, id: Long): TreeNode<T> {
+ *     return when (kind) {
+ *       1 -> SunspotText()
+ *       2 -> SunspotButton()
+ *       else -> throw IllegalArgumentException("Unknown kind $kind")
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Note: We generate an abstract class and not an interface so generics carry through to Objective-C
+ * and Swift.
+ */
 internal fun generateWidgetFactory(schema: Schema): FileSpec {
   return FileSpec.builder(schema.displayPackage, schema.getWidgetFactoryType().simpleName)
     .addType(
-      TypeSpec.interfaceBuilder(schema.getWidgetFactoryType())
-        .addModifiers(PUBLIC)
+      TypeSpec.classBuilder(schema.getWidgetFactoryType())
+        .addModifiers(PUBLIC, ABSTRACT)
         .addTypeVariable(typeVariableT)
         .addSuperinterface(factoryOfT)
         .apply {
@@ -88,35 +93,40 @@ internal fun generateWidgetFactory(schema: Schema): FileSpec {
     .build()
 }
 
-/*
-interface SunspotButton<out T: Any> : SunspotNode<T> {
-  fun text(text: String?)
-  fun enabled(enabled: Boolean)
-  fun onClick(onClick: (() -> Unit)?)
-
-  override fun apply(diff: PropertyDiff, events: (Event) -> Unit) {
-    when (val tag = diff.tag) {
-      1 -> text(diff.value as String?)
-      2 -> enabled(diff.value as Boolean)
-      3 -> {
-        val onClick: (() -> Unit)? = if (diff.value as Boolean) {
-          val event = Event(diff.id, 3, null);
-          { events(event) }
-        } else {
-          null
-        }
-        onClick(onClick)
-      }
-      else -> throw IllegalArgumentException("Unknown tag $tag")
-    }
-  }
-}
-*/
+/**
+ * ```kotlin
+ * abstract class SunspotButton<out T: Any> : SunspotNode<T> {
+ *   abstract fun text(text: String?)
+ *   abstract fun enabled(enabled: Boolean)
+ *   abstract fun onClick(onClick: (() -> Unit)?)
+ *
+ *   override fun apply(diff: PropertyDiff, events: (Event) -> Unit) {
+ *     when (val tag = diff.tag) {
+ *       1 -> text(diff.value as String?)
+ *       2 -> enabled(diff.value as Boolean)
+ *       3 -> {
+ *         val onClick: (() -> Unit)? = if (diff.value as Boolean) {
+ *           val event = Event(diff.id, 3, null);
+ *           { events(event) }
+ *         } else {
+ *           null
+ *         }
+ *         onClick(onClick)
+ *       }
+ *       else -> throw IllegalArgumentException("Unknown tag $tag")
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Note: We generate an abstract class and not an interface so generics carry through to Objective-C
+ * and Swift.
+ */
 internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
   return FileSpec.builder(schema.displayPackage, widget.flatName)
     .addType(
-      TypeSpec.interfaceBuilder(widget.flatName)
-        .addModifiers(PUBLIC)
+      TypeSpec.classBuilder(widget.flatName)
+        .addModifiers(PUBLIC, ABSTRACT)
         .addTypeVariable(typeVariableT)
         .addSuperinterface(widgetOfT)
         .apply {

--- a/treehouse/treehouse-widget/src/androidMain/kotlin/app/cash/treehouse/widget/ViewGroupChildren.kt
+++ b/treehouse/treehouse-widget/src/androidMain/kotlin/app/cash/treehouse/widget/ViewGroupChildren.kt
@@ -18,7 +18,7 @@ package app.cash.treehouse.widget
 import android.view.View
 import android.view.ViewGroup
 
-public class ViewGroupChildren(private val parent: ViewGroup) : Widget.Children<View> {
+public class ViewGroupChildren(private val parent: ViewGroup) : Widget.Children<View>() {
   override fun insert(index: Int, widget: View) {
     parent.addView(widget, index)
   }

--- a/treehouse/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/MutableListChildren.kt
+++ b/treehouse/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/MutableListChildren.kt
@@ -20,7 +20,7 @@ import kotlin.jvm.JvmOverloads
 public class MutableListChildren<T : Any>
 @JvmOverloads constructor(
   public val list: MutableList<T> = mutableListOf(),
-) : Widget.Children<T>, Iterable<T> {
+) : Widget.Children<T>(), Iterable<T> {
   override fun insert(index: Int, widget: T) {
     list.add(index, widget)
   }

--- a/treehouse/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/Widget.kt
+++ b/treehouse/treehouse-widget/src/commonMain/kotlin/app/cash/treehouse/widget/Widget.kt
@@ -32,10 +32,13 @@ public interface Widget<T : Any> {
    *
    * Arguments to these methods can be assumed to be validated against the current state of the
    * list. No additional validation needs to be performed (for example, checking index bounds).
+   *
+   * Note: This is an abstract class and not an interface so generics carry through to Objective-C
+   * and Swift.
    */
-  public interface Children<T : Any> {
+  public abstract class Children<T : Any> {
     /** Insert child [widget] at [index]. */
-    public fun insert(index: Int, widget: T)
+    public abstract fun insert(index: Int, widget: T)
     /**
      * Move [count] child widgets from [fromIndex] to [toIndex].
      *
@@ -44,11 +47,11 @@ public interface Widget<T : Any> {
      * [toIndex] should be 3. If the widgets were `A B C D E`, calling `move(1, 3, 1)` would
      * result in the widgets being reordered to `A C B D E`.
      */
-    public fun move(fromIndex: Int, toIndex: Int, count: Int)
+    public abstract fun move(fromIndex: Int, toIndex: Int, count: Int)
     /** Remove [count] child widgets starting from [index]. */
-    public fun remove(index: Int, count: Int)
+    public abstract fun remove(index: Int, count: Int)
     /** Remove all child widgets. */
-    public fun clear()
+    public abstract fun clear()
   }
 
   public interface Factory<T : Any> {

--- a/treehouse/treehouse-widget/src/commonTest/kotlin/app/cash/treehouse/widget/WidgetDisplayTest.kt
+++ b/treehouse/treehouse-widget/src/commonTest/kotlin/app/cash/treehouse/widget/WidgetDisplayTest.kt
@@ -49,7 +49,7 @@ class WidgetDisplayTest {
     override fun create(kind: Int, id: Long) = throw UnsupportedOperationException()
   }
 
-  private object NullWidgetChildren : Widget.Children<Unit> {
+  private object NullWidgetChildren : Widget.Children<Unit>() {
     override fun insert(index: Int, widget: Unit) = throw UnsupportedOperationException()
     override fun move(fromIndex: Int, toIndex: Int, count: Int) = throw UnsupportedOperationException()
     override fun remove(index: Int, count: Int) = throw UnsupportedOperationException()

--- a/treehouse/treehouse-widget/src/jsMain/kotlin/app/cash/treehouse/widget/HTMLElementChildren.kt
+++ b/treehouse/treehouse-widget/src/jsMain/kotlin/app/cash/treehouse/widget/HTMLElementChildren.kt
@@ -21,7 +21,7 @@ import org.w3c.dom.get
 
 public class HTMLElementChildren(
   private val parent: HTMLElement,
-) : Widget.Children<HTMLElement> {
+) : Widget.Children<HTMLElement>() {
   override fun insert(index: Int, widget: HTMLElement) {
     // Null element returned when index == childCount causes insertion at end.
     val current = parent.children[index]


### PR DESCRIPTION
This allows propagation of generics and functions with default implementations to subclasses in Objective-C or (more importantly) Swift.

Closes #170