### PR TITLE
Avoid runtime polymorphism for JSON properties

### DIFF
--- a/samples/counter/android/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android/src/main/java/example/android/MainActivity.kt
@@ -30,7 +30,6 @@ import example.shared.Counter
 import example.sunspot.compose.ProtocolComposeWidgetFactory
 import example.sunspot.compose.SunspotComposition
 import example.sunspot.widget.ProtocolDisplayWidgetFactory
-import example.sunspot.widget.ProtocolSunspotBox
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 
@@ -53,9 +52,10 @@ class MainActivity : Activity() {
     }
     setContentView(root)
 
+    val factory = ProtocolDisplayWidgetFactory(AndroidSunspotWidgetFactory(this))
     val display = ProtocolDisplay(
-      root = ProtocolSunspotBox(AndroidSunspotBox(root)),
-      factory = ProtocolDisplayWidgetFactory(AndroidSunspotWidgetFactory(this)),
+      root = factory.wrap(AndroidSunspotBox(root)),
+      factory = factory,
       eventSink = composition,
     )
 

--- a/samples/counter/browser/src/main/kotlin/example/browser/main.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/main.kt
@@ -23,7 +23,6 @@ import example.shared.Counter
 import example.sunspot.compose.ProtocolComposeWidgetFactory
 import example.sunspot.compose.SunspotComposition
 import example.sunspot.widget.ProtocolDisplayWidgetFactory
-import example.sunspot.widget.ProtocolSunspotBox
 import kotlinx.browser.document
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.plus
@@ -38,9 +37,10 @@ fun main() {
   )
 
   val content = document.getElementById("content")!! as HTMLElement
+  val factory = ProtocolDisplayWidgetFactory(HtmlSunspotNodeFactory(document))
   val display = ProtocolDisplay(
-    root = ProtocolSunspotBox(HtmlSunspotBox(content)),
-    factory = ProtocolDisplayWidgetFactory(HtmlSunspotNodeFactory(document)),
+    root = factory.wrap(HtmlSunspotBox(content)),
+    factory = factory,
     eventSink = composition,
   )
 

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/CounterViewControllerDelegate.kt
@@ -23,7 +23,6 @@ import example.shared.Counter
 import example.sunspot.compose.ProtocolComposeWidgetFactory
 import example.sunspot.compose.SunspotComposition
 import example.sunspot.widget.ProtocolDisplayWidgetFactory
-import example.sunspot.widget.ProtocolSunspotBox
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.plus
@@ -44,9 +43,10 @@ class CounterViewControllerDelegate(
       onEvent = { NSLog("TreehouseEvent: $it") }
     )
 
+    val factory = ProtocolDisplayWidgetFactory(IosSunspotNodeFactory)
     val display = ProtocolDisplay(
-      root = ProtocolSunspotBox(IosSunspotBox(root)),
-      factory = ProtocolDisplayWidgetFactory(IosSunspotNodeFactory),
+      root = factory.wrap(IosSunspotBox(root)),
+      factory = factory,
       eventSink = composition
     )
 

--- a/samples/counter/shared/src/commonTest/kotlin/example/shared/CounterTest.kt
+++ b/samples/counter/shared/src/commonTest/kotlin/example/shared/CounterTest.kt
@@ -25,7 +25,6 @@ import example.sunspot.compose.SunspotComposition
 import example.sunspot.test.SchemaSunspotBox
 import example.sunspot.test.SchemaSunspotWidgetFactory
 import example.sunspot.widget.ProtocolDisplayWidgetFactory
-import example.sunspot.widget.ProtocolSunspotBox
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -44,9 +43,10 @@ class CounterTest {
       onEvent = { println(it) },
     )
 
+    val factory = ProtocolDisplayWidgetFactory(SchemaSunspotWidgetFactory)
     val display = ProtocolDisplay(
-      root = ProtocolSunspotBox(root),
-      factory = ProtocolDisplayWidgetFactory(SchemaSunspotWidgetFactory),
+      root = factory.wrap(root),
+      factory = factory,
       eventSink = composition,
     )
 

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/TodoActivity.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/TodoActivity.kt
@@ -52,9 +52,10 @@ class TodoActivity : ComponentActivity() {
     }
     setContentView(composeView)
 
+    val factory = ProtocolDisplayWidgetFactory(ComposeUiWidgetFactory)
     val display = ProtocolDisplay(
-      root = ProtocolColumn(root),
-      factory = ProtocolDisplayWidgetFactory(ComposeUiWidgetFactory),
+      root = factory.wrap(root),
+      factory = factory,
       eventSink = composition,
     )
 

--- a/samples/todo-list/android-views/src/main/java/example/android/views/TodoActivity.kt
+++ b/samples/todo-list/android-views/src/main/java/example/android/views/TodoActivity.kt
@@ -51,9 +51,10 @@ class TodoActivity : AppCompatActivity() {
     }
     setContentView(root)
 
+    val factory = ProtocolDisplayWidgetFactory(ViewWidgetFactory(this))
     val display = ProtocolDisplay(
-      root = ProtocolColumn(ViewColumn(root)),
-      factory = ProtocolDisplayWidgetFactory(ViewWidgetFactory(this)),
+      root = factory.wrap(ViewColumn(root)),
+      factory = factory,
       eventSink = composition,
     )
 

--- a/treehouse/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/ProtocolTest.kt
+++ b/treehouse/treehouse-compose/src/commonTest/kotlin/app/cash/treehouse/compose/ProtocolTest.kt
@@ -32,6 +32,7 @@ import example.treehouse.compose.ProtocolComposeWidgetFactory
 import example.treehouse.compose.Text
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.yield
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -65,8 +66,8 @@ class ProtocolTest {
           ChildrenDiff.Insert(3L, 1, 4L, 2 /* text */, 0),
         ),
         propertyDiffs = listOf(
-          PropertyDiff(2L, 1 /* text */, "hey"),
-          PropertyDiff(4L, 1 /* text */, "hello"),
+          PropertyDiff(2L, 1 /* text */, JsonPrimitive("hey")),
+          PropertyDiff(4L, 1 /* text */, JsonPrimitive("hello")),
         ),
       ),
       diffs.removeFirst()
@@ -105,37 +106,37 @@ class ProtocolTest {
           ChildrenDiff.Insert(RootId, RootChildrenTag, 1L, 3 /* button */, 0),
         ),
         propertyDiffs = listOf(
-          PropertyDiff(1L, 1 /* text */, "state: 0"),
-          PropertyDiff(1L, 2 /* onClick */, true),
+          PropertyDiff(1L, 1 /* text */, JsonPrimitive("state: 0")),
+          PropertyDiff(1L, 2 /* onClick */, JsonPrimitive(true)),
         ),
       ),
       diffs.removeFirst()
     )
 
     // Invoke the onClick lambda to move the state from 0 to 1.
-    composition.sendEvent(Event(1L, 2, null))
+    composition.sendEvent(Event(1L, 2))
     yield() // Allow state change to be handled.
 
     clock.awaitFrame()
     assertEquals(
       Diff(
         propertyDiffs = listOf(
-          PropertyDiff(1L, 1 /* text */, "state: 1"),
+          PropertyDiff(1L, 1 /* text */, JsonPrimitive("state: 1")),
         ),
       ),
       diffs.removeFirst()
     )
 
     // Invoke the onClick lambda to move the state from 1 to 2.
-    composition.sendEvent(Event(1L, 2, null))
+    composition.sendEvent(Event(1L, 2))
     yield() // Allow state change to be handled.
 
     clock.awaitFrame()
     assertEquals(
       Diff(
         propertyDiffs = listOf(
-          PropertyDiff(1L, 1 /* text */, "state: 2"),
-          PropertyDiff(1L, 2 /* text */, false),
+          PropertyDiff(1L, 1 /* text */, JsonPrimitive("state: 2")),
+          PropertyDiff(1L, 2 /* text */, JsonPrimitive(false)),
         ),
       ),
       diffs.removeFirst()
@@ -149,7 +150,7 @@ class ProtocolTest {
     assertEquals(
       Diff(
         propertyDiffs = listOf(
-          PropertyDiff(1L, 1 /* text */, "state: 3"),
+          PropertyDiff(1L, 1 /* text */, JsonPrimitive("state: 3")),
         ),
       ),
       diffs.removeFirst()

--- a/treehouse/treehouse-protocol/build.gradle
+++ b/treehouse/treehouse-protocol/build.gradle
@@ -10,12 +10,12 @@ kotlin {
     commonMain {
       dependencies {
         api deps.kotlinx.serialization.core
+        api deps.kotlinx.serialization.json
       }
     }
     commonTest {
       dependencies {
         implementation deps.kotlin.test
-        implementation deps.kotlinx.serialization.json
       }
     }
   }

--- a/treehouse/treehouse-protocol/src/commonMain/kotlin/app/cash/treehouse/protocol/protocol.kt
+++ b/treehouse/treehouse-protocol/src/commonMain/kotlin/app/cash/treehouse/protocol/protocol.kt
@@ -15,9 +15,10 @@
  */
 package app.cash.treehouse.protocol
 
-import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 
 public fun interface EventSink {
   public fun sendEvent(event: Event)
@@ -33,7 +34,7 @@ public data class Event(
   val id: Long,
   /** Identifies which event occurred on the widget with [id]. */
   val tag: Int,
-  @Polymorphic val value: Any? = null,
+  val value: JsonElement = JsonNull,
 )
 
 @Serializable
@@ -48,7 +49,7 @@ public data class PropertyDiff(
   val id: Long,
   /** Identifies which property changed on the widget with [id]. */
   val tag: Int,
-  @Polymorphic val value: Any? = null,
+  val value: JsonElement = JsonNull,
 )
 
 @Serializable

--- a/treehouse/treehouse-protocol/src/commonTest/kotlin/app/cash/treehouse/protocol/ProtocolTest.kt
+++ b/treehouse/treehouse-protocol/src/commonTest/kotlin/app/cash/treehouse/protocol/ProtocolTest.kt
@@ -16,10 +16,9 @@
 package app.cash.treehouse.protocol
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -27,21 +26,16 @@ import kotlin.test.assertFailsWith
 class ProtocolTest {
   private val format = Json {
     useArrayPolymorphism = true
-    serializersModule = SerializersModule {
-      polymorphic(Any::class) {
-        subclass(String::class, String.serializer())
-      }
-    }
   }
 
   @Test fun eventNonNullValue() {
-    val model = Event(1, 2, "Hello")
-    val json = """{"id":1,"tag":2,"value":["kotlin.String","Hello"]}"""
+    val model = Event(1, 2, JsonPrimitive("Hello"))
+    val json = """{"id":1,"tag":2,"value":"Hello"}"""
     assertJsonRoundtrip(Event.serializer(), model, json)
   }
 
   @Test fun eventNullValue() {
-    val model = Event(1, 2, null)
+    val model = Event(1, 2)
     val json = """{"id":1,"tag":2}"""
     assertJsonRoundtrip(Event.serializer(), model, json)
   }
@@ -55,8 +49,8 @@ class ProtocolTest {
         ChildrenDiff.Remove(1, 2, 3, 4, listOf(5, 6, 7, 8)),
       ),
       propertyDiffs = listOf(
-        PropertyDiff(1, 2, "Hello"),
-        PropertyDiff(1, 2, null),
+        PropertyDiff(1, 2, JsonPrimitive("Hello")),
+        PropertyDiff(1, 2, JsonNull),
       ),
     )
     val json = "" +
@@ -66,7 +60,7 @@ class ProtocolTest {
       """["move",{"id":1,"tag":2,"fromIndex":3,"toIndex":4,"count":5}],""" +
       """["remove",{"id":1,"tag":2,"index":3,"count":4,"removedIds":[5,6,7,8]}]""" +
       """],"propertyDiffs":[""" +
-      """{"id":1,"tag":2,"value":["kotlin.String","Hello"]},""" +
+      """{"id":1,"tag":2,"value":"Hello"},""" +
       """{"id":1,"tag":2}""" +
       """]}"""
     assertJsonRoundtrip(Diff.serializer(), model, json)

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/types.kt
@@ -56,3 +56,13 @@ internal val iae = ClassName("kotlin", "IllegalArgumentException")
 
 internal val typeVariableT = TypeVariableName("T", listOf(ANY))
 internal val childrenOfT = widgetChildren.parameterizedBy(typeVariableT)
+
+private val jsonCompanion = ClassName("kotlinx.serialization.json", "Json", "Default")
+internal val jsonPrimitive = MemberName("kotlinx.serialization.json", "JsonPrimitive")
+internal val jsonPrimitiveToBoolean = MemberName("kotlinx.serialization.json", "boolean")
+internal val jsonElementToJsonPrimitive = MemberName("kotlinx.serialization.json", "jsonPrimitive")
+internal val encodeToJsonElement = MemberName(jsonCompanion, "encodeToJsonElement")
+internal val decodeFromJsonElement = MemberName(jsonCompanion, "decodeFromJsonElement")
+internal val serializer = MemberName("kotlinx.serialization", "serializer")
+internal val serializersModule = ClassName("kotlinx.serialization.modules", "SerializersModule")
+internal val kSerializer = ClassName("kotlinx.serialization", "KSerializer")

--- a/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetProtocolGeneration.kt
+++ b/treehouse/treehouse-schema-generator/src/main/kotlin/app/cash/treehouse/schema/generator/widgetProtocolGeneration.kt
@@ -21,27 +21,34 @@ import app.cash.treehouse.schema.parser.Event
 import app.cash.treehouse.schema.parser.Property
 import app.cash.treehouse.schema.parser.Schema
 import app.cash.treehouse.schema.parser.Widget
-import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 
 /*
 public class ProtocolDisplayWidgetFactory<T : Any>(
-  private val delegate: SunspotWidgetFactory<T>
+  private val delegate: SunspotWidgetFactory<T>,
+  private val serializersModule: SerializersModule = SerializersModule { }
 ) : ProtocolWidget.Factory<T> {
   public override fun create(kind: Int): ProtocolWidget<T> = when (kind) {
-    1 -> ProtocolSunspotBox(delegate.SunspotBox())
-    2 -> ProtocolSunspotText(delegate.SunspotText())
-    3 -> ProtocolSunspotButton(delegate.SunspotButton())
+    1 -> wrap(delegate.SunspotBox())
+    2 -> wrap(delegate.SunspotText())
+    3 -> wrap(delegate.SunspotButton())
     else -> throw IllegalArgumentException("Unknown kind $kind")
   }
+
+  public fun wrap(value: SunspotBox): ProtocolSunspotBox {
+    return ProtocolSunspotBox(delegate.SunspotBox(), serializersModule)
+  }
+  etc.
 }
 */
 internal fun generateDisplayProtocolWidgetFactory(schema: Schema): FileSpec {
@@ -54,11 +61,23 @@ internal fun generateDisplayProtocolWidgetFactory(schema: Schema): FileSpec {
         .primaryConstructor(
           FunSpec.constructorBuilder()
             .addParameter("delegate", widgetFactory)
+            .addParameter(
+              ParameterSpec.builder("serializersModule", serializersModule)
+                // TODO Use EmptySerializersModule once stable
+                //  https://github.com/Kotlin/kotlinx.serialization/issues/1765
+                .defaultValue("%T { }", serializersModule)
+                .build()
+            )
             .build()
         )
         .addProperty(
           PropertySpec.builder("delegate", widgetFactory, PRIVATE)
             .initializer("delegate")
+            .build()
+        )
+        .addProperty(
+          PropertySpec.builder("serializersModule", serializersModule, PRIVATE)
+            .initializer("serializersModule")
             .build()
         )
         .addFunction(
@@ -69,14 +88,25 @@ internal fun generateDisplayProtocolWidgetFactory(schema: Schema): FileSpec {
             .beginControlFlow("return when (kind)")
             .apply {
               for (widget in schema.widgets.sortedBy { it.tag }) {
-                val protocolType = schema.displayProtocolWidgetType(widget)
-                addStatement("%L -> %T(delegate.%N())", widget.tag, protocolType, widget.flatName)
+                addStatement("%L -> wrap(delegate.%N())", widget.tag, widget.flatName)
               }
             }
             .addStatement("else -> throw %T(\"Unknown kind \$kind\")", iae)
             .endControlFlow()
             .build()
         )
+        .apply {
+          for (widget in schema.widgets.sortedBy { it.flatName }) {
+            val protocolWidgetType = schema.displayProtocolWidgetType(widget)
+            addFunction(
+              FunSpec.builder("wrap")
+                .addParameter("value", schema.widgetType(widget).parameterizedBy(typeVariableT))
+                .returns(protocolWidgetType.parameterizedBy(typeVariableT))
+                .addStatement("return %T(value, serializersModule)", protocolWidgetType)
+                .build()
+            )
+          }
+        }
         .build()
     )
     .build()
@@ -84,18 +114,21 @@ internal fun generateDisplayProtocolWidgetFactory(schema: Schema): FileSpec {
 
 /*
 public class ProtocolSunspotButton<T : Any>(
-  private val delegate: SunspotButton<T>
+  private val delegate: SunspotButton<T>,
+  serializersModule: SerializersModule,
 ) : ProtocolWidget<T> {
-  public override val value: T
-    get() = delegate.value
+  public override val value: T get() = delegate.value
+
+  private val serializer_0: KSerializer<String?> = serializersModule.serializer()
+  private val serializer_1: KSerializer<Boolean> = serializersModule.serializer()
 
   public override fun apply(diff: PropertyDiff, eventSink: EventSink): Unit {
     when (val tag = diff.tag) {
-      1 -> delegate.text(diff.value as String?)
-      2 -> delegate.enabled(diff.value as Boolean)
+      1 -> delegate.text(Json.decodeFromJsonElement(serializer_0, diff.value))
+      2 -> delegate.enabled(Json.decodeFromJsonElement(serializer_1, diff.value))
       3 -> {
-        val onClick: (() -> Unit)? = if (diff.value as Boolean) {
-          { eventSink.sendEvent(Event(diff.id, 3, null)) }
+        val onClick: (() -> Unit)? = if (diff.value.jsonPrimitive.boolean) {
+          { eventSink.sendEvent(Event(diff.id, 3)) }
         } else {
           null
         }
@@ -118,6 +151,7 @@ internal fun generateDisplayProtocolWidget(schema: Schema, widget: Widget): File
         .primaryConstructor(
           FunSpec.constructorBuilder()
             .addParameter("delegate", widgetType)
+            .addParameter("serializersModule", serializersModule)
             .build()
         )
         .addProperty(
@@ -136,6 +170,8 @@ internal fun generateDisplayProtocolWidget(schema: Schema, widget: Widget): File
         )
         .apply {
           val (childrens, properties) = widget.traits.partition { it is Children }
+          var nextSerializerId = 0
+          val serializerIds = mutableMapOf<TypeName, Int>()
 
           if (properties.isNotEmpty()) {
             addFunction(
@@ -148,21 +184,31 @@ internal fun generateDisplayProtocolWidget(schema: Schema, widget: Widget): File
                   for (trait in widget.traits) {
                     @Exhaustive when (trait) {
                       is Property -> {
+                        val propertyType = trait.type.asTypeName()
+                        val serializerId = serializerIds.computeIfAbsent(propertyType) {
+                          nextSerializerId++
+                        }
+
                         addStatement(
-                          "%L -> delegate.%N(diff.value as %T)", trait.tag, trait.name,
-                          trait.type.asTypeName()
+                          "%L -> delegate.%N(%M(serializer_%L, diff.value))", trait.tag, trait.name,
+                          decodeFromJsonElement, serializerId
                         )
                       }
                       is Event -> {
                         beginControlFlow("%L ->", trait.tag)
                         beginControlFlow(
-                          "val %N: %T = if (diff.value as %T)", trait.name, trait.lambdaType,
-                          BOOLEAN
+                          "val %N: %T = if (diff.value.%M.%M)", trait.name, trait.lambdaType,
+                          jsonElementToJsonPrimitive, jsonPrimitiveToBoolean
                         )
-                        addStatement(
-                          "{ eventSink.sendEvent(%T(diff.id, %L, %L)) }", eventType, trait.tag,
-                          if (trait.parameterType != null) "it" else "null"
-                        )
+                        val parameterType = trait.parameterType?.asTypeName()
+                        if (parameterType != null) {
+                          val serializerId = serializerIds.computeIfAbsent(parameterType) {
+                            nextSerializerId++
+                          }
+                          addStatement("{ eventSink.sendEvent(%T(diff.id, %L, %M(serializer_%L, it))) }", eventType, trait.tag, encodeToJsonElement, serializerId)
+                        } else {
+                          addStatement("{ eventSink.sendEvent(%T(diff.id, %L)) }", eventType, trait.tag,)
+                        }
                         nextControlFlow("else")
                         addStatement("null")
                         endControlFlow()
@@ -171,6 +217,15 @@ internal fun generateDisplayProtocolWidget(schema: Schema, widget: Widget): File
                       }
                       is Children -> throw AssertionError()
                     }
+                  }
+
+                  for ((typeName, id) in serializerIds) {
+                    addProperty(
+                      PropertySpec.builder("serializer_$id", kSerializer.parameterizedBy(typeName))
+                        .addModifiers(PRIVATE)
+                        .initializer("serializersModule.%M()", serializer)
+                        .build()
+                    )
                   }
                 }
                 .addStatement("else -> throw %T(\"Unknown tag \$tag\")", iae)

--- a/treehouse/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateComposeProtocolWidgetTest.kt
+++ b/treehouse/treehouse-schema-generator/src/test/kotlin/app/cash/treehouse/schema/generator/GenerateComposeProtocolWidgetTest.kt
@@ -42,7 +42,7 @@ class GenerateComposeProtocolWidgetTest {
     assertThat(fileSpec.toString()).contains(
       """
       |  public override fun id(id: String): Unit {
-      |    appendDiff(PropertyDiff(this.id, 2, id))
+      |    appendDiff(PropertyDiff(this.id, 2, encodeToJsonElement(serializer_0, id)))
       |  }
       |""".trimMargin()
     )


### PR DESCRIPTION
There's less work to do if we look up the serializers at compile time. This also allows passing a custom SerializersModule for more control over serialization.

Closes #179.