### PR TITLE
Expose `HostConfiguration` type to Compose through Treehouse

### DIFF
--- a/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseComposeView.kt
+++ b/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseComposeView.kt
@@ -17,16 +17,22 @@ package app.cash.redwood.treehouse.composeui
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Configuration.UI_MODE_NIGHT_MASK
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.ComposeView
+import app.cash.redwood.treehouse.HostConfiguration
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.widget.Widget
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @SuppressLint("ViewConstructor")
 public class TreehouseComposeView<T : Any>(
@@ -62,6 +68,12 @@ public class TreehouseComposeView<T : Any>(
       }
     }
 
+  private val mutableHostConfiguration =
+    MutableStateFlow(computeHostConfiguration(context.resources.configuration))
+
+  override val hostConfiguration: StateFlow<HostConfiguration>
+    get() = mutableHostConfiguration
+
   public fun setContent(content: TreehouseView.Content<T>) {
     treehouseApp.dispatchers.checkUi()
     this.content = content
@@ -78,6 +90,19 @@ public class TreehouseComposeView<T : Any>(
     treehouseApp.onContentChanged(this)
   }
 
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    mutableHostConfiguration.value = computeHostConfiguration(newConfig)
+  }
+
   override fun generateDefaultLayoutParams(): LayoutParams =
     LayoutParams(MATCH_PARENT, MATCH_PARENT)
+}
+
+private fun computeHostConfiguration(
+  config: Configuration,
+): HostConfiguration {
+  return HostConfiguration(
+    darkMode = (config.uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES,
+  )
 }

--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -17,11 +17,16 @@ package app.cash.redwood.treehouse
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Configuration.UI_MODE_NIGHT_MASK
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import app.cash.redwood.widget.ViewGroupChildren
 import app.cash.redwood.widget.Widget
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @SuppressLint("ViewConstructor")
 public class TreehouseWidgetView<T : Any>(
@@ -41,6 +46,12 @@ public class TreehouseWidgetView<T : Any>(
 
   override val children: Widget.Children<*> = ViewGroupChildren(this)
 
+  private val mutableHostConfiguration =
+    MutableStateFlow(computeHostConfiguration(context.resources.configuration))
+
+  override val hostConfiguration: StateFlow<HostConfiguration>
+    get() = mutableHostConfiguration
+
   public fun setContent(content: TreehouseView.Content<T>) {
     treehouseApp.dispatchers.checkUi()
     this.content = content
@@ -57,6 +68,19 @@ public class TreehouseWidgetView<T : Any>(
     treehouseApp.onContentChanged(this)
   }
 
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    mutableHostConfiguration.value = computeHostConfiguration(newConfig)
+  }
+
   override fun generateDefaultLayoutParams(): LayoutParams =
     LayoutParams(MATCH_PARENT, MATCH_PARENT)
+}
+
+private fun computeHostConfiguration(
+  config: Configuration,
+): HostConfiguration {
+  return HostConfiguration(
+    darkMode = (config.uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES,
+  )
 }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/FlowWithInitialValue.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/FlowWithInitialValue.kt
@@ -15,18 +15,16 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.protocol.Event
-import app.cash.zipline.ZiplineService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 
-/**
- * Adapt TreehouseComposition to conform the limitations of Zipline interfaces.
- *
- * Most callers shouldn't use this directly; instead use `TreehouseUi`.
- */
-public interface ZiplineTreehouseUi : ZiplineService {
-  public fun start(
-    diffSink: DiffSinkService,
-    hostConfigurations: FlowWithInitialValue<HostConfiguration>,
-  )
-  public fun sendEvent(event: Event)
-}
+@Serializable
+public data class FlowWithInitialValue<T>(
+  val initial: T,
+  @Contextual val flow: Flow<T>,
+)
+
+public fun <T> StateFlow<T>.toFlowWithInitialValue(): FlowWithInitialValue<T> =
+  FlowWithInitialValue(value, this)

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/HostConfiguration.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/HostConfiguration.kt
@@ -15,18 +15,11 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.protocol.Event
-import app.cash.zipline.ZiplineService
+import kotlinx.serialization.Serializable
 
-/**
- * Adapt TreehouseComposition to conform the limitations of Zipline interfaces.
- *
- * Most callers shouldn't use this directly; instead use `TreehouseUi`.
- */
-public interface ZiplineTreehouseUi : ZiplineService {
-  public fun start(
-    diffSink: DiffSinkService,
-    hostConfigurations: FlowWithInitialValue<HostConfiguration>,
-  )
-  public fun sendEvent(event: Event)
+@Serializable
+public data class HostConfiguration(
+  val darkMode: Boolean = false,
+) {
+  public companion object
 }

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -197,7 +197,7 @@ public class TreehouseApp<T : Any>(
         }
       }
 
-      content.start(diffSinkService)
+      content.start(diffSinkService, view.hostConfiguration.toFlowWithInitialValue())
     }
 
     fun cancel() {

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -16,11 +16,13 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.widget.Widget
+import kotlinx.coroutines.flow.StateFlow
 
 public interface TreehouseView<T : Any> {
   /** This is the actual content, or null if not attached to the screen. */
   public val boundContent: Content<T>?
   public val children: Widget.Children<*>
+  public val hostConfiguration: StateFlow<HostConfiguration>
 
   public interface Content<T : Any> {
     public fun get(app: T): ZiplineTreehouseUi

--- a/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/HostConfiguration.kt
+++ b/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/HostConfiguration.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.compositionLocalOf
+import app.cash.redwood.compose.WidgetVersion
+
+/**
+ * Provide the configuration of the host display.
+ * This value will be bound automatically when Treehouse is used.
+ * Custom values should only be provided into a composition for testing purposes!
+ *
+ * @see WidgetVersion
+ */
+public val LocalHostConfiguration: ProvidableCompositionLocal<HostConfiguration> =
+  compositionLocalOf {
+    throw AssertionError("HostConfiguration was not provided!")
+  }
+
+/**
+ * Expose various configuration properties of the host.
+ *
+ * @see HostConfiguration
+ */
+@Suppress("unused") // Emulating a CompositionLocal.
+public val HostConfiguration.Companion.current: HostConfiguration
+  @Composable
+  @ReadOnlyComposable
+  get() = LocalHostConfiguration.current


### PR DESCRIPTION
This will hold more in the future such as the locale, pixel density, etc. For now we propagate whether the host is in dark mode to get things started.

https://user-images.githubusercontent.com/66577/192565428-61c9db20-764c-40bd-b46b-cdacb343dab3.mov

Refs #355