### PR TITLE
Fix scheduling 2 CI jobs for PRs.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - '**'
-    tags-ignore:
-      - '**'
+      - trunk
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"


### PR DESCRIPTION
Currently, we're scheduling 2 identical `build` CI jobs for PRs that are from branches inside the Redwood repo as they match both the `pull_request` and `push` triggers.

Unfortunately it doesn't look like there's a straightforward way to fix this duplication so I suggest we do the same as OkHttp and only build pull requests and `trunk`. This means CI won't build branches unless there's an associated PR. Open to suggestions!