### PR TITLE
Fix regression in FlexboxEngine when calculating flex lines.

### DIFF
--- a/redwood-flexbox-engine/src/commonMain/kotlin/app/cash/redwood/FlexboxEngine.kt
+++ b/redwood-flexbox-engine/src/commonMain/kotlin/app/cash/redwood/FlexboxEngine.kt
@@ -362,7 +362,7 @@ public class FlexboxEngine {
         // Let the sumCrossSize start from the negative value of the last flex line's
         // cross size because otherwise flex lines aren't calculated enough to fill the
         // visible area.
-        sumCrossSize -= flexLine.crossSize
+        sumCrossSize = -flexLine.crossSize
         reachedToIndex = true
       }
       if (sumCrossSize > needsCalcAmount && reachedToIndex) {


### PR DESCRIPTION
Logic mistake introduced by this PR: https://github.com/cashapp/redwood/pull/379