### PR TITLE
Diff-consuming widgets should be internal

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
@@ -205,7 +205,7 @@ internal fun generateDiffConsumingWidget(schema: Schema, widget: Widget, host: S
   return FileSpec.builder(type.packageName, type.simpleName)
     .addType(
       TypeSpec.classBuilder(type)
-        .addModifiers(if (schema === host) PUBLIC else INTERNAL)
+        .addModifiers(INTERNAL)
         .addTypeVariable(typeVariableT)
         .addSuperinterface(protocolType)
         .primaryConstructor(


### PR DESCRIPTION
Was a bug introduced when schema dependencies were added. Caught by forthcoming API tracking thing.