### PR TITLE
Automatically apply the serialization plugin to protocol generation

### DIFF
--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
@@ -59,6 +59,9 @@ public abstract class RedwoodGeneratorPlugin(
     if (strategy == Compose) {
       project.plugins.apply(RedwoodPlugin::class.java)
     }
+    if (strategy == ComposeProtocol || strategy == WidgetProtocol) {
+      project.plugins.apply("org.jetbrains.kotlin.plugin.serialization")
+    }
 
     val extension = project.extensions.create(
       "redwoodSchema",


### PR DESCRIPTION
When layout modifiers are produced this plugin needs to run.