### PR TITLE
Remove use of the 'hosted' compiler

### DIFF
--- a/compose-gradle-plugin/src/main/kotlin/app/cash/redwood/tools/JetBrainsComposePlugin.kt
+++ b/compose-gradle-plugin/src/main/kotlin/app/cash/redwood/tools/JetBrainsComposePlugin.kt
@@ -37,10 +37,6 @@ class JetBrainsComposePlugin : KotlinCompilerPluginSupportPlugin {
     return SubpluginArtifact("org.jetbrains.compose.compiler", "compiler", jbComposeVersion)
   }
 
-  override fun getPluginArtifactForNative(): SubpluginArtifact {
-    return SubpluginArtifact("org.jetbrains.compose.compiler", "compiler-hosted", jbComposeVersion)
-  }
-
   override fun applyToCompilation(
     kotlinCompilation: KotlinCompilation<*>
   ): Provider<List<SubpluginOption>> {

--- a/compose/README.md
+++ b/compose/README.md
@@ -4,8 +4,7 @@ We build our own copy of the Compose runtime as a multiplatform project with JVM
 targets in addition to the regular Android. All sources come from
 [JetBrains' fork](https://github.com/JetBrains/androidx/) which are included as a git submodule.
 
-The compiler and "hosted" compiler (i.e., the one which works on Kotlin/Native targets) are also
-from JetBrains, but we use their binary artifacts from Maven Central.
+The compiler is also from JetBrains, but we use their binary artifact from Maven Central.
 
 
 ## Updating

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,6 @@ androidx-core = { module = "androidx.core:core-ktx", version = "1.2.0" }
 androidx-compose-material = { module = "androidx.compose.material:material", version = "1.2.0-rc03" }
 
 jetbrains-compose-compiler = { module = "org.jetbrains.compose.compiler:compiler", version.ref = "jbCompose" }
-jetbrains-compose-compilerHosted = { module = "org.jetbrains.compose.compiler:compiler-hosted", version.ref = "jbCompose" }
 
 androidGradlePlugin = { module = "com.android.tools.build:gradle", version = "7.2.0" }
 materialDesign = { module = "com.google.android.material:material", version = "1.4.0" }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodPlugin.kt
@@ -39,12 +39,6 @@ public class RedwoodPlugin : KotlinCompilerPluginSupportPlugin {
     jbComposeVersion,
   )
 
-  override fun getPluginArtifactForNative(): SubpluginArtifact = SubpluginArtifact(
-    "org.jetbrains.compose.compiler",
-    "compiler-hosted",
-    jbComposeVersion,
-  )
-
   override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
     kotlinCompilation.dependencies {
       api("app.cash.redwood:redwood-compose:$redwoodVersion")


### PR DESCRIPTION
This is no longer necessary to use as of Kotlin 1.7.0 per https://kotlinlang.org/docs/whatsnew17.html#unified-compiler-plugin-abi-with-jvm-and-js-ir-backends