### PR TITLE
Expose scope as sealed interface

### DIFF
--- a/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
@@ -56,10 +56,7 @@ class ComposeGenerationTest {
     val fileSpec = generateComposable(schema, schema.widgets.single())
     assertThat(fileSpec.toString()).apply {
       contains("scoped: @Composable @ScopedAndUnscopedSchemaComposable RowScope.() -> Unit")
-      contains("RowScope.scoped()")
-
       contains("unscoped: @Composable @ScopedAndUnscopedSchemaComposable () -> Unit")
-      contains("unscoped()")
     }
   }
 
@@ -70,7 +67,7 @@ class ComposeGenerationTest {
     assertThat(fileSpec.toString()).contains(
       """
       |@LayoutScopeMarker
-      |public object RowScope
+      |public sealed interface RowScope
       """.trimMargin(),
     )
   }


### PR DESCRIPTION
To avoid using functions outside of the scope.

Closes #451 

This was the minimal change to fix the problem. I don't think there's much/any value to actually splitting the function across these types unless I've missed something.