### PR TITLE
Always clear old children before the initial diff

### DIFF
--- a/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseComposeView.kt
+++ b/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseComposeView.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.ComposeView
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.protocol.widget.DiffConsumingWidget
@@ -107,5 +108,8 @@ internal class ProtocolDisplayRoot(
     error("unexpected update on view root: $diff")
   }
 
-  override fun children(tag: Int) = children
+  override fun children(tag: Int) = when (tag) {
+    RootChildrenTag -> children
+    else -> error("unexpected tag: $tag")
+  }
 }

--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherAndroid.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherAndroid.kt
@@ -20,6 +20,7 @@ import android.os.Looper
 import android.util.Log
 import android.view.View
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.protocol.widget.DiffConsumingWidget
@@ -115,5 +116,8 @@ internal class ProtocolDisplayRoot(
     error("unexpected update on view root: $diff")
   }
 
-  override fun children(tag: Int) = children
+  override fun children(tag: Int) = when (tag) {
+    RootChildrenTag -> children
+    else -> error("unexpected tag: $tag")
+  }
 }

--- a/redwood-treehouse/src/engineMain/kotlin/app/cash/redwood/treehouse/RealViewBinder.kt
+++ b/redwood-treehouse/src/engineMain/kotlin/app/cash/redwood/treehouse/RealViewBinder.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
 import app.cash.redwood.protocol.Diff
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.widget.DiffConsumingWidget
@@ -22,7 +23,6 @@ import app.cash.redwood.protocol.widget.ProtocolDisplay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
-import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
 
 /** Displays Redwood widgets to a [TreehouseView]. */
 public class RealViewBinder(

--- a/redwood-treehouse/src/engineMain/kotlin/app/cash/redwood/treehouse/RealViewBinder.kt
+++ b/redwood-treehouse/src/engineMain/kotlin/app/cash/redwood/treehouse/RealViewBinder.kt
@@ -76,6 +76,7 @@ public class RealViewBinder(
         scope.launch(dispatchers.main) {
           if (firstDiff) {
             firstDiff = false
+            view.protocolDisplayRoot.children(0)!!.clear()
 
             when {
               isInitialCode -> adapter.beforeInitialCode(view)

--- a/redwood-treehouse/src/engineMain/kotlin/app/cash/redwood/treehouse/RealViewBinder.kt
+++ b/redwood-treehouse/src/engineMain/kotlin/app/cash/redwood/treehouse/RealViewBinder.kt
@@ -22,6 +22,7 @@ import app.cash.redwood.protocol.widget.ProtocolDisplay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
 
 /** Displays Redwood widgets to a [TreehouseView]. */
 public class RealViewBinder(
@@ -76,7 +77,7 @@ public class RealViewBinder(
         scope.launch(dispatchers.main) {
           if (firstDiff) {
             firstDiff = false
-            view.protocolDisplayRoot.children(0)!!.clear()
+            view.protocolDisplayRoot.children(RootChildrenTag)!!.clear()
 
             when {
               isInitialCode -> adapter.beforeInitialCode(view)

--- a/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherIos.kt
+++ b/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherIos.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.protocol.widget.DiffConsumingWidget
@@ -104,5 +105,8 @@ internal class ProtocolDisplayRoot(
     error("unexpected update on view root: $diff")
   }
 
-  override fun children(tag: Int) = children
+  override fun children(tag: Int) = when (tag) {
+    RootChildrenTag -> children
+    else -> error("unexpected tag: $tag")
+  }
 }


### PR DESCRIPTION
As-is we need this boilerplate in every implementation of beforeUpdatedCode().