### PR TITLE
Create a common way for published multiplatform modules to add all the same targets

### DIFF
--- a/treehouse/addAllTargets.gradle
+++ b/treehouse/addAllTargets.gradle
@@ -1,0 +1,53 @@
+plugins.withId('org.jetbrains.kotlin.multiplatform') {
+  kotlin {
+    if (plugins.hasPlugin('com.android.library')) {
+      android {
+        publishLibraryVariants('release')
+      }
+    }
+    iosArm32()
+    iosArm64()
+    iosX64()
+    js {
+      browser()
+    }
+    jvm()
+    macosX64()
+    mingwX64()
+    tvosX64()
+    tvosArm64()
+    watchosArm32()
+    watchosArm64()
+    macosArm64()
+    iosSimulatorArm64()
+    watchosSimulatorArm64()
+    tvosSimulatorArm64()
+
+    sourceSets {
+      nativeMain {
+      }
+
+      nativeTest {
+      }
+    }
+
+    configure([
+      targets.iosArm32,
+      targets.iosArm64,
+      targets.iosX64,
+      targets.macosX64,
+      targets.mingwX64,
+      targets.tvosArm64,
+      targets.tvosX64,
+      targets.watchosArm32,
+      targets.watchosArm64,
+      targets.macosArm64,
+      targets.iosSimulatorArm64,
+      targets.watchosSimulatorArm64,
+      targets.tvosSimulatorArm64,
+    ]) {
+      compilations.main.source(sourceSets.nativeMain)
+      compilations.test.source(sourceSets.nativeTest)
+    }
+  }
+}

--- a/treehouse/compose/runtime/build.gradle
+++ b/treehouse/compose/runtime/build.gradle
@@ -43,26 +43,7 @@ tasks.named("generateMetadataFileForKotlinMultiplatformPublication").configure {
 }
 
 kotlin {
-  android {
-    publishLibraryVariants('release')
-  }
-  iosArm32()
-  iosArm64()
-  iosX64()
-  js {
-    browser()
-  }
-  jvm()
-  macosX64()
-  mingwX64()
-  tvosX64()
-  tvosArm64()
-  watchosArm32()
-  watchosArm64()
-  macosArm64()
-  iosSimulatorArm64()
-  watchosSimulatorArm64()
-  tvosSimulatorArm64()
+  apply from: "${rootDir}/addAllTargets.gradle"
 
   sourceSets {
     commonMain {
@@ -92,10 +73,6 @@ kotlin {
         api 'androidx.annotation:annotation:1.1.0'
       }
     }
-    nativeMain {
-    }
-    nativeTest {
-    }
     jvmMain {
       kotlin {
         srcDir '../upstream/compose/runtime/runtime/src/jvmMain/kotlin'
@@ -110,25 +87,6 @@ kotlin {
         implementation deps.kotlinx.coroutines.test
       }
     }
-  }
-
-  configure([
-    targets.iosArm32,
-    targets.iosArm64,
-    targets.iosX64,
-    targets.macosX64,
-    targets.mingwX64,
-    targets.tvosArm64,
-    targets.tvosX64,
-    targets.watchosArm32,
-    targets.watchosArm64,
-    targets.macosArm64,
-    targets.iosSimulatorArm64,
-    targets.watchosSimulatorArm64,
-    targets.tvosSimulatorArm64,
-  ]) {
-    compilations.main.source(sourceSets.nativeMain)
-    compilations.test.source(sourceSets.nativeTest)
   }
 }
 

--- a/treehouse/treehouse-compose/build.gradle
+++ b/treehouse/treehouse-compose/build.gradle
@@ -6,26 +6,7 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  android {
-    publishLibraryVariants('release')
-  }
-  iosArm32()
-  iosArm64()
-  iosX64()
-  js {
-    browser()
-  }
-  jvm()
-  macosX64()
-  mingwX64()
-  tvosX64()
-  tvosArm64()
-  watchosArm32()
-  watchosArm64()
-  macosArm64()
-  iosSimulatorArm64()
-  watchosSimulatorArm64()
-  tvosSimulatorArm64()
+  apply from: "${rootDir}/addAllTargets.gradle"
 
   sourceSets {
     commonMain {
@@ -49,26 +30,6 @@ kotlin {
     androidTest {
       dependsOn jvmTest
     }
-    nativeTest {
-    }
-  }
-
-  configure([
-    targets.iosArm32,
-    targets.iosArm64,
-    targets.iosX64,
-    targets.macosX64,
-    targets.mingwX64,
-    targets.tvosArm64,
-    targets.tvosX64,
-    targets.watchosArm32,
-    targets.watchosArm64,
-    targets.macosArm64,
-    targets.iosSimulatorArm64,
-    targets.watchosSimulatorArm64,
-    targets.tvosSimulatorArm64,
-  ]) {
-    compilations.test.source(sourceSets.nativeTest)
   }
 }
 

--- a/treehouse/treehouse-protocol/build.gradle
+++ b/treehouse/treehouse-protocol/build.gradle
@@ -4,23 +4,7 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  iosArm32()
-  iosArm64()
-  iosX64()
-  js {
-    browser()
-  }
-  jvm()
-  macosX64()
-  mingwX64()
-  tvosX64()
-  tvosArm64()
-  watchosArm32()
-  watchosArm64()
-  macosArm64()
-  iosSimulatorArm64()
-  watchosSimulatorArm64()
-  tvosSimulatorArm64()
+  apply from: "${rootDir}/addAllTargets.gradle"
 
   sourceSets {
     commonMain {

--- a/treehouse/treehouse-schema-annotations/build.gradle
+++ b/treehouse/treehouse-schema-annotations/build.gradle
@@ -3,9 +3,5 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  js() {
-    nodejs()
-  }
-  jvm()
-  ios()
+  apply from: "${rootDir}/addAllTargets.gradle"
 }

--- a/treehouse/treehouse-widget/build.gradle
+++ b/treehouse/treehouse-widget/build.gradle
@@ -4,26 +4,7 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  android {
-    publishLibraryVariants('release')
-  }
-  iosArm32()
-  iosArm64()
-  iosX64()
-  js {
-    browser()
-  }
-  jvm()
-  macosX64()
-  mingwX64()
-  tvosX64()
-  tvosArm64()
-  watchosArm32()
-  watchosArm64()
-  macosArm64()
-  iosSimulatorArm64()
-  watchosSimulatorArm64()
-  tvosSimulatorArm64()
+  apply from: "${rootDir}/addAllTargets.gradle"
 
   sourceSets {
     commonMain {


### PR DESCRIPTION
Theres probably a better way to do it, I tried just doing a normal groovy function definition but I got some mystical clojure errors and decided to not

Closes #32.