### PR TITLE
Remove release build type from Android apps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,17 @@ allprojects {
     }
   }
 
+  // Disable the release build type because we never need it for sample applications.
+  plugins.withId('com.android.application') {
+    project.android {
+      variantFilter { variant ->
+        if (variant.buildType.name == 'release') {
+          variant.ignore = true
+        }
+      }
+    }
+  }
+
   plugins.withId('com.vanniktech.maven.publish.base') {
     group = project.property("GROUP") as String
     version = project.property("VERSION_NAME") as String


### PR DESCRIPTION
This should result in only a single variant remaining: a debug variant. Reduces the amount of tasks that run locally and on CI when you do an 'assemble'.

Before:

    $ ga --dry-run | \grep SKIPPED | wc -l
          1879

After:

    $ ga --dry-run | \grep SKIPPED | wc -l
          1761