### PR TITLE
Reduce FlexContainer.measure complexity. Remove calls to measure.

### DIFF
--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexContainer.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexContainer.kt
@@ -453,19 +453,16 @@ public class FlexContainer {
             }
           }
           val childHeightMeasureSpec = getChildHeightMeasureSpecInternal(
-            heightMeasureSpec,
-            child,
-            flexLine.sumCrossSizeBefore,
+            heightMeasureSpec = heightMeasureSpec,
+            flexItem = child,
+            padding = flexLine.sumCrossSizeBefore,
           )
           val childWidthMeasureSpec = MeasureSpec.from(newWidth, MeasureSpecMode.Exactly)
           child.applyMeasure(childWidthMeasureSpec, childHeightMeasureSpec)
           childMeasuredWidth = child.measuredWidth
           childMeasuredHeight = child.measuredHeight
         }
-        largestCrossSize = maxOf(
-          largestCrossSize,
-          childMeasuredHeight + child.margin.top + child.margin.bottom,
-        )
+        largestCrossSize = maxOf(largestCrossSize, childMeasuredHeight + child.margin.top + child.margin.bottom)
         flexLine.mainSize += (childMeasuredWidth + child.margin.start + child.margin.end)
       } else {
         // The direction of the main axis is vertical
@@ -510,10 +507,7 @@ public class FlexContainer {
           childMeasuredWidth = child.measuredWidth
           childMeasuredHeight = child.measuredHeight
         }
-        largestCrossSize = maxOf(
-          largestCrossSize,
-          childMeasuredWidth + child.margin.start + child.margin.end,
-        )
+        largestCrossSize = maxOf(largestCrossSize, childMeasuredWidth + child.margin.start + child.margin.end)
         flexLine.mainSize += (childMeasuredHeight + child.margin.top + child.margin.bottom)
       }
       flexLine.crossSize = maxOf(flexLine.crossSize, largestCrossSize)

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexContainer.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexContainer.kt
@@ -656,10 +656,7 @@ public class FlexContainer {
           childMeasuredWidth = child.measuredWidth
           childMeasuredHeight = child.measuredHeight
         }
-        largestCrossSize = maxOf(
-          largestCrossSize,
-          childMeasuredWidth + child.margin.start + child.margin.end,
-        )
+        largestCrossSize = maxOf(largestCrossSize, childMeasuredWidth + child.margin.start + child.margin.end)
         flexLine.mainSize += (childMeasuredHeight + child.margin.top + child.margin.bottom)
       }
       flexLine.crossSize = maxOf(flexLine.crossSize, largestCrossSize)

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/Measurable.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/Measurable.kt
@@ -32,21 +32,33 @@ public open class Measurable {
    */
   public open val height: Int = WrapContent
 
-  public open fun minIntrinsicWidth(height: Int): Int {
-    return 0
-  }
+  /**
+   * The minimum width attribute of the item.
+   *
+   * The attribute determines the minimum width the child can shrink to.
+   */
+  public open val minWidth: Int = 0
 
-  public open fun minIntrinsicHeight(width: Int): Int {
-    return 0
-  }
+  /**
+   * The minimum height attribute of the item.
+   *
+   * The attribute determines the minimum height the child can shrink to.
+   */
+  public open val minHeight: Int = 0
 
-  public open fun maxIntrinsicWidth(height: Int): Int {
-    return Int.MAX_VALUE
-  }
+  /**
+   * The maximum width attribute of the item.
+   *
+   * The attribute determines the maximum width the child can expand to.
+   */
+  public open val maxWidth: Int = Int.MAX_VALUE
 
-  public open fun maxIntrinsicHeight(width: Int): Int {
-    return Int.MAX_VALUE
-  }
+  /**
+   * The maximum height attribute of the item.
+   *
+   * The attribute determines the maximum height the child can expand to.
+   */
+  public open val maxHeight: Int = Int.MAX_VALUE
 
   public open fun measure(widthSpec: MeasureSpec, heightSpec: MeasureSpec): Size {
     return Size(
@@ -69,23 +81,3 @@ public open class Measurable {
     public const val WrapContent: Int = -2
   }
 }
-
-/**
- * Returns the absolute minimum width an item can be displayed at.
- */
-public val Measurable.minWidth: Int get() = minIntrinsicWidth(0)
-
-/**
- * Returns the absolute minimum height an item can be displayed at.
- */
-public val Measurable.minHeight: Int get() = minIntrinsicHeight(0)
-
-/**
- * Returns the absolute maximum width an item can be displayed at.
- */
-public val Measurable.maxWidth: Int get() = maxIntrinsicWidth(Int.MAX_VALUE)
-
-/**
- * Returns the absolute maximum height an item can be displayed at.
- */
-public val Measurable.maxHeight: Int get() = maxIntrinsicHeight(Int.MAX_VALUE)

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/Measurable.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/Measurable.kt
@@ -32,31 +32,21 @@ public open class Measurable {
    */
   public open val height: Int = WrapContent
 
-  /**
-   * The minimum width attribute of the item.
-   *
-   * The attribute determines the minimum width the child can shrink to.
-   */
-  public open val minWidth: Int = 0
+  public open fun minIntrinsicWidth(height: Int): Int {
+    return 0
+  }
 
-  /**
-   * The minimum height attribute of the item.
-   *
-   * The attribute determines the minimum height the child can shrink to.
-   */
-  public open val minHeight: Int = 0
+  public open fun minIntrinsicHeight(width: Int): Int {
+    return 0
+  }
 
-  /**
-   * The maximum width attribute of the item.
-   *
-   * The attribute determines the maximum width the child can expand to.
-   */
-  public open val maxWidth: Int = Int.MAX_VALUE
+  public open fun maxIntrinsicWidth(height: Int): Int {
+    return Int.MAX_VALUE
+  }
 
-  /**
-   * The maximum height attribute of the item.
-   */
-  public open val maxHeight: Int = Int.MAX_VALUE
+  public open fun maxIntrinsicHeight(width: Int): Int {
+    return Int.MAX_VALUE
+  }
 
   public open fun measure(widthSpec: MeasureSpec, heightSpec: MeasureSpec): Size {
     return Size(
@@ -79,3 +69,23 @@ public open class Measurable {
     public const val WrapContent: Int = -2
   }
 }
+
+/**
+ * Returns the absolute minimum width an item can be displayed at.
+ */
+public val Measurable.minWidth: Int get() = minIntrinsicWidth(0)
+
+/**
+ * Returns the absolute minimum height an item can be displayed at.
+ */
+public val Measurable.minHeight: Int get() = minIntrinsicHeight(0)
+
+/**
+ * Returns the absolute maximum width an item can be displayed at.
+ */
+public val Measurable.maxWidth: Int get() = maxIntrinsicWidth(Int.MAX_VALUE)
+
+/**
+ * Returns the absolute maximum height an item can be displayed at.
+ */
+public val Measurable.maxHeight: Int get() = maxIntrinsicHeight(Int.MAX_VALUE)

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/Orientation.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/Orientation.kt
@@ -19,53 +19,47 @@ internal fun FlexDirection.toOrientation(): Orientation {
   return if (isHorizontal) Orientation.Horizontal else Orientation.Vertical
 }
 
+internal fun Orientation.mainMeasuredSizeWithMargin(node: FlexItem): Int =
+  mainMeasuredSize(node) + mainMargin(node)
+
+internal fun Orientation.crossMeasuredSizeWithMargin(node: FlexItem): Int =
+  crossMeasuredSize(node) + crossMargin(node)
+
 /**
  * An interface to perform operations along the main/cross axis without knowledge
  * of the underlying [FlexDirection].
  */
 internal sealed interface Orientation {
-  fun mainPaddingStart(padding: Spacing): Int
-  fun mainPaddingEnd(padding: Spacing): Int
-  fun crossPaddingStart(padding: Spacing): Int
-  fun crossPaddingEnd(padding: Spacing): Int
+  fun mainPadding(padding: Spacing): Int
+  fun crossPadding(padding: Spacing): Int
 
-  fun mainSize(node: FlexItem): Int
-  fun crossSize(node: FlexItem): Int
-  fun mainMeasuredSize(node: FlexItem): Int
-  fun crossMeasuredSize(node: FlexItem): Int
+  fun mainMargin(item: FlexItem): Int
+  fun crossMargin(item: FlexItem): Int
 
-  fun mainMarginStart(node: FlexItem): Int
-  fun mainMarginEnd(node: FlexItem): Int
-  fun crossMarginStart(node: FlexItem): Int
-  fun crossMarginEnd(node: FlexItem): Int
+  fun mainSize(item: FlexItem): Int
+  fun crossSize(item: FlexItem): Int
+  fun mainMeasuredSize(item: FlexItem): Int
+  fun crossMeasuredSize(item: FlexItem): Int
 
   object Horizontal : Orientation {
-    override fun mainPaddingStart(padding: Spacing) = padding.start
-    override fun mainPaddingEnd(padding: Spacing) = padding.end
-    override fun crossPaddingStart(padding: Spacing) = padding.top
-    override fun crossPaddingEnd(padding: Spacing) = padding.bottom
-    override fun mainSize(node: FlexItem) = node.measurable.width
-    override fun crossSize(node: FlexItem) = node.measurable.height
-    override fun mainMeasuredSize(node: FlexItem) = node.measuredWidth
-    override fun crossMeasuredSize(node: FlexItem) = node.measuredHeight
-    override fun mainMarginStart(node: FlexItem) = node.margin.start
-    override fun mainMarginEnd(node: FlexItem) = node.margin.end
-    override fun crossMarginStart(node: FlexItem) = node.margin.top
-    override fun crossMarginEnd(node: FlexItem) = node.margin.bottom
+    override fun mainPadding(padding: Spacing) = padding.start + padding.end
+    override fun crossPadding(padding: Spacing) = padding.top + padding.bottom
+    override fun mainMargin(item: FlexItem) = item.margin.start + item.margin.end
+    override fun crossMargin(item: FlexItem) = item.margin.top + item.margin.bottom
+    override fun mainSize(item: FlexItem) = item.measurable.width
+    override fun crossSize(item: FlexItem) = item.measurable.height
+    override fun mainMeasuredSize(item: FlexItem) = item.measuredWidth
+    override fun crossMeasuredSize(item: FlexItem) = item.measuredHeight
   }
 
   object Vertical : Orientation {
-    override fun mainPaddingStart(padding: Spacing) = padding.top
-    override fun mainPaddingEnd(padding: Spacing) = padding.bottom
-    override fun crossPaddingStart(padding: Spacing) = padding.start
-    override fun crossPaddingEnd(padding: Spacing) = padding.end
-    override fun mainSize(node: FlexItem) = node.measurable.height
-    override fun crossSize(node: FlexItem) = node.measurable.width
-    override fun mainMeasuredSize(node: FlexItem) = node.measuredHeight
-    override fun crossMeasuredSize(node: FlexItem) = node.measuredWidth
-    override fun mainMarginStart(node: FlexItem) = node.margin.top
-    override fun mainMarginEnd(node: FlexItem) = node.margin.bottom
-    override fun crossMarginStart(node: FlexItem) = node.margin.start
-    override fun crossMarginEnd(node: FlexItem) = node.margin.end
+    override fun mainPadding(padding: Spacing) = padding.top + padding.bottom
+    override fun crossPadding(padding: Spacing) = padding.start + padding.end
+    override fun mainMargin(item: FlexItem) = item.margin.top + item.margin.bottom
+    override fun crossMargin(item: FlexItem) = item.margin.start + item.margin.end
+    override fun mainSize(item: FlexItem) = item.measurable.height
+    override fun crossSize(item: FlexItem) = item.measurable.width
+    override fun mainMeasuredSize(item: FlexItem) = item.measuredHeight
+    override fun crossMeasuredSize(item: FlexItem) = item.measuredWidth
   }
 }


### PR DESCRIPTION
Reduces the number of branching paths based on `FlexDirection.isHorizontal` and uses `Orientation` instead.

Also removes several calls to `measure`. I think the remaining calls (except the main `measure` call) can be replaced by `minIntrinsicWidth(height: Int)`, etc. calls in a separate PR.