### PR TITLE
Remove release build type from iOS apps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+
 buildscript {
   dependencies {
     classpath libs.kotlin.gradlePlugin
@@ -96,6 +99,25 @@ allprojects {
       freeCompilerArgs += [
         '-Xjvm-default=all',
       ]
+    }
+  }
+
+  // Disable the release linking tasks because we never need it for iOS sample applications.
+  // TODO Switch to https://youtrack.jetbrains.com/issue/KT-54424 when it is supported.
+  plugins.withId('org.jetbrains.kotlin.multiplatform') {
+    kotlin {
+      targets.withType(KotlinNativeTarget) {
+        binaries.all {
+          if (it.buildType == NativeBuildType.RELEASE) {
+            it.linkTask.enabled = false
+          }
+        }
+      }
+    }
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask).configureEach {
+      if (it.name.contains("Release")) {
+        it.enabled = false
+      }
     }
   }
 


### PR DESCRIPTION
This keeps only the debug build type through various semi-hacks. Reduces the amount of tasks that run locally and on CI when you do an 'assemble'.

Before:

    $ time gca -q 2> /dev/null

    real	6m16.328s
    user	0m1.360s
    sys	0m0.263s

After:

    $ time gca -q 2> /dev/null

    real	2m59.198s
    user	0m1.239s
    sys	0m0.204s