### PR TITLE
Add the project dir to lint and reduce its work

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinx-serialization = "1.3.0"
 androidComposeCompiler = "1.3.0-rc01"
 androidComposeRuntime = "1.3.0-alpha01"
 jbCompose = "1.2.0-alpha01-dev741"
-lint = "30.2.0"
+lint = "30.4.0-alpha09"
 
 [libraries]
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintPlugin.kt
@@ -209,6 +209,7 @@ private fun Project.createRedwoodLintTask(
     task.description = taskDescription(descriptionTarget)
 
     task.toolClasspath.setFrom(configuration.incoming.artifacts.artifactFiles)
+    task.projectDirectory.set(project.projectDir)
     task.sourceDirectories.set(sourceDirs())
     task.dependencies.setFrom(
       classpath().incoming.artifactView {


### PR DESCRIPTION
Use a custom project type to reduce the amount of things that Lint will look at. We only want to parse source files for now.