### PR TITLE
Generate composition factory in regular compose module

### DIFF
--- a/samples/counter/android/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android/src/main/java/example/android/MainActivity.kt
@@ -23,14 +23,14 @@ import android.widget.LinearLayout
 import android.widget.LinearLayout.LayoutParams
 import android.widget.LinearLayout.VERTICAL
 import app.cash.treehouse.compose.AndroidUiDispatcher
-import app.cash.treehouse.compose.TreehouseComposition
-import app.cash.treehouse.protocol.widget.ProtocolWidgetDisplay
+import app.cash.treehouse.protocol.widget.ProtocolDisplay
 import example.android.sunspot.AndroidSunspotBox
 import example.android.sunspot.AndroidSunspotWidgetFactory
 import example.shared.Counter
-import example.sunspot.compose.ProtocolSunspotComposition
+import example.sunspot.compose.ProtocolComposeWidgetFactory
+import example.sunspot.compose.SunspotComposition
+import example.sunspot.widget.ProtocolDisplayWidgetFactory
 import example.sunspot.widget.ProtocolSunspotBox
-import example.sunspot.widget.ProtocolWidgetFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 
@@ -40,8 +40,9 @@ class MainActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val composition = ProtocolSunspotComposition(
+    val composition = SunspotComposition(
       scope = scope,
+      factory = ProtocolComposeWidgetFactory(),
       onDiff = { Log.d("TreehouseDiff", it.toString()) },
       onEvent = { Log.d("TreehouseEvent", it.toString()) },
     )
@@ -52,9 +53,9 @@ class MainActivity : Activity() {
     }
     setContentView(root)
 
-    val display = ProtocolWidgetDisplay(
+    val display = ProtocolDisplay(
       root = ProtocolSunspotBox(AndroidSunspotBox(root)),
-      factory = ProtocolWidgetFactory(AndroidSunspotWidgetFactory(this)),
+      factory = ProtocolDisplayWidgetFactory(AndroidSunspotWidgetFactory(this)),
       eventSink = composition,
     )
 

--- a/samples/counter/browser/src/main/kotlin/example/browser/main.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/main.kt
@@ -16,29 +16,31 @@
 package example.browser
 
 import app.cash.treehouse.compose.WindowAnimationFrameClock
-import app.cash.treehouse.protocol.widget.ProtocolWidgetDisplay
+import app.cash.treehouse.protocol.widget.ProtocolDisplay
 import example.browser.sunspot.HtmlSunspotBox
 import example.browser.sunspot.HtmlSunspotNodeFactory
 import example.shared.Counter
-import example.sunspot.compose.ProtocolSunspotComposition
+import example.sunspot.compose.ProtocolComposeWidgetFactory
+import example.sunspot.compose.SunspotComposition
+import example.sunspot.widget.ProtocolDisplayWidgetFactory
 import example.sunspot.widget.ProtocolSunspotBox
-import example.sunspot.widget.ProtocolWidgetFactory
 import kotlinx.browser.document
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.plus
 import org.w3c.dom.HTMLElement
 
 fun main() {
-  val composition = ProtocolSunspotComposition(
+  val composition = SunspotComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
+    factory = ProtocolComposeWidgetFactory(),
     onDiff = { console.log("TreehouseDiff", it.toString()) },
     onEvent = { console.log("TreehouseEvent", it.toString()) },
   )
 
   val content = document.getElementById("content")!! as HTMLElement
-  val display = ProtocolWidgetDisplay(
+  val display = ProtocolDisplay(
     root = ProtocolSunspotBox(HtmlSunspotBox(content)),
-    factory = ProtocolWidgetFactory(HtmlSunspotNodeFactory(document)),
+    factory = ProtocolDisplayWidgetFactory(HtmlSunspotNodeFactory(document)),
     eventSink = composition,
   )
 

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/CounterViewControllerDelegate.kt
@@ -16,13 +16,14 @@
 package example.ios
 
 import androidx.compose.runtime.BroadcastFrameClock
-import app.cash.treehouse.protocol.widget.ProtocolWidgetDisplay
+import app.cash.treehouse.protocol.widget.ProtocolDisplay
 import example.ios.sunspot.IosSunspotBox
 import example.ios.sunspot.IosSunspotNodeFactory
 import example.shared.Counter
-import example.sunspot.compose.ProtocolSunspotComposition
+import example.sunspot.compose.ProtocolComposeWidgetFactory
+import example.sunspot.compose.SunspotComposition
+import example.sunspot.widget.ProtocolDisplayWidgetFactory
 import example.sunspot.widget.ProtocolSunspotBox
-import example.sunspot.widget.ProtocolWidgetFactory
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.plus
@@ -36,15 +37,16 @@ class CounterViewControllerDelegate(
   private val scope = MainScope() + clock
 
   init {
-    val composition = ProtocolSunspotComposition(
+    val composition = SunspotComposition(
       scope = scope,
+      factory = ProtocolComposeWidgetFactory(),
       onDiff = { NSLog("TreehouseDiff: $it") },
       onEvent = { NSLog("TreehouseEvent: $it") }
     )
 
-    val display = ProtocolWidgetDisplay(
+    val display = ProtocolDisplay(
       root = ProtocolSunspotBox(IosSunspotBox(root)),
-      factory = ProtocolWidgetFactory(IosSunspotNodeFactory),
+      factory = ProtocolDisplayWidgetFactory(IosSunspotNodeFactory),
       eventSink = composition
     )
 

--- a/samples/counter/shared/src/commonTest/kotlin/example/shared/CounterTest.kt
+++ b/samples/counter/shared/src/commonTest/kotlin/example/shared/CounterTest.kt
@@ -16,15 +16,16 @@
 package example.shared
 
 import androidx.compose.runtime.BroadcastFrameClock
-import app.cash.treehouse.protocol.widget.ProtocolWidgetDisplay
+import app.cash.treehouse.protocol.widget.ProtocolDisplay
 import example.sunspot.SunspotBox
 import example.sunspot.SunspotButton
 import example.sunspot.SunspotText
-import example.sunspot.compose.ProtocolSunspotComposition
+import example.sunspot.compose.ProtocolComposeWidgetFactory
+import example.sunspot.compose.SunspotComposition
 import example.sunspot.test.SchemaSunspotBox
 import example.sunspot.test.SchemaSunspotWidgetFactory
+import example.sunspot.widget.ProtocolDisplayWidgetFactory
 import example.sunspot.widget.ProtocolSunspotBox
-import example.sunspot.widget.ProtocolWidgetFactory
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -36,15 +37,16 @@ class CounterTest {
     val root = SchemaSunspotBox()
 
     val clock = BroadcastFrameClock()
-    val composition = ProtocolSunspotComposition(
+    val composition = SunspotComposition(
       scope = this + clock,
+      factory = ProtocolComposeWidgetFactory(),
       onDiff = { println(it) },
       onEvent = { println(it) },
     )
 
-    val display = ProtocolWidgetDisplay(
+    val display = ProtocolDisplay(
       root = ProtocolSunspotBox(root),
-      factory = ProtocolWidgetFactory(SchemaSunspotWidgetFactory),
+      factory = ProtocolDisplayWidgetFactory(SchemaSunspotWidgetFactory),
       eventSink = composition,
     )
 

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/TodoActivity.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/TodoActivity.kt
@@ -23,11 +23,12 @@ import android.widget.LinearLayout
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.platform.ComposeView
 import app.cash.treehouse.compose.AndroidUiDispatcher.Companion.Main
-import app.cash.treehouse.protocol.widget.ProtocolWidgetDisplay
+import app.cash.treehouse.protocol.widget.ProtocolDisplay
 import example.presenters.TodoPresenter
-import example.schema.compose.ProtocolTodoComposition
+import example.schema.compose.ProtocolComposeWidgetFactory
+import example.schema.compose.TodoComposition
 import example.schema.widget.ProtocolColumn
-import example.schema.widget.ProtocolWidgetFactory
+import example.schema.widget.ProtocolDisplayWidgetFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 
@@ -37,8 +38,9 @@ class TodoActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val composition = ProtocolTodoComposition(
+    val composition = TodoComposition(
       scope = scope,
+      factory = ProtocolComposeWidgetFactory(),
       onDiff = { Log.d("TreehouseDiff", it.toString()) },
       onEvent = { Log.d("TreehouseEvent", it.toString()) },
     )
@@ -50,9 +52,9 @@ class TodoActivity : ComponentActivity() {
     }
     setContentView(composeView)
 
-    val display = ProtocolWidgetDisplay(
+    val display = ProtocolDisplay(
       root = ProtocolColumn(root),
-      factory = ProtocolWidgetFactory(ComposeUiWidgetFactory),
+      factory = ProtocolDisplayWidgetFactory(ComposeUiWidgetFactory),
       eventSink = composition,
     )
 

--- a/samples/todo-list/android-views/src/main/java/example/android/views/TodoActivity.kt
+++ b/samples/todo-list/android-views/src/main/java/example/android/views/TodoActivity.kt
@@ -23,11 +23,12 @@ import android.widget.LinearLayout
 import android.widget.LinearLayout.VERTICAL
 import androidx.appcompat.app.AppCompatActivity
 import app.cash.treehouse.compose.AndroidUiDispatcher.Companion.Main
-import app.cash.treehouse.protocol.widget.ProtocolWidgetDisplay
+import app.cash.treehouse.protocol.widget.ProtocolDisplay
 import example.presenters.TodoPresenter
-import example.schema.compose.ProtocolTodoComposition
+import example.schema.compose.ProtocolComposeWidgetFactory
+import example.schema.compose.TodoComposition
 import example.schema.widget.ProtocolColumn
-import example.schema.widget.ProtocolWidgetFactory
+import example.schema.widget.ProtocolDisplayWidgetFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 
@@ -37,8 +38,9 @@ class TodoActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val composition = ProtocolTodoComposition(
+    val composition = TodoComposition(
       scope = scope,
+      factory = ProtocolComposeWidgetFactory(),
       onDiff = { Log.d("TreehouseDiff", it.toString()) },
       onEvent = { Log.d("TreehouseEvent", it.toString()) },
     )
@@ -49,9 +51,9 @@ class TodoActivity : AppCompatActivity() {
     }
     setContentView(root)
 
-    val display = ProtocolWidgetDisplay(
+    val display = ProtocolDisplay(
       root = ProtocolColumn(ViewColumn(root)),
-      factory = ProtocolWidgetFactory(ViewWidgetFactory(this)),
+      factory = ProtocolDisplayWidgetFactory(ViewWidgetFactory(this)),
       eventSink = composition,
     )
 

--- a/treehouse/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/ProtocolTest.kt
+++ b/treehouse/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/ProtocolTest.kt
@@ -27,7 +27,8 @@ import app.cash.treehouse.protocol.Event
 import app.cash.treehouse.protocol.PropertyDiff
 import example.treehouse.compose.Box
 import example.treehouse.compose.Button
-import example.treehouse.compose.ProtocolExampleSchemaComposition
+import example.treehouse.compose.ExampleSchemaComposition
+import example.treehouse.compose.ProtocolComposeWidgetFactory
 import example.treehouse.compose.Text
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.yield
@@ -38,7 +39,10 @@ import kotlin.test.fail
 class ProtocolTest {
   @Test fun childrenInheritIdFromSyntheticParent() = runTest {
     val clock = BroadcastFrameClock()
-    val composition = ProtocolExampleSchemaComposition(scope = this + clock)
+    val composition = ExampleSchemaComposition(
+      scope = this + clock,
+      factory = ProtocolComposeWidgetFactory(),
+    )
     val diffs = ArrayDeque<Diff>()
     composition.start { diff -> diffs += diff }
 
@@ -74,7 +78,10 @@ class ProtocolTest {
   @Test fun protocolSkipsLambdaChangeOfSamePresence() = runTest {
     val clock = BroadcastFrameClock()
     var state by mutableStateOf(0)
-    val composition = ProtocolExampleSchemaComposition(scope = this + clock)
+    val composition = ExampleSchemaComposition(
+      scope = this + clock,
+      factory = ProtocolComposeWidgetFactory(),
+    )
     val diffs = ArrayDeque<Diff>()
     composition.start { diff -> diffs += diff }
 

--- a/treehouse/treehouse-protocol-widget/src/commonMain/kotlin/app/cash/treehouse/protocol/widget/ProtocolDisplay.kt
+++ b/treehouse/treehouse-protocol-widget/src/commonMain/kotlin/app/cash/treehouse/protocol/widget/ProtocolDisplay.kt
@@ -22,7 +22,7 @@ import app.cash.treehouse.protocol.Diff
 import app.cash.treehouse.protocol.DiffSink
 import app.cash.treehouse.protocol.EventSink
 
-public class ProtocolWidgetDisplay<T : Any>(
+public class ProtocolDisplay<T : Any>(
   private val root: ProtocolWidget<T>,
   private val factory: ProtocolWidget.Factory<T>,
   private val eventSink: EventSink,

--- a/treehouse/treehouse-protocol-widget/src/commonTest/kotlin/app/cash/treehouse/protocol/widget/ProtocolWidgetDisplayTest.kt
+++ b/treehouse/treehouse-protocol-widget/src/commonTest/kotlin/app/cash/treehouse/protocol/widget/ProtocolWidgetDisplayTest.kt
@@ -24,10 +24,10 @@ import kotlin.test.assertFailsWith
 
 class ProtocolWidgetDisplayTest {
   @Test fun rootWidgetMustHaveRootChildrenTag() {
-    ProtocolWidgetDisplay(GoodRootWidget, NullWidgetFactory) { }
+    ProtocolDisplay(GoodRootWidget, NullWidgetFactory) { }
 
     assertFailsWith<IllegalArgumentException> {
-      ProtocolWidgetDisplay(BadRootWidget, NullWidgetFactory) { }
+      ProtocolDisplay(BadRootWidget, NullWidgetFactory) { }
     }
   }
 

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeGeneration.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeGeneration.kt
@@ -32,6 +32,39 @@ import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.joinToCode
 
 /*
+public fun SunspotComposition(
+  scope: CoroutineScope,
+  factory: SunspotWidgetFactory<*>,
+  onDiff: DiffSink = DiffSink {},
+  onEvent: EventSink = EventSink {},
+): TreehouseComposition {
+  return TreehouseComposition(scope, factory, onDiff, onEvent)
+}
+*/
+internal fun generateCompositionFactory(schema: Schema): FileSpec {
+  return FileSpec.builder(schema.composePackage, "composition")
+    .addFunction(
+      FunSpec.builder("${schema.name}Composition")
+        .addParameter("scope", coroutineScope)
+        .addParameter("factory", schema.getWidgetFactoryType().parameterizedBy(STAR))
+        .addParameter(
+          ParameterSpec.builder("onDiff", diffSink)
+            .defaultValue("%T {}", diffSink)
+            .build()
+        )
+        .addParameter(
+          ParameterSpec.builder("onEvent", eventSink)
+            .defaultValue("%T {}", eventSink)
+            .build()
+        )
+        .returns(treehouseComposition)
+        .addStatement("return %T(scope, factory, onDiff, onEvent)", treehouseComposition)
+        .build()
+    )
+    .build()
+}
+
+/*
 @Composable
 fun SunspotButton(
   text: String?,

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeProtocolGeneration.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/composeProtocolGeneration.kt
@@ -21,57 +21,28 @@ import app.cash.treehouse.schema.parser.Event
 import app.cash.treehouse.schema.parser.Property
 import app.cash.treehouse.schema.parser.Schema
 import app.cash.treehouse.schema.parser.Widget
-import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.NOTHING
-import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 
 /*
-public fun ProtocolSunspotComposition(
-  scope: CoroutineScope,
-  onDiff: DiffSink = DiffSink {},
-  onEvent: EventSink = EventSink {},
-): TreehouseComposition {
-  return TreehouseComposition(scope, ProtocolWidgetFactory(), onDiff, onEvent)
-}
-
-private class ProtocolWidgetFactory : SunspotWidgetFactory<Nothing> {
+class ProtocolComposeWidgetFactory : SunspotWidgetFactory<Nothing> {
   override fun SunspotBox(): SunspotBox<Nothing> = ProtocolSunspotBox()
   override fun SunspotText(): SunspotText<Nothing> = ProtocolSunspotText()
   override fun SunspotButton(): SunspotButton<Nothing> = ProtocolSunspotButton()
 }
 */
 internal fun generateComposeProtocolWidgetFactory(schema: Schema): FileSpec {
-  val factory = ClassName(schema.composePackage, "Protocol${schema.name}WidgetFactory")
-  return FileSpec.builder(schema.composePackage, "composition")
-    .addFunction(
-      FunSpec.builder("Protocol${schema.name}Composition")
-        .addParameter("scope", coroutineScope)
-        .addParameter(
-          ParameterSpec.builder("onDiff", diffSink)
-            .defaultValue("%T {}", diffSink)
-            .build()
-        )
-        .addParameter(
-          ParameterSpec.builder("onEvent", eventSink)
-            .defaultValue("%T {}", eventSink)
-            .build()
-        )
-        .returns(treehouseComposition)
-        .addStatement("return %T(scope, %T(), onDiff, onEvent)", treehouseComposition, factory)
-        .build()
-    )
+  return FileSpec.builder(schema.composePackage, "ProtocolComposeWidgetFactory")
     .addType(
-      TypeSpec.classBuilder(factory)
-        .addModifiers(PRIVATE)
+      TypeSpec.classBuilder("ProtocolComposeWidgetFactory")
         .addSuperinterface(schema.getWidgetFactoryType().parameterizedBy(NOTHING))
         .apply {
           for (widget in schema.widgets) {

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/main.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/main.kt
@@ -77,6 +77,7 @@ private class TreehouseGenerator : CliktCommand() {
     val schema = parseSchema(schemaType)
     @Exhaustive when (type) {
       Compose -> {
+        generateCompositionFactory(schema).writeTo(out)
         for (widget in schema.widgets) {
           generateComposable(schema, widget).writeTo(out)
         }

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetProtocolGeneration.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetProtocolGeneration.kt
@@ -33,7 +33,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 
 /*
-public class ProtocolWidgetFactory<T : Any>(
+public class ProtocolDisplayWidgetFactory<T : Any>(
   private val delegate: SunspotWidgetFactory<T>
 ) : ProtocolWidget.Factory<T> {
   public override fun create(kind: Int): ProtocolWidget<T> = when (kind) {
@@ -46,9 +46,9 @@ public class ProtocolWidgetFactory<T : Any>(
 */
 internal fun generateDisplayProtocolWidgetFactory(schema: Schema): FileSpec {
   val widgetFactory = schema.getWidgetFactoryType().parameterizedBy(typeVariableT)
-  return FileSpec.builder(schema.displayPackage, "ProtocolWidgetFactory")
+  return FileSpec.builder(schema.displayPackage, "ProtocolDisplayWidgetFactory")
     .addType(
-      TypeSpec.classBuilder("ProtocolWidgetFactory")
+      TypeSpec.classBuilder("ProtocolDisplayWidgetFactory")
         .addTypeVariable(typeVariableT)
         .addSuperinterface(protocolWidgetFactory.parameterizedBy(typeVariableT))
         .primaryConstructor(


### PR DESCRIPTION
This allows the factory to be properly typed, and the protocol factory for compose to simply be one such type which fullfils that contract. Currently, however, it is the ONLY supported implementation that works, despite a normal widget factory also able to be used. Its support will come in a follow-up.

Refs #14