### PR TITLE
Update AGP to 7.3.0 and Java to 18.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3.5.1
         with:
           distribution: 'zulu'
-          java-version: 14
+          java-version: 19
       - uses: gradle/gradle-build-action@v2
 
       - run: ./gradlew build dokkaHtmlMultiModule --parallel

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3.5.1
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 18
       - uses: gradle/gradle-build-action@v2
 
       - run: ./gradlew build dokkaHtmlMultiModule --parallel

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ google-material = { module = "com.google.android.material:material", version = "
 
 jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jbComposeRuntime" }
 
-androidGradlePlugin = { module = "com.android.tools.build:gradle", version = "7.2.2" }
+androidGradlePlugin = { module = "com.android.tools.build:gradle", version = "7.3.0" }
 kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.11.0" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.1.0" }
 junit = { module = "junit:junit", version = "4.13.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.1.0" }
 junit = { module = "junit:junit", version = "4.13.1" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.1" }
 truth = { module = "com.google.truth:truth", version = "1.1" }
-robolectric = { module = "org.robolectric:robolectric", version = "4.5.1" }
+robolectric = { module = "org.robolectric:robolectric", version = "4.9" }
 okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
 okHttp = { module = "com.squareup.okhttp3:okhttp", version = "4.9.1" }
 zipline = { module = "app.cash.zipline:zipline", version.ref = "zipline" }


### PR DESCRIPTION
Bumping AGP to 7.3.0 should fix the Dokka issue we're seeing on `trunk`: https://github.com/Kotlin/dokka/issues/2472. Java 19 will be supported in the next version of Gradle.