### PR TITLE
Remove exhaustive plugin and use progressive mode instead

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ kotlinx-coroutines = "1.5.2"
 kotlinx-serialization = "1.3.0"
 androidCompose = "1.2.0-alpha03"
 jbCompose = "1.2.0-alpha01-dev606"
-exhaustive = "0.1.1"
 
 [libraries]
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
@@ -32,7 +31,6 @@ androidGradlePlugin = { module = "com.android.tools.build:gradle", version = "7.
 materialDesign = { module = "com.google.android.material:material", version = "1.4.0" }
 kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.11.0" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.1.0" }
-exhaustiveAnnotation = { module = "app.cash.exhaustive:exhaustive-annotation", version.ref = "exhaustive" }
 junit = { module = "junit:junit", version = "4.13.1" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.1" }
 truth = { module = "com.google.truth:truth", version = "1.1" }

--- a/redwood/build.gradle
+++ b/redwood/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     classpath libs.kotlin.gradlePlugin
     classpath libs.androidGradlePlugin
     classpath "org.jetbrains.kotlin:kotlin-serialization:${libs.versions.kotlin.get()}"
-    classpath "app.cash.exhaustive:exhaustive-gradle:${libs.versions.exhaustive.get()}"
     classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
     classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.30'
     classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
@@ -67,6 +66,14 @@ allprojects {
           optIn('kotlin.RequiresOptIn')
         }
       }
+    }
+  }
+
+  tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile).configureEach { task ->
+    task.kotlinOptions {
+      freeCompilerArgs += [
+        '-progressive', // https://kotlinlang.org/docs/whatsnew13.html#progressive-mode
+      ]
     }
   }
 

--- a/redwood/redwood-gradle-plugin/build.gradle
+++ b/redwood/redwood-gradle-plugin/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'java-gradle-plugin'
-apply plugin: 'app.cash.exhaustive'
 apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {

--- a/redwood/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodPlugin.kt
+++ b/redwood/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodPlugin.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.gradle
 
-import app.cash.exhaustive.Exhaustive
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -50,7 +49,7 @@ public class RedwoodPlugin : KotlinCompilerPluginSupportPlugin {
       implementation("app.cash.redwood:redwood-compose:$redwoodVersion")
     }
 
-    @Exhaustive when (kotlinCompilation.platformType) {
+    when (kotlinCompilation.platformType) {
       androidJvm, jvm -> {
         if ((kotlinCompilation.kotlinOptions as KotlinJvmOptions).useOldBackend) {
           throw IllegalStateException("Redwood only works with the default IR-based backend")

--- a/redwood/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
+++ b/redwood/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
@@ -42,7 +42,8 @@ import app.cash.redwood.protocol.PropertyDiff
  * @suppress For generated code usage only.
  */
 @Composable
-public fun `$SyntheticChildren`(tag: Int, content: @Composable () -> Unit) {
+@Suppress("FunctionName") // Hiding from auto-complete.
+public fun _SyntheticChildren(tag: Int, content: @Composable () -> Unit) {
   ComposeNode<DiffProducingChildrenWidget.Intermediate, Applier<*>>(
     factory = {
       DiffProducingChildrenWidget.Intermediate(tag)

--- a/redwood/redwood-schema-generator/build.gradle
+++ b/redwood/redwood-schema-generator/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
-apply plugin: 'app.cash.exhaustive'
 
 dependencies {
   implementation projects.redwoodSchema

--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/composeGeneration.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/composeGeneration.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.schema.generator
 
-import app.cash.exhaustive.Exhaustive
 import app.cash.redwood.schema.parser.Children
 import app.cash.redwood.schema.parser.Event
 import app.cash.redwood.schema.parser.Property
@@ -89,7 +88,7 @@ internal fun generateComposable(schema: Schema, widget: Widget): FileSpec {
           val updateLambda = CodeBlock.builder()
           val childrenLambda = CodeBlock.builder()
           for (trait in widget.traits) {
-            @Exhaustive when (trait) {
+            when (trait) {
               is Property,
               is Event -> {
                 updateLambda.add("set(%1N) { %1N(%1N) }\n", trait.name)

--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/diffConsumingGeneration.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/diffConsumingGeneration.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.schema.generator
 
-import app.cash.exhaustive.Exhaustive
 import app.cash.redwood.schema.parser.Children
 import app.cash.redwood.schema.parser.Event
 import app.cash.redwood.schema.parser.Property
@@ -208,7 +207,7 @@ internal fun generateDiffConsumingWidget(schema: Schema, widget: Widget): FileSp
               .beginControlFlow("when (val tag = diff.tag)")
               .apply {
                 for (trait in properties) {
-                  @Exhaustive when (trait) {
+                  when (trait) {
                     is Property -> {
                       val propertyType = trait.type.asTypeName()
                       val serializerId = serializerIds.computeIfAbsent(propertyType) {

--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/diffProducingGeneration.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/diffProducingGeneration.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.schema.generator
 
-import app.cash.exhaustive.Exhaustive
 import app.cash.redwood.schema.parser.Children
 import app.cash.redwood.schema.parser.Event
 import app.cash.redwood.schema.parser.Property
@@ -154,7 +153,7 @@ internal fun generateDiffProducingWidget(schema: Schema, widget: Widget): FileSp
           val serializerIds = mutableMapOf<TypeName, Int>()
 
           for (trait in widget.traits) {
-            @Exhaustive when (trait) {
+            when (trait) {
               is Property -> {
                 val traitTypeName = trait.type.asTypeName()
                 val serializerId = serializerIds.computeIfAbsent(traitTypeName) {

--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/main.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/main.kt
@@ -17,7 +17,6 @@
 
 package app.cash.redwood.schema.generator
 
-import app.cash.exhaustive.Exhaustive
 import app.cash.redwood.schema.generator.RedwoodGenerator.Type.Compose
 import app.cash.redwood.schema.generator.RedwoodGenerator.Type.ComposeProtocol
 import app.cash.redwood.schema.generator.RedwoodGenerator.Type.Test
@@ -75,7 +74,7 @@ private class RedwoodGenerator : CliktCommand() {
 
   override fun run() {
     val schema = parseSchema(schemaType)
-    @Exhaustive when (type) {
+    when (type) {
       Compose -> {
         for (widget in schema.widgets) {
           generateComposable(schema, widget).writeTo(out)

--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/schemaGeneration.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/schemaGeneration.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.schema.generator
 
-import app.cash.exhaustive.Exhaustive
 import app.cash.redwood.schema.parser.Children
 import app.cash.redwood.schema.parser.Event
 import app.cash.redwood.schema.parser.Property
@@ -115,7 +114,7 @@ internal fun generateSchemaWidget(schema: Schema, widget: Widget): FileSpec {
         .apply {
           val schemaParameters = mutableListOf<CodeBlock>()
           for (trait in widget.traits) {
-            @Exhaustive when (trait) {
+            when (trait) {
               is Property -> {
                 addProperty(
                   PropertySpec.builder(
@@ -200,7 +199,7 @@ internal fun generateSchemaWidget(schema: Schema, widget: Widget): FileSpec {
             .endControlFlow()
             .apply {
               for (trait in widget.traits) {
-                @Exhaustive when (trait) {
+                when (trait) {
                   is Property -> {
                     beginControlFlow("if (expected.%1N != %1N)", trait.name)
                     addStatement(

--- a/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/types.kt
+++ b/redwood/redwood-schema-generator/src/main/kotlin/app/cash/redwood/schema/generator/types.kt
@@ -31,7 +31,7 @@ internal val propertyDiff = ClassName("app.cash.redwood.protocol", "PropertyDiff
 internal val abstractDiffProducingWidget = ClassName("app.cash.redwood.protocol.compose", "AbstractDiffProducingWidget")
 internal val diffProducingWidget = ClassName("app.cash.redwood.protocol.compose", "DiffProducingWidget")
 internal val diffProducingWidgetFactory = diffProducingWidget.nestedClass("Factory")
-internal val syntheticChildren = MemberName("app.cash.redwood.protocol.compose", "\$SyntheticChildren")
+internal val syntheticChildren = MemberName("app.cash.redwood.protocol.compose", "_SyntheticChildren")
 internal val ComposeProtocolMismatchHandler = ClassName("app.cash.redwood.protocol.compose", "ProtocolMismatchHandler")
 
 internal val DiffConsumingWidget = ClassName("app.cash.redwood.protocol.widget", "DiffConsumingWidget")


### PR DESCRIPTION
This affords the same check but built-in to the Kotlin compiler. Also had to fix the naming of our synthetic children composable as it will no longer be allowed in Kotlin 1.7 and progressive mode enforces that today.