### PR TITLE
Generate method references for composable property setters.

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -79,17 +79,17 @@ internal fun generateComposableTargetMarker(schema: Schema): FileSpec {
 @Composable
 @SunspotComposable
 fun SunspotButton(
-  layoutModifier: LayoutModifier = LayoutModifier,
   text: String?,
   enabled: Boolean = true,
-  onClick: (() -> Unit)? = null
+  onClick: (() -> Unit)? = null,
+  layoutModifier: LayoutModifier = LayoutModifier,
 ): Unit {
   RedwoodComposeNode<SunspotWidgetFactory<*>, SunspotButton<*>>(
     factory = SunspotWidgetFactory<*>::SunspotButton,
     update = {
-      set(text) { text(text) }
-      set(enabled) { enabled(enabled) }
-      set(onClick) { onClick(onClick) }
+      set(text, SunspotButton<*>::text)
+      set(enabled, SunspotButton<*>::enabled)
+      set(onClick, SunspotButton<*>::onClick)
     },
   )
 }
@@ -164,14 +164,14 @@ internal fun generateComposable(
           }
 
           val updateLambda = CodeBlock.builder()
-            .add("set(layoutModifier) { layoutModifiers = layoutModifier }\n")
+            .add("set(layoutModifier) { layoutModifiers = it }\n")
 
           val childrenLambda = CodeBlock.builder()
           for (trait in widget.traits) {
             when (trait) {
               is Property,
               is Event, -> {
-                updateLambda.add("set(%1N) { %1N(%1N) }\n", trait.name)
+                updateLambda.add("set(%1N, %2T::%1N)\n", trait.name, widgetType)
               }
               is Children -> {
                 childrenLambda.apply {

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -164,7 +164,7 @@ internal fun generateComposable(
           }
 
           val updateLambda = CodeBlock.builder()
-            .add("set(layoutModifier) { layoutModifiers = it }\n")
+            .add("set(layoutModifier) { layoutModifiers = layoutModifier }\n")
 
           val childrenLambda = CodeBlock.builder()
           for (trait in widget.traits) {


### PR DESCRIPTION
Not sure there's a benefit to this considering the code isn't run on the JVM, but figured I would propose the change.