### PR TITLE
Add Compose and widget protocol mismatch handlers

### DIFF
--- a/redwood/redwood-protocol-compose/build.gradle
+++ b/redwood/redwood-protocol-compose/build.gradle
@@ -18,6 +18,7 @@ kotlin {
     commonTest {
       dependencies {
         implementation libs.kotlin.test
+        implementation projects.redwoodTestSchema.compose.protocol
       }
     }
   }

--- a/redwood/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
+++ b/redwood/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
@@ -67,6 +67,11 @@ private sealed class DiffProducingChildrenWidget(
       id = RootId
     }
   }
+
+  override fun sendEvent(event: Event) {
+    // These types should never make it into the node map and thus cannot be targeted by events.
+    throw AssertionError()
+  }
 }
 
 /**
@@ -91,9 +96,7 @@ public abstract class AbstractDiffProducingWidget(
     _diffAppender.append(diff)
   }
 
-  public open fun sendEvent(event: Event) {
-    throw IllegalStateException("Node ID $id of type $type does not handle events")
-  }
+  public abstract fun sendEvent(event: Event)
 }
 
 /**

--- a/redwood/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolMismatchHandler.kt
+++ b/redwood/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolMismatchHandler.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+import kotlin.jvm.JvmField
+
+/**
+ * Handler invoked when the protocol sent from the widget display to Compose encounters unknown
+ * entities. This usually occurs when either the Compose-side or the widget-side was generated from
+ * a newer schema than the other, or if their schemas were changed in an incompatible way.
+ */
+public interface ProtocolMismatchHandler {
+  /** Handle a request to process an unknown event [tag] for the specified widget [kind]. */
+  public fun onUnknownEvent(kind: Int, tag: Int)
+
+  public companion object {
+    /** A [ProtocolMismatchHandler] which throws [IllegalArgumentException] for all callbacks. */
+    @JvmField
+    public val Throwing: ProtocolMismatchHandler = object : ProtocolMismatchHandler {
+      override fun onUnknownEvent(kind: Int, tag: Int) {
+        throw IllegalArgumentException("Unknown event tag $tag for widget kind $kind")
+      }
+    }
+  }
+}

--- a/redwood/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetFactoryTest.kt
+++ b/redwood/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetFactoryTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+import app.cash.redwood.protocol.Event
+import example.redwood.compose.DiffProducingExampleSchemaWidgetFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DiffProducingWidgetFactoryTest {
+  @Test fun unknownEventThrowsDefault() {
+    val factory = DiffProducingExampleSchemaWidgetFactory()
+    val button = factory.Button() as AbstractDiffProducingWidget
+
+    val event = Event(1L, 3456543)
+    val t = assertFailsWith<IllegalArgumentException> {
+      button.sendEvent(event)
+    }
+
+    assertEquals("Unknown event tag 3456543 for widget kind 3", t.message)
+  }
+
+  @Test fun unknownEventCallsHandler() {
+    val handler = RecordingProtocolMismatchHandler()
+    val factory = DiffProducingExampleSchemaWidgetFactory(mismatchHandler = handler)
+    val button = factory.Button() as AbstractDiffProducingWidget
+
+    button.sendEvent(Event(1L, 3456543))
+
+    assertEquals(listOf("Unknown event 3456543 for 3"), handler.events)
+  }
+}

--- a/redwood/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/RecordingProtocolMismatchHandler.kt
+++ b/redwood/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/RecordingProtocolMismatchHandler.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+class RecordingProtocolMismatchHandler : ProtocolMismatchHandler {
+  val events = mutableListOf<String>()
+
+  override fun onUnknownEvent(kind: Int, tag: Int) {
+    events += "Unknown event $tag for $kind"
+  }
+}

--- a/redwood/redwood-protocol-widget/build.gradle
+++ b/redwood/redwood-protocol-widget/build.gradle
@@ -18,5 +18,11 @@ kotlin {
         implementation libs.kotlin.test
       }
     }
+    jvmTest { // TODO all targets!
+      dependencies {
+        implementation projects.redwoodTestSchema.widget.protocol
+        implementation projects.redwoodTestSchema.test
+      }
+    }
   }
 }

--- a/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidget.kt
+++ b/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidget.kt
@@ -23,15 +23,25 @@ import app.cash.redwood.widget.Widget
  * A [Widget] which consumes protocol diffs and applies them to a platform-specific representation.
  */
 public interface DiffConsumingWidget<T : Any> : Widget<T> {
-  public fun apply(diff: PropertyDiff, eventSink: EventSink) {
-    throw IllegalArgumentException("Widget has no properties")
-  }
+  public fun apply(diff: PropertyDiff, eventSink: EventSink)
 
-  public fun children(tag: Int): Widget.Children<T> {
-    throw IllegalArgumentException("Widget does not support children")
-  }
+  /**
+   * Return one of this widget's children groups by its [tag].
+   *
+   * Invalid [tag] values can either produce an exception or result in `null` being returned.
+   * If `null` is returned, the caller should make every effort to ignore these children and
+   * continue executing.
+   */
+  public fun children(tag: Int): Widget.Children<T>?
 
   public interface Factory<T : Any> {
-    public fun create(kind: Int): DiffConsumingWidget<T>
+    /**
+     * Create a new protocol-consuming widget of the specified [kind].
+     *
+     * Invalid [kind] values can either produce an exception or result in `null` being returned.
+     * If `null` is returned, the caller should make every effort to ignore this widget and
+     * continue executing.
+     */
+    public fun create(kind: Int): DiffConsumingWidget<T>?
   }
 }

--- a/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
+++ b/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
@@ -28,9 +28,10 @@ public class ProtocolDisplay<T : Any>(
   private val eventSink: EventSink,
 ) : DiffSink {
   init {
-    // Check that the root widget has a group of children with the shared root tag. This call
-    // will throw if that invariant does not hold.
-    root.children(RootChildrenTag)
+    // Check that the root widget has a group of children with the shared root tag.
+    requireNotNull(root.children(RootChildrenTag)) {
+      "Root widget does not support children with tag $RootChildrenTag"
+    }
   }
 
   private val widgets = mutableMapOf(RootId to root)
@@ -40,11 +41,11 @@ public class ProtocolDisplay<T : Any>(
       val widget = checkNotNull(widgets[childrenDiff.id]) {
         "Unknown widget ID ${childrenDiff.id}"
       }
-      val children = widget.children(childrenDiff.tag)
+      val children = widget.children(childrenDiff.tag) ?: continue
 
       when (childrenDiff) {
         is ChildrenDiff.Insert -> {
-          val childWidget = factory.create(childrenDiff.kind)
+          val childWidget = factory.create(childrenDiff.kind) ?: continue
           widgets[childrenDiff.childId] = childWidget
           children.insert(childrenDiff.index, childWidget.value)
         }

--- a/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolMismatchHandler.kt
+++ b/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolMismatchHandler.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import kotlin.jvm.JvmField
+
+/**
+ * Handler invoked when the protocol sent from Compose to the widget display encounters unknown
+ * entities. This usually occurs when either the Compose-side or the widget-side was generated from
+ * a newer schema than the other, or if their schemas were changed in an incompatible way.
+ */
+public interface ProtocolMismatchHandler {
+  /** Handle a request to create an unknown widget [kind]. */
+  public fun onUnknownWidget(kind: Int)
+  /** Handle a request to manipulate unknown children [tag] for the specified widget [kind]. */
+  public fun onUnknownChildren(kind: Int, tag: Int)
+  /** Handle a request to set an unknown property [tag] for the specified widget [kind]. */
+  public fun onUnknownProperty(kind: Int, tag: Int)
+
+  public companion object {
+    /** A [ProtocolMismatchHandler] which throws [IllegalArgumentException] for all callbacks. */
+    @JvmField
+    public val Throwing: ProtocolMismatchHandler = object : ProtocolMismatchHandler {
+      override fun onUnknownWidget(kind: Int) {
+        throw IllegalArgumentException("Unknown widget kind $kind")
+      }
+
+      override fun onUnknownChildren(kind: Int, tag: Int) {
+        throw IllegalArgumentException("Unknown children tag $tag for widget kind $kind")
+      }
+
+      override fun onUnknownProperty(kind: Int, tag: Int) {
+        throw IllegalArgumentException("Unknown property tag $tag for widget kind $kind")
+      }
+    }
+  }
+}

--- a/redwood/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplayTest.kt
+++ b/redwood/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplayTest.kt
@@ -24,20 +24,32 @@ import kotlin.test.assertFailsWith
 
 class ProtocolDisplayTest {
   @Test fun rootWidgetMustHaveRootChildrenTag() {
-    ProtocolDisplay(GoodRootWidget, NullWidgetFactory) { }
+    ProtocolDisplay(RootWidgetWithChildren, NullWidgetFactory) { }
 
     assertFailsWith<IllegalArgumentException> {
-      ProtocolDisplay(BadRootWidget, NullWidgetFactory) { }
+      ProtocolDisplay(RootWidgetChildrenThrows, NullWidgetFactory) { }
+    }
+
+    // Calls to children() are allowed to return null (usually from a ProtocolMismatchHandler)
+    // so ensure that this very important case still causes an exception given that behavior.
+    assertFailsWith<IllegalArgumentException> {
+      ProtocolDisplay(RootWidgetChildrenNull, NullWidgetFactory) { }
     }
   }
 
-  private object BadRootWidget : DiffConsumingWidget<Unit> {
+  private object RootWidgetChildrenThrows : DiffConsumingWidget<Unit> {
     override val value get() = Unit
     override fun apply(diff: PropertyDiff, eventSink: EventSink) = throw UnsupportedOperationException()
     override fun children(tag: Int) = throw IllegalArgumentException()
   }
 
-  private object GoodRootWidget : DiffConsumingWidget<Unit> {
+  private object RootWidgetChildrenNull : DiffConsumingWidget<Unit> {
+    override val value get() = Unit
+    override fun apply(diff: PropertyDiff, eventSink: EventSink) = throw UnsupportedOperationException()
+    override fun children(tag: Int) = null
+  }
+
+  private object RootWidgetWithChildren : DiffConsumingWidget<Unit> {
     override val value get() = Unit
     override fun apply(diff: PropertyDiff, eventSink: EventSink) = throw UnsupportedOperationException()
     override fun children(tag: Int) = when (tag) {

--- a/redwood/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/RecordingProtocolMismatchHandler.kt
+++ b/redwood/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/RecordingProtocolMismatchHandler.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+class RecordingProtocolMismatchHandler : ProtocolMismatchHandler {
+  val events = mutableListOf<String>()
+
+  override fun onUnknownWidget(kind: Int) {
+    events += "Unknown widget $kind"
+  }
+
+  override fun onUnknownChildren(kind: Int, tag: Int) {
+    events += "Unknown children $tag for $kind"
+  }
+
+  override fun onUnknownProperty(kind: Int, tag: Int) {
+    events += "Unknown property $tag for $kind"
+  }
+}

--- a/redwood/redwood-protocol-widget/src/jvmTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidgetFactoryTest.kt
+++ b/redwood/redwood-protocol-widget/src/jvmTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidgetFactoryTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import app.cash.redwood.protocol.EventSink
+import app.cash.redwood.protocol.PropertyDiff
+import example.redwood.test.SchemaExampleSchemaWidgetFactory
+import example.redwood.widget.DiffConsumingExampleSchemaWidgetFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class DiffConsumingWidgetFactoryTest {
+  @Test fun unknownWidgetThrowsDefault() {
+    val factory = DiffConsumingExampleSchemaWidgetFactory(SchemaExampleSchemaWidgetFactory)
+
+    val t = assertFailsWith<IllegalArgumentException> {
+      factory.create(345432)
+    }
+    assertEquals("Unknown widget kind 345432", t.message)
+  }
+
+  @Test fun unknownWidgetCallsHandler() {
+    val handler = RecordingProtocolMismatchHandler()
+    val factory = DiffConsumingExampleSchemaWidgetFactory(
+      delegate = SchemaExampleSchemaWidgetFactory,
+      mismatchHandler = handler,
+    )
+
+    assertNull(factory.create(345432))
+
+    assertEquals(listOf("Unknown widget 345432"), handler.events)
+  }
+
+  @Test fun unknownChildrenThrowsDefault() {
+    val factory = DiffConsumingExampleSchemaWidgetFactory(SchemaExampleSchemaWidgetFactory)
+    val button = factory.create(3) as DiffConsumingWidget<*>
+
+    val t = assertFailsWith<IllegalArgumentException> {
+      button.children(345432)
+    }
+    assertEquals("Unknown children tag 345432 for widget kind 3", t.message)
+  }
+
+  @Test fun unknownChildrenCallsHandler() {
+    val handler = RecordingProtocolMismatchHandler()
+    val factory = DiffConsumingExampleSchemaWidgetFactory(
+      delegate = SchemaExampleSchemaWidgetFactory,
+      mismatchHandler = handler,
+    )
+
+    val button = factory.create(3) as DiffConsumingWidget<*>
+    assertNull(button.children(345432))
+
+    assertEquals(listOf("Unknown children 345432 for 3"), handler.events)
+  }
+
+  @Test fun unknownPropertyThrowsDefaults() {
+    val factory = DiffConsumingExampleSchemaWidgetFactory(SchemaExampleSchemaWidgetFactory)
+    val button = factory.create(3) as DiffConsumingWidget<*>
+
+    val diff = PropertyDiff(1L, 345432)
+    val eventSink = EventSink { throw UnsupportedOperationException() }
+    val t = assertFailsWith<IllegalArgumentException> {
+      button.apply(diff, eventSink)
+    }
+    assertEquals("Unknown property tag 345432 for widget kind 3", t.message)
+  }
+
+  @Test fun unknownPropertyCallsHandler() {
+    val handler = RecordingProtocolMismatchHandler()
+    val factory = DiffConsumingExampleSchemaWidgetFactory(
+      delegate = SchemaExampleSchemaWidgetFactory,
+      mismatchHandler = handler,
+    )
+    val button = factory.create(3) as DiffConsumingWidget<*>
+
+    button.apply(PropertyDiff(1L, 345432)) { throw UnsupportedOperationException() }
+
+    assertEquals(listOf("Unknown property 345432 for 3"), handler.events)
+  }
+}

--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/types.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/types.kt
@@ -32,9 +32,11 @@ internal val abstractDiffProducingWidget = ClassName("app.cash.redwood.protocol.
 internal val diffProducingWidget = ClassName("app.cash.redwood.protocol.compose", "DiffProducingWidget")
 internal val diffProducingWidgetFactory = diffProducingWidget.nestedClass("Factory")
 internal val syntheticChildren = MemberName("app.cash.redwood.protocol.compose", "\$SyntheticChildren")
+internal val ComposeProtocolMismatchHandler = ClassName("app.cash.redwood.protocol.compose", "ProtocolMismatchHandler")
 
 internal val DiffConsumingWidget = ClassName("app.cash.redwood.protocol.widget", "DiffConsumingWidget")
 internal val DiffConsumingWidgetFactory = DiffConsumingWidget.nestedClass("Factory")
+internal val WidgetProtocolMismatchHandler = ClassName("app.cash.redwood.protocol.widget", "ProtocolMismatchHandler")
 
 internal val widgetType = ClassName("app.cash.redwood.widget", "Widget")
 internal val widgetChildren = widgetType.nestedClass("Children")
@@ -53,7 +55,6 @@ internal val composableLambda = LambdaTypeName.get(returnType = UNIT)
   )
 
 internal val ae = ClassName("kotlin", "AssertionError")
-internal val iae = ClassName("kotlin", "IllegalArgumentException")
 
 internal val typeVariableT = TypeVariableName("T", listOf(ANY))
 internal val childrenOfT = widgetChildren.parameterizedBy(typeVariableT)

--- a/redwood/redwood-test-schema/test/build.gradle
+++ b/redwood/redwood-test-schema/test/build.gradle
@@ -1,0 +1,41 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+def generatedDir = 'build/generated/redwood'
+
+sourceSets {
+  main {
+    kotlin {
+      srcDir generatedDir
+    }
+  }
+}
+
+dependencies {
+  api projects.redwoodTestSchema
+  api projects.redwoodTestSchema.widget
+}
+
+configurations {
+  generator
+}
+
+dependencies {
+  generator projects.redwoodSchemaGenerator
+  generator projects.redwoodTestSchema
+}
+
+def generate = tasks.register('redwoodGenerate', JavaExec) {
+  it.classpath(configurations.generator)
+  it.main('app.cash.redwood.schema.generator.Main')
+  it.args(
+    '--test',
+    '--out', generatedDir,
+    'example.redwood.ExampleSchema',
+  )
+
+  it.doFirst {
+    file(generatedDir).deleteDir()
+  }
+}
+
+compileKotlin.dependsOn(generate.get())

--- a/redwood/redwood-test-schema/widget/protocol/build.gradle
+++ b/redwood/redwood-test-schema/widget/protocol/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+
+def generatedDir = 'build/generated/redwood'
+
+kotlin {
+  apply from: "${rootDir}/addAllTargets.gradle"
+
+  sourceSets {
+    commonMain {
+      kotlin {
+        srcDir generatedDir
+      }
+      dependencies {
+        api projects.redwoodProtocolWidget
+        api projects.redwoodTestSchema.widget
+      }
+    }
+  }
+}
+
+configurations {
+  generator
+}
+
+dependencies {
+  generator projects.redwoodSchemaGenerator
+  generator projects.redwoodTestSchema
+}
+
+def generate = tasks.register('redwoodGenerate', JavaExec) {
+  it.classpath(configurations.generator)
+  it.main('app.cash.redwood.schema.generator.Main')
+  it.args(
+    '--widget-protocol',
+    '--out', generatedDir,
+    'example.redwood.ExampleSchema',
+  )
+
+  it.doFirst {
+    file(generatedDir).deleteDir()
+  }
+}
+
+kotlin.targets.all { target ->
+  target.compilations.all { compilation ->
+    compilation.compileKotlinTask.dependsOn(generate.get())
+  }
+}

--- a/redwood/settings.gradle
+++ b/redwood/settings.gradle
@@ -15,7 +15,9 @@ include ':redwood-widget'
 include ':redwood-test-schema'
 include ':redwood-test-schema:compose'
 include ':redwood-test-schema:compose:protocol'
+include ':redwood-test-schema:test'
 include ':redwood-test-schema:widget'
+include ':redwood-test-schema:widget:protocol'
 
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
 


### PR DESCRIPTION
These dictate the behavior when a widget, property, children, or event is seen by older code without knowledge of a newer schema.

Closes #210.