### PR TITLE
Use a Gradle plugin to setup the JetBrains Compose compiler plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,9 @@
 *.iml
 
 # Gradle
-/.gradle
+.gradle
 build
 /reports
-
-# Gradle (nested build)
-/redwood/.gradle
 
 # Android
 local.properties

--- a/redwood/build.gradle
+++ b/redwood/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
-
 buildscript {
   dependencies {
     classpath libs.kotlin.gradlePlugin
@@ -10,6 +8,7 @@ buildscript {
     classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.30'
     classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.8.2'
+    classpath 'app.cash.redwood.tools:compose-gradle-plugin'
   }
   repositories {
     mavenCentral()
@@ -78,24 +77,6 @@ allprojects {
         '-Xopt-in=kotlin.RequiresOptIn',
       ]
     }
-  }
-
-  // This is required for JetBrains' Compose fork to build JS correctly.
-  tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile).configureEach { task ->
-    task.kotlinOptions {
-      freeCompilerArgs += [
-        "-P", "plugin:androidx.compose.compiler.plugins.kotlin:generateDecoys=true",
-      ]
-    }
-  }
-
-  // Kotlin/Native compiler reports its version like 1.4.21-344 whereas Kotlin/JVM and Kotlin/JS say
-  // only 1.4.21. The Compose compiler checks this version and fails for the Kotlin/Native variant.
-  tasks.withType(org.jetbrains.kotlin.gradle.tasks.AbstractKotlinNativeCompile).configureEach {
-    it.compilerPluginOptions.addPluginArgument(
-      'androidx.compose.compiler.plugins.kotlin',
-      new SubpluginOption('suppressKotlinVersionCompatibilityCheck', 'true')
-    )
   }
 
   plugins.withType(com.android.build.gradle.BasePlugin).configureEach { plugin ->

--- a/redwood/compose-gradle-plugin/build.gradle
+++ b/redwood/compose-gradle-plugin/build.gradle
@@ -1,0 +1,56 @@
+buildscript {
+  dependencies {
+    classpath libs.kotlin.gradlePlugin
+  }
+  repositories {
+    mavenCentral()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'java-gradle-plugin'
+
+dependencies {
+  compileOnly gradleApi()
+  compileOnly libs.kotlin.gradlePlugin
+}
+
+repositories {
+  mavenCentral()
+}
+
+gradlePlugin {
+  plugins {
+    jetbrainsCompose {
+      id = "app.cash.redwood.tools.compose"
+      displayName = "JetBrains Compose"
+      description = "Gradle plugin to apply JetBrains Compose compiler"
+      implementationClass = "app.cash.redwood.tools.JetBrainsComposePlugin"
+    }
+  }
+}
+
+def versionDirectory = "$buildDir/generated/version/"
+
+sourceSets {
+  main.java.srcDir versionDirectory
+}
+
+task pluginVersion {
+  def outputDir = file(versionDirectory)
+
+  inputs.property 'jbComposeVersion', libs.versions.jbCompose.get()
+  outputs.dir outputDir
+
+  doLast {
+    def versionFile = file("$outputDir/app/cash/redwood/gradle/version.kt")
+    versionFile.parentFile.mkdirs()
+    versionFile.text = """// Generated file. Do not edit!
+package app.cash.redwood.tools
+
+internal const val jbComposeVersion = "${libs.versions.jbCompose.get()}"
+"""
+  }
+}
+
+tasks.getByName('compileKotlin').dependsOn('pluginVersion')

--- a/redwood/compose-gradle-plugin/settings.gradle
+++ b/redwood/compose-gradle-plugin/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood/compose-gradle-plugin/src/main/kotlin/app/cash/redwood/tools/JetBrainsComposePlugin.kt
+++ b/redwood/compose-gradle-plugin/src/main/kotlin/app/cash/redwood/tools/JetBrainsComposePlugin.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.tools
+
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.androidJvm
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.common
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.js
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.jvm
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.native
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+
+class JetBrainsComposePlugin : KotlinCompilerPluginSupportPlugin {
+  override fun isApplicable(kotlinCompilation: KotlinCompilation<*>) = true
+
+  override fun getCompilerPluginId() = "app.cash.redwood.tools.compose"
+
+  override fun getPluginArtifact(): SubpluginArtifact {
+    return SubpluginArtifact("org.jetbrains.compose.compiler", "compiler", jbComposeVersion)
+  }
+
+  override fun getPluginArtifactForNative(): SubpluginArtifact {
+    return SubpluginArtifact("org.jetbrains.compose.compiler", "compiler-hosted", jbComposeVersion)
+  }
+
+  override fun applyToCompilation(
+    kotlinCompilation: KotlinCompilation<*>
+  ): Provider<List<SubpluginOption>> {
+    when (kotlinCompilation.platformType) {
+      androidJvm, jvm -> {
+        if ((kotlinCompilation.kotlinOptions as KotlinJvmOptions).useOldBackend) {
+          throw IllegalStateException("Compose only works with the default IR-based backend")
+        }
+      }
+      js -> {
+        // This enables a workaround for Compose lambda generation to function correctly in JS.
+        kotlinCompilation.kotlinOptions.freeCompilerArgs +=
+          listOf("-P", "plugin:androidx.compose.compiler.plugins.kotlin:generateDecoys=true")
+      }
+      native -> {
+        // Kotlin/Native compiler reports its version like 1.4.21-344 whereas Kotlin/JVM and
+        // Kotlin/JS say only 1.4.21. Compose checks this version and fails for Kotlin/Native.
+        kotlinCompilation.kotlinOptions.freeCompilerArgs +=
+          listOf("-P", "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true")
+      }
+      common -> {
+        // Nothing to do!
+      }
+    }
+
+    return kotlinCompilation.target.project.provider { emptyList() }
+  }
+}

--- a/redwood/compose/runtime/build.gradle
+++ b/redwood/compose/runtime/build.gradle
@@ -1,9 +1,8 @@
-import org.jetbrains.kotlin.gradle.plugin.KotlinPluginKt
-
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'app.cash.redwood.tools.compose'
 
 archivesBaseName = 'redwood-jetpack-compose'
 
@@ -130,9 +129,4 @@ android {
   testOptions {
     unitTests.returnDefaultValues = true
   }
-}
-
-dependencies {
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compiler)
-  add(KotlinPluginKt.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compilerHosted)
 }

--- a/redwood/redwood-compose/build.gradle
+++ b/redwood/redwood-compose/build.gradle
@@ -1,9 +1,8 @@
-import org.jetbrains.kotlin.gradle.plugin.KotlinPluginKt
-
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'app.cash.redwood.tools.compose'
 
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"
@@ -39,11 +38,6 @@ android {
   testOptions {
     unitTests.returnDefaultValues = true
   }
-}
-
-dependencies {
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compiler)
-  add(KotlinPluginKt.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compilerHosted)
 }
 
 spotless {

--- a/redwood/redwood-protocol-compose/build.gradle
+++ b/redwood/redwood-protocol-compose/build.gradle
@@ -1,9 +1,8 @@
-import org.jetbrains.kotlin.gradle.plugin.KotlinPluginKt
-
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'app.cash.redwood.tools.compose'
 
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"
@@ -21,9 +20,4 @@ kotlin {
       }
     }
   }
-}
-
-dependencies {
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compiler)
-  add(KotlinPluginKt.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compilerHosted)
 }

--- a/redwood/redwood-test-schema/compose/build.gradle
+++ b/redwood/redwood-test-schema/compose/build.gradle
@@ -1,6 +1,5 @@
-import org.jetbrains.kotlin.gradle.plugin.KotlinPluginKt
-
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'app.cash.redwood.tools.compose'
 
 def generatedDir = 'build/generated/redwood'
 
@@ -25,9 +24,6 @@ configurations {
 }
 
 dependencies {
-  add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compiler)
-  add(KotlinPluginKt.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, libs.jetbrains.compose.compilerHosted)
-
   generator projects.redwoodSchemaGenerator
   generator projects.redwoodTestSchema
 }

--- a/redwood/settings.gradle
+++ b/redwood/settings.gradle
@@ -26,3 +26,9 @@ dependencyResolutionManagement {
     }
   }
 }
+
+includeBuild('compose-gradle-plugin') {
+  dependencySubstitution {
+    substitute module('app.cash.redwood.tools:compose-gradle-plugin') using project(':')
+  }
+}


### PR DESCRIPTION
But only for our own modules which cannot use the Redwood Gradle plugin.

Obligatory: Yo dawg. I heard you like `includeBuild`. So I put an `includeBuild` inside your `includeBuild`!

This makes HMPP work. There are no HMPP changes in this PR, however. They will follow as a #214 rebase + some small tweaks.