### PR TITLE
Eliminate compiler warning in generated protocol widgets

### DIFF
--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/diffConsumingGeneration.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/diffConsumingGeneration.kt
@@ -271,17 +271,22 @@ internal fun generateDiffConsumingWidget(schema: Schema, widget: Widget): FileSp
               .addModifiers(OVERRIDE)
               .addParameter("tag", INT)
               .returns(childrenOfT.copy(nullable = true))
-              .beginControlFlow("return when (tag)")
               .apply {
-                for (children in childrens) {
-                  addStatement("%L -> delegate.%N", children.tag, children.name)
+                if (childrens.isNotEmpty()) {
+                  beginControlFlow("return when (tag)")
+                  for (children in childrens) {
+                    addStatement("%L -> delegate.%N", children.tag, children.name)
+                  }
+                  beginControlFlow("else ->")
+                  addStatement("mismatchHandler.onUnknownChildren(%L, tag)", widget.tag)
+                  addStatement("null")
+                  endControlFlow()
+                  endControlFlow()
+                } else {
+                  addStatement("mismatchHandler.onUnknownChildren(%L, tag)", widget.tag)
+                  addStatement("return null")
                 }
               }
-              .beginControlFlow("else ->")
-              .addStatement("mismatchHandler.onUnknownChildren(%L, tag)", widget.tag)
-              .addStatement("null")
-              .endControlFlow()
-              .endControlFlow()
               .build()
           )
         }

--- a/redwood/redwood-test-schema/compose/build.gradle
+++ b/redwood/redwood-test-schema/compose/build.gradle
@@ -6,6 +6,9 @@ def generatedDir = 'build/generated/redwood'
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"
 
+  // Ensure our codegen correctly works in explicit API mode.
+  explicitApi()
+
   sourceSets {
     commonMain {
       kotlin {
@@ -14,6 +17,21 @@ kotlin {
       dependencies {
         api projects.redwoodTestSchema.widget
         api projects.redwoodProtocolCompose // TODO should be redwoodCompose!
+      }
+    }
+  }
+
+  targets.all {
+    compilations.all {
+      kotlinOptions {
+        // Ensure our codegen does not produce any warnings.
+        allWarningsAsErrors = true
+
+        freeCompilerArgs += [
+          // Ensure our codegen can handle the latest language semantics.
+          // https://kotlinlang.org/docs/compiler-reference.html#progressive
+          '-progressive'
+        ]
       }
     }
   }

--- a/redwood/redwood-test-schema/compose/protocol/build.gradle
+++ b/redwood/redwood-test-schema/compose/protocol/build.gradle
@@ -5,6 +5,9 @@ def generatedDir = 'build/generated/redwood'
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"
 
+  // Ensure our codegen correctly works in explicit API mode.
+  explicitApi()
+
   sourceSets {
     commonMain {
       kotlin {
@@ -13,6 +16,21 @@ kotlin {
       dependencies {
         api projects.redwoodProtocolCompose
         api projects.redwoodTestSchema.widget
+      }
+    }
+  }
+
+  targets.all {
+    compilations.all {
+      kotlinOptions {
+        // Ensure our codegen does not produce any warnings.
+        allWarningsAsErrors = true
+
+        freeCompilerArgs += [
+          // Ensure our codegen can handle the latest language semantics.
+          // https://kotlinlang.org/docs/compiler-reference.html#progressive
+          '-progressive'
+        ]
       }
     }
   }

--- a/redwood/redwood-test-schema/widget/build.gradle
+++ b/redwood/redwood-test-schema/widget/build.gradle
@@ -5,6 +5,9 @@ def generatedDir = 'build/generated/redwood'
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"
 
+  // Ensure our codegen correctly works in explicit API mode.
+  explicitApi()
+
   sourceSets {
     commonMain {
       kotlin {
@@ -12,6 +15,21 @@ kotlin {
       }
       dependencies {
         api projects.redwoodWidget
+      }
+    }
+  }
+
+  targets.all {
+    compilations.all {
+      kotlinOptions {
+        // Ensure our codegen does not produce any warnings.
+        allWarningsAsErrors = true
+
+        freeCompilerArgs += [
+          // Ensure our codegen can handle the latest language semantics.
+          // https://kotlinlang.org/docs/compiler-reference.html#progressive
+          '-progressive'
+        ]
       }
     }
   }

--- a/redwood/redwood-test-schema/widget/protocol/build.gradle
+++ b/redwood/redwood-test-schema/widget/protocol/build.gradle
@@ -5,6 +5,9 @@ def generatedDir = 'build/generated/redwood'
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"
 
+  // Ensure our codegen correctly works in explicit API mode.
+  explicitApi()
+
   sourceSets {
     commonMain {
       kotlin {
@@ -13,6 +16,21 @@ kotlin {
       dependencies {
         api projects.redwoodProtocolWidget
         api projects.redwoodTestSchema.widget
+      }
+    }
+  }
+
+  targets.all {
+    compilations.all {
+      kotlinOptions {
+        // Ensure our codegen does not produce any warnings.
+        allWarningsAsErrors = true
+
+        freeCompilerArgs += [
+          // Ensure our codegen can handle the latest language semantics.
+          // https://kotlinlang.org/docs/compiler-reference.html#progressive
+          '-progressive'
+        ]
       }
     }
   }


### PR DESCRIPTION
Previously we were generating a `when (tag) { else -> {} }` and the compiler does not like the unused `tag` subject.

Also ratchet up the strictness of our test schema by enabling progressive mode, turning all warnings into errors, and enabling explicit API mode.

Closes #34.