### PR TITLE
Track Zipline API changes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidComposeCompiler = "1.3.0-rc01"
 androidComposeRuntime = "1.3.0-alpha01"
 jbCompose = "1.2.0-alpha01-dev741"
 lint = "30.4.0-alpha09"
-zipline = "0.9.2"
+zipline = "0.9.3"
 
 [libraries]
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }

--- a/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehouseApp.kt
@@ -161,7 +161,6 @@ public class TreehouseApp<T : Any>(
     public abstract val name: String
     public abstract val manifestUrl: Flow<String>
 
-    // TODO(jwilson): move SerializersModule from TreehousePlatform.
     public open val serializersModule: SerializersModule
       get() = EmptySerializersModule()
 

--- a/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehouseEventListener.kt
+++ b/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehouseEventListener.kt
@@ -37,7 +37,11 @@ internal class TreehouseEventListener(
     platform.logInfo("Loading application $applicationName from $manifestUrl", null)
   }
 
-  override fun applicationLoadEnd(applicationName: String, manifestUrl: String?) {
+  override fun applicationLoadEnd(
+    applicationName: String,
+    manifestUrl: String?,
+    startValue: Any?,
+  ) {
     platform.logInfo("Loaded application $applicationName", null)
   }
 
@@ -45,11 +49,17 @@ internal class TreehouseEventListener(
     applicationName: String,
     manifestUrl: String?,
     exception: Exception,
+    startValue: Any?,
   ) {
     platform.logWarning("Loading application $applicationName failed", exception)
   }
 
-  override fun downloadFailed(applicationName: String, url: String, exception: Exception) {
+  override fun downloadFailed(
+    applicationName: String,
+    url: String,
+    exception: Exception,
+    startValue: Any?,
+  ) {
     platform.logInfo("Downloading code failed; will retry: $exception", null)
   }
 

--- a/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehouseLauncher.kt
+++ b/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehouseLauncher.kt
@@ -16,32 +16,61 @@
 package app.cash.treehouse
 
 import app.cash.zipline.loader.LoadedZipline
+import app.cash.zipline.loader.ManifestVerifier
+import app.cash.zipline.loader.ZiplineCache
+import app.cash.zipline.loader.ZiplineHttpClient
 import app.cash.zipline.loader.ZiplineLoader
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import okio.Closeable
+import okio.FileSystem
+import okio.Path
 
 /**
- * This manages a cache that should be shared by all launched applications. For best performance
- * and correctness this must be a singleton.
+ * This manages a cache that should be shared by all launched applications.
+ *
+ * This class holds a stateful disk cache. At most one instance with each [cacheName] should be
+ * open at any time. Most callers should use a single [TreehouseLauncher] for best caching.
  */
 public class TreehouseLauncher internal constructor(
   private val platform: TreehousePlatform,
-) {
-  /** Dispatchers to execute code with the right capabilities. */
-  public val dispatchers: TreehouseDispatchers = platform.dispatchers
+  public val dispatchers: TreehouseDispatchers,
+  httpClient: ZiplineHttpClient,
+  manifestVerifier: ManifestVerifier,
+  private val embeddedDir: Path,
+  private val embeddedFileSystem: FileSystem,
+  private val cacheName: String,
+  private val cacheMaxSizeInBytes: Long,
+) : Closeable {
+  /** Loads applications from the network only. The cache is neither read nor written. */
+  private val ziplineLoaderNetworkOnly = ZiplineLoader(
+    dispatcher = dispatchers.zipline,
+    manifestVerifier = manifestVerifier,
+    httpClient = httpClient,
+    eventListener = TreehouseEventListener(platform),
+  )
 
-  /** Lazily create the ZiplineLoader so its initialized off the main dispatcher. */
-  private val ziplineLoader: ZiplineLoader by lazy {
-    platform.newZiplineLoader()
+  /** This is lazy to avoid initializing the cache on the thread that creates this launcher. */
+  private val cache: ZiplineCache by lazy {
+    platform.newCache(name = cacheName, maxSizeInBytes = cacheMaxSizeInBytes)
+  }
+
+  /** Loads applications from the network, the cache, or the embedded resources. */
+  private val ziplineLoaderNetworkCacheEmbedded: ZiplineLoader by lazy {
+    ziplineLoaderNetworkOnly.withCache(
+      cache = cache,
+    ).withEmbedded(
+      embeddedDir = embeddedDir,
+      embeddedFileSystem = embeddedFileSystem,
+    )
   }
 
   public fun <T : Any> launch(
     scope: CoroutineScope,
     spec: TreehouseApp.Spec<T>,
   ): TreehouseApp<T> {
-    val dispatchers = platform.dispatchers
     val treehouseApp = TreehouseApp<T>(
       scope = scope,
       dispatchers = dispatchers,
@@ -64,16 +93,26 @@ public class TreehouseLauncher internal constructor(
    * found.
    */
   private fun ziplineFlow(spec: TreehouseApp.Spec<*>): Flow<LoadedZipline> {
+    val ziplineLoaderForLoad = when (spec.freshCodePolicy) {
+      FreshCodePolicy.ALWAYS_REFRESH_IMMEDIATELY -> ziplineLoaderNetworkOnly
+      else -> ziplineLoaderNetworkCacheEmbedded
+    }
+
     val manifestUrlFlowForLoad = when (spec.freshCodePolicy) {
       FreshCodePolicy.ALWAYS_REFRESH_IMMEDIATELY -> spec.manifestUrl.rebounce(500.milliseconds)
       else -> spec.manifestUrl
     }
 
-    return ziplineLoader.load(
-      spec.name,
-      manifestUrlFlowForLoad,
+    return ziplineLoaderForLoad.load(
+      applicationName = spec.name,
+      manifestUrlFlow = manifestUrlFlowForLoad,
+      serializersModule = spec.serializersModule,
     ) { zipline ->
       spec.bindServices(zipline)
     }
+  }
+
+  override fun close() {
+    cache.close()
   }
 }

--- a/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehousePlatform.kt
+++ b/redwood-treehouse/src/engineMain/kotlin/app/cash/treehouse/TreehousePlatform.kt
@@ -15,22 +15,12 @@
  */
 package app.cash.treehouse
 
-import app.cash.zipline.loader.ZiplineLoader
-import kotlinx.serialization.modules.SerializersModule
-import okio.Path
+import app.cash.zipline.loader.ZiplineCache
 
 internal interface TreehousePlatform {
-  val dispatchers: TreehouseDispatchers
-
-  /** Directory for the cache shared by all Treehouse applications. */
-  val cacheDirectory: Path
-
-  // TODO(jwilson): move this to TreehouseLauncher.Spec.
-  val serializersModule: SerializersModule
-
   fun logInfo(message: String, throwable: Throwable?)
 
   fun logWarning(message: String, throwable: Throwable?)
 
-  fun newZiplineLoader(): ZiplineLoader
+  fun newCache(name: String, maxSizeInBytes: Long): ZiplineCache
 }


### PR DESCRIPTION
We fixed Zipline so TreehouseLauncher can keep serializers and
caches the way that works best.