### PR TITLE
Remove ability to omit the content lambda

### DIFF
--- a/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
+++ b/treehouse/treehouse-compose/src/commonMain/kotlin/app/cash/treehouse/compose/applier.kt
@@ -36,7 +36,7 @@ import app.cash.treehouse.protocol.PropertyDiff
 public inline fun <F, W> TreehouseComposeNode(
   crossinline factory: (F) -> W,
   update: @DisallowComposableCalls Updater<W>.() -> Unit,
-  content: @Composable () -> Unit = {},
+  content: @Composable () -> Unit,
 ) {
   // NOTE: You MUST keep the implementation of this function (or more specifically, the interaction
   //  with currentComposer) in sync with ComposeNode.


### PR DESCRIPTION
Default composable argument values are broken in JS currently. This function is always called from generated code and we always unconditionally specify a lambda.