### PR TITLE
Avoid unused warnings when no layout modifiers present

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.schema.parser.Widget
 import app.cash.redwood.schema.parser.Widget.Children
 import app.cash.redwood.schema.parser.Widget.Event
 import app.cash.redwood.schema.parser.Widget.Property
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -352,6 +353,13 @@ internal fun generateDiffConsumingLayoutModifier(schema: Schema): FileSpec {
         .addStatement("")
         .beginControlFlow("return when (tag)")
         .apply {
+          if (schema.layoutModifiers.isEmpty()) {
+            addAnnotation(
+              AnnotationSpec.builder(Suppress::class)
+                .addMember("%S, %S, %S", "UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNUSED_VARIABLE")
+                .build(),
+            )
+          }
           for (layoutModifier in schema.layoutModifiers) {
             val typeName = ClassName(schema.widgetPackage, layoutModifier.type.simpleName!! + "Impl")
             if (layoutModifier.properties.isEmpty()) {

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.schema.parser.Widget
 import app.cash.redwood.schema.parser.Widget.Children
 import app.cash.redwood.schema.parser.Widget.Event
 import app.cash.redwood.schema.parser.Widget.Property
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -283,6 +284,14 @@ internal fun generateDiffProducingLayoutModifier(schema: Schema): FileSpec {
         .returns(JsonElement)
         .beginControlFlow("return when (this)")
         .apply {
+          if (schema.layoutModifiers.isEmpty()) {
+            addAnnotation(
+              AnnotationSpec.builder(Suppress::class)
+                .addMember("%S, %S", "UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+                .build(),
+            )
+          }
+
           for (layoutModifier in schema.layoutModifiers) {
             val modifierType = schema.layoutModifierType(layoutModifier)
             val surrogate = schema.layoutModifierSurrogate(layoutModifier)

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -78,6 +78,8 @@ test {
   dependsOn(':redwood-schema:installArchives')
   dependsOn(':redwood-schema-annotations:installArchives')
   dependsOn(':redwood-widget:installArchives')
+
+  inputs.dir(project.file('src/test/fixture'))
 }
 
 buildConfig {

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/build.gradle
@@ -1,0 +1,38 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
+    classpath libs.androidGradlePlugin
+    classpath libs.kotlin.gradlePlugin
+    classpath libs.kotlin.serializationPlugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    maven {
+      url 'https://maven.pkg.jetbrains.space/public/p/compose/dev'
+    }
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    maven {
+      url 'https://maven.pkg.jetbrains.space/public/p/compose/dev'
+    }
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+dependencies {
+  api "app.cash.redwood:redwood-schema-annotations:$redwoodVersion"
+}

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/compose-protocol/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/compose-protocol/build.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
+apply plugin: 'app.cash.redwood.generator.compose.protocol'
+
+kotlin {
+  jvm()
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(project(':widget'))
+      }
+    }
+  }
+
+  targets.all {
+    compilations.all {
+      kotlinOptions {
+        // Ensure our codegen does not produce any warnings.
+        allWarningsAsErrors = true
+      }
+    }
+  }
+}
+
+redwoodSchema {
+  source = project(':')
+  type = 'example.counter.Counter'
+}

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/settings.gradle
@@ -1,0 +1,11 @@
+include ':compose-protocol'
+include ':widget'
+include ':widget-protocol'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/src/main/kotlin/example/counter/schema.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.counter
+
+import app.cash.redwood.schema.Children
+import app.cash.redwood.schema.Default
+import app.cash.redwood.schema.Property
+import app.cash.redwood.schema.Schema
+import app.cash.redwood.schema.Widget
+
+@Schema(
+  [
+    CounterBox::class,
+  ]
+)
+interface Counter
+
+@Widget(1)
+data class CounterBox(
+  @Children(1) val children: List<Any>,
+)

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/widget-protocol/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/widget-protocol/build.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
+apply plugin: 'app.cash.redwood.generator.widget.protocol'
+
+kotlin {
+  jvm()
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(project(':widget'))
+      }
+    }
+  }
+
+  targets.all {
+    compilations.all {
+      kotlinOptions {
+        // Ensure our codegen does not produce any warnings.
+        allWarningsAsErrors = true
+      }
+    }
+  }
+}
+
+redwoodSchema {
+  source = project(':')
+  type = 'example.counter.Counter'
+}

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/widget/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/widget/build.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'app.cash.redwood.generator.widget'
+
+kotlin {
+  jvm()
+
+  targets.all {
+    compilations.all {
+      kotlinOptions {
+        // Ensure our codegen does not produce any warnings.
+        allWarningsAsErrors = true
+      }
+    }
+  }
+}
+
+redwoodSchema {
+  source = project(':')
+  type = 'example.counter.Counter'
+}

--- a/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
+++ b/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
@@ -115,6 +115,13 @@ class FixtureTest {
     )
   }
 
+  @Test fun protocolWithoutLayoutModifiers() {
+    // When no layout modifiers are present, the serialization codegen contains unused things.
+    // Ensure that it does not produce warnings (which are set to error in this build).
+    val fixtureDir = File("src/test/fixture/protocol-no-layout-modifiers")
+    fixtureGradleRunner(fixtureDir).build()
+  }
+
   private fun fixtureGradleRunner(
     fixtureDir: File,
     task: String = "build",


### PR DESCRIPTION
This is easier than varying the codegen.