### PR TITLE
Remove FlexItem.layout and store the bounds on the FlexItem.

### DIFF
--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexItem.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexItem.kt
@@ -101,7 +101,7 @@ public class FlexItem(
   public val margin: Spacing = Spacing.Zero,
 
   /**
-   * A callback to to measure this item according to a set of measurement constraints.
+   * A callback to measure this item according to a set of measurement constraints.
    */
   public var measurable: Measurable = Measurable(),
 ) {

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexItem.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexItem.kt
@@ -84,9 +84,9 @@ public class FlexItem(
   /**
    * The wrapBefore attribute of the item.
    *
-   * The attribute forces a flex line wrapping. i.e. if this is set to `true` for a
+   * The attribute forces a flex line wrapping. i.e. if this is set to `true` for an
    * item, the item will become the first item of the new flex line. (A wrapping happens
-   * regardless of the items being processed in the the previous flex line)
+   * regardless of the items being processed in the previous flex line)
    * This attribute is ignored if the flex_wrap attribute is set as nowrap.
    * The equivalent attribute isn't defined in the original CSS Flexible Box Module
    * specification, but having this attribute is useful for Android developers to flatten
@@ -103,26 +103,18 @@ public class FlexItem(
   /**
    * A callback to measure this item according to a set of measurement constraints.
    */
-  public var measurable: Measurable = Measurable(),
+  public val measurable: Measurable = Measurable(),
 ) {
-  /**
-   * The measured width after invoking [Measurable.measure].
-   *
-   * TODO: Remove this mutable attribute and use the returned [Size] from [Measurable.measure].
-   */
-  public var measuredWidth: Int = -1
 
-  /**
-   * The measured height after invoking [Measurable.measure].
-   *
-   * TODO: Remove this mutable attribute and use the returned [Size] from [Measurable.measure].
-   */
+  /** The item's size after invoking [FlexContainer.measure]. */
+  public var measuredWidth: Int = -1
   public var measuredHeight: Int = -1
 
-  /**
-   * A callback to place the item inside a given set of coordinates.
-   */
-  public var layout: (left: Int, top: Int, right: Int, bottom: Int) -> Unit = { _, _, _, _ -> }
+  /** The item's bounds after invoking [FlexContainer.layout]. */
+  public var left: Int = -1
+  public var top: Int = -1
+  public var right: Int = -1
+  public var bottom: Int = -1
 
   public companion object {
     /** The default value for the baseline attribute */

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/MeasureResult.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/MeasureResult.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.flexcontainer
+
+/**
+ * Holds the state produced by calling [FlexContainer.measure].
+ */
+public class MeasureResult internal constructor(
+  internal val flexLines: List<FlexLine>,
+  public val containerSize: Size,
+)

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/utils.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/utils.kt
@@ -37,6 +37,16 @@ internal inline fun FlexItem.layout(left: Int, top: Int, right: Int, bottom: Int
 internal val FlexLine.itemCountVisible: Int
   get() = itemCount - invisibleItemCount
 
+/** The largest main size of all flex lines. */
+internal fun List<FlexLine>.getLargestMainSize(): Int {
+  return if (isEmpty()) Int.MIN_VALUE else maxOf { it.mainSize }
+}
+
+/** The sum of the cross sizes of all flex lines. */
+internal fun List<FlexLine>.getSumOfCrossSize(): Int {
+  return sumOf { it.crossSize }
+}
+
 internal fun MeasureSpec.Companion.getChildMeasureSpec(
   spec: MeasureSpec,
   padding: Int,

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/utils.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/utils.kt
@@ -27,10 +27,11 @@ internal fun AlignSelf.toAlignItems() = when (this) {
   else -> throw AssertionError()
 }
 
-/** Convenience function to use named arguments. */
-@Suppress("EXTENSION_FUNCTION_SHADOWED_BY_MEMBER_PROPERTY_WITH_INVOKE", "NOTHING_TO_INLINE")
-internal inline fun FlexItem.layout(left: Int, top: Int, right: Int, bottom: Int) {
-  layout(left, top, right, bottom)
+internal fun FlexItem.layout(left: Int, top: Int, right: Int, bottom: Int) {
+  this.left = left
+  this.top = top
+  this.right = right
+  this.bottom = bottom
 }
 
 /** The number of items who are not invisible in this flex line. */

--- a/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerStringCanvasTest.kt
+++ b/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerStringCanvasTest.kt
@@ -277,14 +277,8 @@ class FlexContainerStringCanvasTest {
     val widthSpec = MeasureSpec.from(width, MeasureSpecMode.Exactly)
     val heightSpec = MeasureSpec.from(height, MeasureSpecMode.Exactly)
 
-    flexLines = if (flexDirection.isHorizontal) {
-      calculateHorizontalFlexLines(widthSpec, heightSpec)
-    } else {
-      calculateVerticalFlexLines(widthSpec, heightSpec)
-    }
-
-    measure(widthSpec, heightSpec)
-    layout(0, 0, width, height)
+    val result = measure(widthSpec, heightSpec)
+    layout(result, Size(width, height))
 
     for (widget in widgets) {
       widget.draw(canvas)

--- a/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerStringCanvasTest.kt
+++ b/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerStringCanvasTest.kt
@@ -33,7 +33,7 @@ class FlexContainerStringCanvasTest {
     val widgets = imdbTop4.map { StringWidget(it) }
     val container = FlexContainer().apply {
       flexDirection = Column
-      items += widgets.map { it.toNode() }
+      items += widgets.map { it.flexItem }
     }
 
     assertEquals(
@@ -69,7 +69,7 @@ class FlexContainerStringCanvasTest {
     val container = FlexContainer().apply {
       flexDirection = Column
       justifyContent = JustifyContent.Center
-      items += widgets.map { it.toNode() }
+      items += widgets.map { it.flexItem }
     }
 
     assertEquals(
@@ -107,7 +107,7 @@ class FlexContainerStringCanvasTest {
     val container = FlexContainer().apply {
       flexDirection = Column
       alignItems = AlignItems.Center
-      items += widgets.map { it.toNode() }
+      items += widgets.map { it.flexItem }
     }
 
     assertEquals(
@@ -143,7 +143,7 @@ class FlexContainerStringCanvasTest {
     val container = FlexContainer().apply {
       flexDirection = Column
       alignItems = AlignItems.Stretch
-      items += widgets.map { it.toNode() }
+      items += widgets.map { it.flexItem }
     }
 
     assertEquals(
@@ -180,7 +180,7 @@ class FlexContainerStringCanvasTest {
     val widgets = imdbTop4.map { StringWidget(it) }
     val container = FlexContainer().apply {
       flexDirection = Row
-      items += widgets.map { it.toNode() }
+      items += widgets.map { it.flexItem }
     }
 
     assertEquals(
@@ -204,7 +204,9 @@ class FlexContainerStringCanvasTest {
     val container = FlexContainer().apply {
       flexDirection = Row
       justifyContent = JustifyContent.Center
-      items += widgets.map { it.toNode(FlexItem(flexBasisPercent = 0f)) }
+      items += widgets.map { widget ->
+        FlexItem(flexBasisPercent = 0f, measurable = widget).also { widget.flexItem = it }
+      }
     }
 
     assertEquals(
@@ -226,7 +228,7 @@ class FlexContainerStringCanvasTest {
     val container = FlexContainer().apply {
       flexDirection = Row
       alignItems = AlignItems.Center
-      items += widgets.map { it.toNode() }
+      items += widgets.map { it.flexItem }
     }
 
     assertEquals(
@@ -250,7 +252,7 @@ class FlexContainerStringCanvasTest {
     val container = FlexContainer().apply {
       flexDirection = Row
       alignItems = AlignItems.Stretch
-      items += widgets.map { it.toNode() }
+      items += widgets.map { it.flexItem }
     }
 
     assertEquals(
@@ -285,12 +287,5 @@ class FlexContainerStringCanvasTest {
     }
 
     return canvas.toString()
-  }
-
-  private fun StringWidget.toNode(item: FlexItem = FlexItem()): FlexItem {
-    return item.apply {
-      this.measurable = this@toNode
-      this.layout = this@toNode::layout
-    }
   }
 }

--- a/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerTest.kt
+++ b/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerTest.kt
@@ -38,11 +38,12 @@ class FlexContainerTest {
     container.items += item2
     container.items += item3
     container.items += item4
+    container.flexDirection = FlexDirection.Row
     container.flexWrap = FlexWrap.Wrap
     val widthMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
     val heightMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
 
-    val lines = container.calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec)
+    val lines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
 
     assertEquals(3, lines.size)
     assertEquals(300, lines[0].mainSize)
@@ -73,12 +74,12 @@ class FlexContainerTest {
     container.items += item2
     container.items += item3
     container.items += item4
-    container.flexWrap = FlexWrap.Wrap
     container.flexDirection = FlexDirection.Column
+    container.flexWrap = FlexWrap.Wrap
     val widthMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
     val heightMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
 
-    val lines = container.calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec)
+    val lines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
 
     assertEquals(3, lines.size)
     assertEquals(300, lines[0].mainSize)
@@ -113,8 +114,8 @@ class FlexContainerTest {
     container.flexWrap = FlexWrap.Wrap
     val widthMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
     val heightMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
-    container.flexLines = container.calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     assertEquals(100, item1.measuredWidth)
     assertEquals(100, item1.measuredHeight)
@@ -142,8 +143,8 @@ class FlexContainerTest {
     container.flexWrap = FlexWrap.Wrap
     val widthMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
     val heightMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
-    container.flexLines = container.calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     assertEquals(100, item1.measuredWidth)
     assertEquals(100, item1.measuredHeight)
@@ -171,8 +172,8 @@ class FlexContainerTest {
     container.flexWrap = FlexWrap.NoWrap
     val widthMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
     val heightMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
-    container.flexLines = container.calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     // Flex shrink is set to 1.0 (default value) for all views.
     // They should be shrank equally for the amount overflown the width
@@ -200,8 +201,8 @@ class FlexContainerTest {
     container.flexWrap = FlexWrap.NoWrap
     val widthMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
     val heightMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
-    container.flexLines = container.calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     // Flex shrink is set to 1.0 (default value) for all views.
     // They should be shrank equally for the amount overflown the height
@@ -224,8 +225,8 @@ class FlexContainerTest {
     container.flexWrap = FlexWrap.NoWrap
     val widthMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.AtMost)
     val heightMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
-    container.flexLines = container.calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     // Container with WRAP_CONTENT and a max width forces resizable children to shrink
     // to avoid exceeding max available space.
@@ -244,8 +245,8 @@ class FlexContainerTest {
     container.flexWrap = FlexWrap.NoWrap
     val widthMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.AtMost)
     val heightMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Unspecified)
-    container.flexLines = container.calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     // Container with WRAP_CONTENT and a max width forces resizable children to shrink
     // to avoid exceeding max available space.
@@ -269,10 +270,10 @@ class FlexContainerTest {
     container.alignContent = AlignContent.Stretch
     val widthMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
     val heightMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Exactly)
-    container.flexLines = container.calculateHorizontalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
-    container.determineCrossSize(widthMeasureSpec, heightMeasureSpec, 0)
-    container.stretchChildren()
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
+    container.determineCrossSize(flexLines, widthMeasureSpec, heightMeasureSpec)
+    container.stretchChildren(flexLines)
 
     // align content is set to Align.STRETCH, the cross size for each flex line is stretched
     // to distribute the remaining free space along the cross axis
@@ -298,10 +299,10 @@ class FlexContainerTest {
     container.alignContent = AlignContent.Stretch
     val widthMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Exactly)
     val heightMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
-    container.flexLines = container.calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    container.determineMainSize(widthMeasureSpec, heightMeasureSpec)
-    container.determineCrossSize(widthMeasureSpec, heightMeasureSpec, 0)
-    container.stretchChildren()
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
+    container.determineCrossSize(flexLines, widthMeasureSpec, heightMeasureSpec)
+    container.stretchChildren(flexLines)
 
     // align content is set to Align.STRETCH, the cross size for each flex line is stretched
     // to distribute the remaining free space along the cross axis
@@ -344,11 +345,11 @@ class FlexContainerTest {
     }
     val widthMeasureSpec = MeasureSpec.from(1000, MeasureSpecMode.Exactly)
     val heightMeasureSpec = MeasureSpec.from(500, MeasureSpecMode.Exactly)
-    container.flexLines = container.calculateVerticalFlexLines(widthMeasureSpec, heightMeasureSpec)
-    assertEquals(3, container.flexLines.size)
-    assertTrue(container.flexLines[0].anyItemsHaveFlexGrow)
-    assertFalse(container.flexLines[1].anyItemsHaveFlexGrow)
-    assertTrue(container.flexLines[2].anyItemsHaveFlexGrow)
+    val flexLines = container.calculateFlexLines(widthMeasureSpec, heightMeasureSpec)
+    assertEquals(3, flexLines.size)
+    assertTrue(flexLines[0].anyItemsHaveFlexGrow)
+    assertFalse(flexLines[1].anyItemsHaveFlexGrow)
+    assertTrue(flexLines[2].anyItemsHaveFlexGrow)
   }
 
   class BoxMeasurable(

--- a/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerTest.kt
+++ b/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/FlexContainerTest.kt
@@ -176,7 +176,7 @@ class FlexContainerTest {
     container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     // Flex shrink is set to 1.0 (default value) for all views.
-    // They should be shrank equally for the amount overflown the width
+    // They should be shrunk equally for the amount overflown the width
     assertEquals(125, item1.measuredWidth)
     assertEquals(100, item1.measuredHeight)
     assertEquals(125, item2.measuredWidth)
@@ -205,7 +205,7 @@ class FlexContainerTest {
     container.determineMainSize(flexLines, widthMeasureSpec, heightMeasureSpec)
 
     // Flex shrink is set to 1.0 (default value) for all views.
-    // They should be shrank equally for the amount overflown the height
+    // They should be shrunk equally for the amount overflown the height
     assertEquals(100, item1.measuredWidth)
     assertEquals(125, item1.measuredHeight)
     assertEquals(100, item2.measuredWidth)

--- a/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/StringWidget.kt
+++ b/redwood-flex-container/src/commonTest/kotlin/app/cash/redwood/flexcontainer/StringWidget.kt
@@ -24,10 +24,7 @@ class StringWidget(
 ) : Measurable() {
   private val words = text.split(" ")
 
-  private var left = -1
-  private var top = -1
-  private var right = -1
-  private var bottom = -1
+  var flexItem = FlexItem(measurable = this)
 
   override val minWidth
     get() = words.maxOf { it.length } + 2
@@ -64,13 +61,6 @@ class StringWidget(
     return Size(measuredWidth, measuredHeight)
   }
 
-  internal fun layout(left: Int, top: Int, right: Int, bottom: Int) {
-    this.left = left
-    this.top = top
-    this.right = right
-    this.bottom = bottom
-  }
-
   /** Returns a list of rows, each containing the words of that row. */
   private fun lines(maxWidth: Int): List<List<String>> {
     var i = 0
@@ -103,6 +93,10 @@ class StringWidget(
   }
 
   fun draw(canvas: StringCanvas) {
+    val left = flexItem.left
+    val top = flexItem.top
+    val right = flexItem.right
+    val bottom = flexItem.bottom
     val lines = lines(maxWidth = right - left - 2)
 
     var y = top

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/ViewFlexContainer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/ViewFlexContainer.kt
@@ -24,7 +24,9 @@ import app.cash.redwood.flexcontainer.AlignItems
 import app.cash.redwood.flexcontainer.FlexContainer
 import app.cash.redwood.flexcontainer.FlexDirection
 import app.cash.redwood.flexcontainer.JustifyContent
+import app.cash.redwood.flexcontainer.MeasureResult
 import app.cash.redwood.flexcontainer.MeasureSpec as RedwoodMeasureSpec
+import app.cash.redwood.flexcontainer.Size
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.widget.MutableListChildren
@@ -83,15 +85,17 @@ internal class ViewFlexContainer(context: Context, direction: FlexDirection) {
 
   private inner class HostView(context: Context) : ViewGroup(context) {
 
+    private lateinit var measureResult: MeasureResult
+
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
       val widthSpec = RedwoodMeasureSpec.fromAndroid(widthMeasureSpec)
       val heightSpec = RedwoodMeasureSpec.fromAndroid(heightMeasureSpec)
-      val (width, height) = container.measure(widthSpec, heightSpec)
-      setMeasuredDimension(width, height)
+      measureResult = container.measure(widthSpec, heightSpec)
+      setMeasuredDimension(measureResult.containerSize.width, measureResult.containerSize.height)
     }
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-      container.layout(left, top, right, bottom)
+      container.layout(measureResult, Size(right - left, bottom - top))
     }
   }
 }

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/utils.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/utils.kt
@@ -69,12 +69,9 @@ internal fun MeasureSpecMode.toAndroid(): Int = when (this) {
   else -> throw AssertionError()
 }
 
-internal fun View.asItem() = FlexItem().apply {
-  measurable = ViewMeasurable(this@asItem)
-  layout = ::layout
-}
+internal fun View.asItem() = FlexItem(measurable = ViewMeasurable(this@asItem))
 
-private class ViewMeasurable(val view: View) : Measurable() {
+private class ViewMeasurable(private val view: View) : Measurable() {
   override val width get() = view.layoutParams.width
   override val height get() = view.layoutParams.height
   override val minWidth get() = view.minimumWidth


### PR DESCRIPTION
Resolves: https://github.com/cashapp/redwood/issues/396