### PR TITLE
Pass `Widget` wrapper when inserting into `Children`

### DIFF
--- a/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
+++ b/redwood/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
@@ -47,7 +47,7 @@ public class ProtocolDisplay<T : Any>(
         is ChildrenDiff.Insert -> {
           val childWidget = factory.create(childrenDiff.kind) ?: continue
           widgets[childrenDiff.childId] = childWidget
-          children.insert(childrenDiff.index, childWidget.value)
+          children.insert(childrenDiff.index, childWidget)
         }
         is ChildrenDiff.Move -> {
           children.move(childrenDiff.fromIndex, childrenDiff.toIndex, childrenDiff.count)

--- a/redwood/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplayTest.kt
+++ b/redwood/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplayTest.kt
@@ -63,7 +63,7 @@ class ProtocolDisplayTest {
   }
 
   private object NullWidgetChildren : Widget.Children<Unit> {
-    override fun insert(index: Int, widget: Unit) = throw UnsupportedOperationException()
+    override fun insert(index: Int, widget: Widget<Unit>) = throw UnsupportedOperationException()
     override fun move(fromIndex: Int, toIndex: Int, count: Int) = throw UnsupportedOperationException()
     override fun remove(index: Int, count: Int) = throw UnsupportedOperationException()
     override fun clear() = throw UnsupportedOperationException()

--- a/redwood/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
+++ b/redwood/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
@@ -19,8 +19,8 @@ import android.view.View
 import android.view.ViewGroup
 
 public class ViewGroupChildren(private val parent: ViewGroup) : Widget.Children<View> {
-  override fun insert(index: Int, widget: View) {
-    parent.addView(widget, index)
+  override fun insert(index: Int, widget: Widget<View>) {
+    parent.addView(widget.value, index)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {

--- a/redwood/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
+++ b/redwood/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
@@ -21,8 +21,8 @@ public class MutableListChildren<T : Any>
 @JvmOverloads constructor(
   public val list: MutableList<T> = mutableListOf(),
 ) : Widget.Children<T>, Iterable<T> {
-  override fun insert(index: Int, widget: T) {
-    list.add(index, widget)
+  override fun insert(index: Int, widget: Widget<T>) {
+    list.add(index, widget.value)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {

--- a/redwood/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -35,7 +35,7 @@ public interface Widget<T : Any> {
    */
   public interface Children<T : Any> {
     /** Insert child [widget] at [index]. */
-    public fun insert(index: Int, widget: T)
+    public fun insert(index: Int, widget: Widget<T>)
     /**
      * Move [count] child widgets from [fromIndex] to [toIndex].
      *

--- a/redwood/redwood-widget/src/commonTest/kotlin/app/cash/redwood/widget/AbstractWidgetChildrenTest.kt
+++ b/redwood/redwood-widget/src/commonTest/kotlin/app/cash/redwood/widget/AbstractWidgetChildrenTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertEquals
 
 abstract class AbstractWidgetChildrenTest<T : Any> {
   abstract val children: Widget.Children<T>
-  abstract fun widget(name: String): T
+  abstract fun widget(name: String): Widget<T>
   abstract fun names(): List<String>
 
   @Test fun insertAppend() {

--- a/redwood/redwood-widget/src/commonTest/kotlin/app/cash/redwood/widget/MutableListChildrenTest.kt
+++ b/redwood/redwood-widget/src/commonTest/kotlin/app/cash/redwood/widget/MutableListChildrenTest.kt
@@ -20,8 +20,10 @@ import kotlin.test.assertEquals
 
 class MutableListChildrenTest : AbstractWidgetChildrenTest<String>() {
   override val children = MutableListChildren<String>()
-  override fun widget(name: String) = name
   override fun names() = children.list
+  override fun widget(name: String) = object : Widget<String> {
+    override val value get() = name
+  }
 
   @Test fun iterableIteratesChildren() {
     assertEquals(emptyList(), children.toList())

--- a/redwood/redwood-widget/src/iosMain/kotlin/app.cash.treehouse.widget/UIViewChildren.kt
+++ b/redwood/redwood-widget/src/iosMain/kotlin/app.cash.treehouse.widget/UIViewChildren.kt
@@ -25,8 +25,8 @@ import platform.darwin.NSInteger
 public class UIViewChildren(
   private val root: UIView,
 ) : Widget.Children<UIView> {
-  override fun insert(index: Int, widget: UIView) {
-    root.insertSubview(widget, index.convert<NSInteger>())
+  override fun insert(index: Int, widget: Widget<UIView>) {
+    root.insertSubview(widget.value, index.convert<NSInteger>())
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {

--- a/redwood/redwood-widget/src/iosTest/kotlin/app.cash.treehouse.widget/UIViewChildrenTest.kt
+++ b/redwood/redwood-widget/src/iosTest/kotlin/app.cash.treehouse.widget/UIViewChildrenTest.kt
@@ -23,9 +23,11 @@ class UIViewChildrenTest : AbstractWidgetChildrenTest<UIView>() {
   private val parent = UIView()
   override val children = UIViewChildren(parent)
 
-  override fun widget(name: String): UIView {
-    return UILabel().apply {
-      text = name
+  override fun widget(name: String): Widget<UIView> {
+    return object : Widget<UIView> {
+      override val value = UILabel().apply {
+        text = name
+      }
     }
   }
 

--- a/redwood/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
+++ b/redwood/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
@@ -22,10 +22,10 @@ import org.w3c.dom.get
 public class HTMLElementChildren(
   private val parent: HTMLElement,
 ) : Widget.Children<HTMLElement> {
-  override fun insert(index: Int, widget: HTMLElement) {
+  override fun insert(index: Int, widget: Widget<HTMLElement>) {
     // Null element returned when index == childCount causes insertion at end.
     val current = parent.children[index]
-    parent.insertBefore(widget, current)
+    parent.insertBefore(widget.value, current)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {

--- a/redwood/redwood-widget/src/jsTest/kotlin/app/cash/redwood/widget/HTMLElementChildrenTest.kt
+++ b/redwood/redwood-widget/src/jsTest/kotlin/app/cash/redwood/widget/HTMLElementChildrenTest.kt
@@ -21,12 +21,14 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
 
 class HTMLElementChildrenTest : AbstractWidgetChildrenTest<HTMLElement>() {
-  private val parent = widget("root")
+  private val parent = widget("root").value
   override val children = HTMLElementChildren(parent)
 
-  override fun widget(name: String): HTMLElement {
-    return (document.createElement("div") as HTMLDivElement).apply {
-      id = name
+  override fun widget(name: String): Widget<HTMLElement> {
+    return object : Widget<HTMLElement> {
+      override val value = (document.createElement("div") as HTMLDivElement).apply {
+        id = name
+      }
     }
   }
 

--- a/redwood/redwood-widget/src/test/kotlin/app/cash/redwood/widget/ViewGroupChildrenTest.kt
+++ b/redwood/redwood-widget/src/test/kotlin/app/cash/redwood/widget/ViewGroupChildrenTest.kt
@@ -26,9 +26,11 @@ class ViewGroupChildrenTest : AbstractWidgetChildrenTest<View>() {
   private val parent = FrameLayout(RuntimeEnvironment.application)
   override val children = ViewGroupChildren(parent)
 
-  override fun widget(name: String): View {
-    return View(RuntimeEnvironment.application).apply {
-      tag = name
+  override fun widget(name: String): Widget<View> {
+    return object : Widget<View> {
+      override val value = View(RuntimeEnvironment.application).apply {
+        tag = name
+      }
     }
   }
 

--- a/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/UIStackViewChildren.kt
+++ b/samples/counter/ios/shared/src/iosMain/kotlin/example/ios/sunspot/UIStackViewChildren.kt
@@ -25,8 +25,8 @@ import platform.UIKit.subviews
 class UIStackViewChildren(
   private val root: UIStackView,
 ) : Widget.Children<UIView> {
-  override fun insert(index: Int, widget: UIView) {
-    root.insertArrangedSubview(widget, index.convert())
+  override fun insert(index: Int, widget: Widget<UIView>) {
+    root.insertArrangedSubview(widget.value, index.convert())
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {

--- a/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiWidgetChildren.kt
+++ b/samples/todo-list/android-composeui/src/main/java/example/android/composeui/ComposeUiWidgetChildren.kt
@@ -30,8 +30,8 @@ class ComposeUiWidgetChildren : Widget.Children<@Composable () -> Unit> {
     }
   }
 
-  override fun insert(index: Int, widget: @Composable () -> Unit) {
-    children.add(index, widget)
+  override fun insert(index: Int, widget: Widget<@Composable () -> Unit≥) {
+    children.add(index, widget.value)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {


### PR DESCRIPTION
This will enable future changes such as querying layout modifiers and upward invalidation propagation.