### PR TITLE
Generate a Composable target marker per schema

### DIFF
--- a/redwood-generator/src/main/kotlin/app/cash/redwood/generator/main.kt
+++ b/redwood-generator/src/main/kotlin/app/cash/redwood/generator/main.kt
@@ -76,6 +76,7 @@ private class RedwoodGenerator : CliktCommand() {
     val schema = parseSchema(schemaType)
     when (type) {
       Compose -> {
+        generateComposableTargetMarker(schema).writeTo(out)
         generateUnscopedModifiers(schema).writeTo(out)
         for (scope in schema.scopes) {
           generateScopeAndScopedModifiers(schema, scope).writeTo(out)

--- a/redwood-generator/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
+++ b/redwood-generator/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
@@ -53,6 +53,8 @@ private val noArgumentEventLambda = LambdaTypeName.get(returnType = UNIT).copy(n
 
 internal val Schema.composePackage get() = "$`package`.compose"
 
+internal val Schema.composeTargetMarker get() = ClassName(composePackage, "${name}Composable")
+
 internal fun Schema.diffProducingWidgetFactoryType(): ClassName {
   return ClassName(composePackage, "DiffProducing${name}WidgetFactory")
 }

--- a/redwood-generator/src/main/kotlin/app/cash/redwood/generator/types.kt
+++ b/redwood-generator/src/main/kotlin/app/cash/redwood/generator/types.kt
@@ -50,14 +50,19 @@ internal val widgetFactory = widgetType.nestedClass("Factory")
 internal val redwoodComposeNode = MemberName("app.cash.redwood.compose", "RedwoodComposeNode")
 
 internal val composable = ClassName("androidx.compose.runtime", "Composable")
+internal val composableTargetMarker = ClassName("androidx.compose.runtime", "ComposableTargetMarker")
 
-internal fun composableLambda(receiver: TypeName?): TypeName {
+internal fun composableLambda(
+  receiver: TypeName?,
+  composeTargetMarker: ClassName,
+): TypeName {
   return LambdaTypeName.get(
     returnType = UNIT,
     receiver = receiver,
   ).copy(
     annotations = listOf(
       AnnotationSpec.builder(composable).build(),
+      AnnotationSpec.builder(composeTargetMarker).build(),
     ),
   )
 }

--- a/redwood-generator/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
+++ b/redwood-generator/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
@@ -37,15 +37,28 @@ class ComposeGenerationTest {
     @Children(2) val unscoped: List<Any>,
   )
 
-  @Test fun scopedAndUnscopedChildren() {
+  @Test fun functionTargetMarker() {
+    val schema = parseSchema(ScopedAndUnscopedSchema::class)
+
+    val fileSpec = generateComposable(schema, schema.widgets.single())
+    assertThat(fileSpec.toString()).contains(
+      """
+      |@Composable
+      |@ScopedAndUnscopedSchemaComposable
+      |public fun
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun scopedAndUnscopedChildrenWithTargetMarker() {
     val schema = parseSchema(ScopedAndUnscopedSchema::class)
 
     val fileSpec = generateComposable(schema, schema.widgets.single())
     assertThat(fileSpec.toString()).apply {
-      contains("scoped: @Composable RowScope.() -> Unit")
+      contains("scoped: @Composable @ScopedAndUnscopedSchemaComposable RowScope.() -> Unit")
       contains("RowScope.scoped()")
 
-      contains("unscoped: @Composable () -> Unit")
+      contains("unscoped: @Composable @ScopedAndUnscopedSchemaComposable () -> Unit")
       contains("unscoped()")
     }
   }


### PR DESCRIPTION
This prevents you from mixing it with Compose UI, Mosaic, Glance, Molecule, or other Redwood schemas.

Closes #212 