### PR TITLE
Force widget and layout modifier tags to be 1-999,999

### DIFF
--- a/redwood-layout-schema/src/main/kotlin/app/cash/redwood/layout/modifiers.kt
+++ b/redwood-layout-schema/src/main/kotlin/app/cash/redwood/layout/modifiers.kt
@@ -19,25 +19,25 @@ import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.schema.LayoutModifier
 
 /** Grow the node relative to [value] along the main axis. */
-@LayoutModifier(1_000_001)
+@LayoutModifier(1)
 public data class GrowLayoutModifier(
   val value: Int,
 )
 
 /** Shrink the node relative to [value] along the main axis. */
-@LayoutModifier(1_000_002)
+@LayoutModifier(2)
 public data class ShrinkLayoutModifier(
   val value: Int,
 )
 
 /** Set the alignment for a node along the horizontal axis. */
-@LayoutModifier(1_000_003)
+@LayoutModifier(3)
 public data class HorizontalAlignmentLayoutModifier(
   val alignment: CrossAxisAlignment,
 )
 
 /** Set the alignment for a node along the vertical axis. */
-@LayoutModifier(1_000_004)
+@LayoutModifier(4)
 public data class VerticalAlignmentLayoutModifier(
   val alignment: CrossAxisAlignment,
 )

--- a/redwood-layout-schema/src/main/kotlin/app/cash/redwood/layout/widgets.kt
+++ b/redwood-layout-schema/src/main/kotlin/app/cash/redwood/layout/widgets.kt
@@ -24,7 +24,7 @@ import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Widget
 
-@Widget(1_000_001)
+@Widget(1)
 public data class Row(
   @Property(1) @Default("Padding.Zero")
   val padding: Padding,
@@ -39,7 +39,7 @@ public data class Row(
 
 public object RowScope
 
-@Widget(1_000_002)
+@Widget(2)
 public data class Column(
   @Property(1) @Default("Padding.Zero")
   val padding: Padding,

--- a/redwood-schema/src/test/kotlin/app/cash/redwood/schema/parser/SchemaParserTest.kt
+++ b/redwood-schema/src/test/kotlin/app/cash/redwood/schema/parser/SchemaParserTest.kt
@@ -452,4 +452,84 @@ class SchemaParserTest {
     val widget = schema.widgets.single()
     assertThat(widget.traits).isEmpty()
   }
+
+  @Schema(
+    [
+      OneMillionWidget::class,
+    ],
+  )
+  interface OneMillionWidgetSchema
+
+  @Widget(1_000_000)
+  object OneMillionWidget
+
+  @Test fun widgetTagOneMillionThrows() {
+    assertThrows<IllegalArgumentException> {
+      parseSchema(OneMillionWidgetSchema::class)
+    }.hasMessageThat().isEqualTo(
+      "@Widget app.cash.redwood.schema.parser.SchemaParserTest.OneMillionWidget " +
+        "tag must be in range [1, 1000000): 1000000",
+    )
+  }
+
+  @Schema(
+    [
+      ZeroWidget::class,
+    ],
+  )
+  interface ZeroWidgetSchema
+
+  @Widget(0)
+  object ZeroWidget
+
+  @Test fun widgetTagZeroThrows() {
+    assertThrows<IllegalArgumentException> {
+      parseSchema(ZeroWidgetSchema::class)
+    }.hasMessageThat().isEqualTo(
+      "@Widget app.cash.redwood.schema.parser.SchemaParserTest.ZeroWidget " +
+        "tag must be in range [1, 1000000): 0",
+    )
+  }
+
+  @Schema(
+    [
+      OneMillionLayoutModifier::class,
+    ],
+  )
+  interface OneMillionLayoutModifierSchema
+
+  @LayoutModifier(1_000_000)
+  data class OneMillionLayoutModifier(
+    val value: Int,
+  )
+
+  @Test fun layoutModifierTagOneMillionThrows() {
+    assertThrows<IllegalArgumentException> {
+      parseSchema(OneMillionLayoutModifierSchema::class)
+    }.hasMessageThat().isEqualTo(
+      "@LayoutModifier app.cash.redwood.schema.parser.SchemaParserTest.OneMillionLayoutModifier " +
+        "tag must be in range [1, 1000000): 1000000",
+    )
+  }
+
+  @Schema(
+    [
+      ZeroLayoutModifier::class,
+    ],
+  )
+  interface ZeroLayoutModifierSchema
+
+  @LayoutModifier(0)
+  data class ZeroLayoutModifier(
+    val value: Int,
+  )
+
+  @Test fun layoutModifierTagZeroThrows() {
+    assertThrows<IllegalArgumentException> {
+      parseSchema(ZeroLayoutModifierSchema::class)
+    }.hasMessageThat().isEqualTo(
+      "@LayoutModifier app.cash.redwood.schema.parser.SchemaParserTest.ZeroLayoutModifier " +
+        "tag must be in range [1, 1000000): 0",
+    )
+  }
 }


### PR DESCRIPTION
This is effectively the lower 6 decimal digits (excluding 0). The upper 4 decimal digits will be used for dependent schema versioning (up to 4000).