### PR TITLE
Object surrogates should be private

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
@@ -328,6 +328,7 @@ internal fun generateDiffProducingLayoutModifier(schema: Schema, host: Schema = 
         addType(
           if (layoutModifier.properties.isEmpty()) {
             TypeSpec.objectBuilder(surrogateName)
+              .addModifiers(PRIVATE)
               .addFunction(
                 FunSpec.builder("encode")
                   .returns(JsonElement)


### PR DESCRIPTION
Working on automated tracking of our generated public API and it caught this.