### PR TITLE
Omit unscoped layout modifier if none present

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/GenerateCommand.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/GenerateCommand.kt
@@ -71,7 +71,7 @@ internal class GenerateCommand : CliktCommand(name = "generate") {
     when (type) {
       Compose -> {
         generateComposableTargetMarker(schema).writeTo(out)
-        generateUnscopedModifiers(schema).writeTo(out)
+        generateUnscopedModifiers(schema)?.writeTo(out)
         for (scope in schema.scopes) {
           generateScopeAndScopedModifiers(schema, scope).writeTo(out)
         }

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -240,14 +240,13 @@ internal fun generateScopeAndScopedModifiers(schema: Schema, scope: KClass<*>): 
     .build()
 }
 
-internal fun generateUnscopedModifiers(schema: Schema): FileSpec {
+internal fun generateUnscopedModifiers(schema: Schema): FileSpec? {
+  val unscopedLayoutModifiers = schema.layoutModifiers.filter { it.scopes.isEmpty() }
+  if (unscopedLayoutModifiers.isEmpty()) return null
+
   return FileSpec.builder(schema.composePackage, "unscopedLayoutModifiers")
     .apply {
-      for (layoutModifier in schema.layoutModifiers) {
-        if (layoutModifier.scopes.isNotEmpty()) {
-          continue
-        }
-
+      for (layoutModifier in unscopedLayoutModifiers) {
         val (function, type) = generateLayoutModifier(schema, layoutModifier)
         addFunction(function)
         addType(type)


### PR DESCRIPTION
No one likes an empty Kotlin file generated.