### PR TITLE
Generate method references for composable layout modifier setters.

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -87,6 +87,7 @@ fun SunspotButton(
   RedwoodComposeNode<SunspotWidgetFactory<*>, SunspotButton<*>>(
     factory = SunspotWidgetFactory<*>::SunspotButton,
     update = {
+      set(layoutModifier, SunspotButton<*>::layoutModifiers::set)
       set(text, SunspotButton<*>::text)
       set(enabled, SunspotButton<*>::enabled)
       set(onClick, SunspotButton<*>::onClick)
@@ -164,7 +165,7 @@ internal fun generateComposable(
           }
 
           val updateLambda = CodeBlock.builder()
-            .add("set(layoutModifier) { layoutModifiers = layoutModifier }\n")
+            .add("set(layoutModifier, %T::layoutModifiers::set)\n", widgetType)
 
           val childrenLambda = CodeBlock.builder()
           for (trait in widget.traits) {


### PR DESCRIPTION
Following the same logic as: https://github.com/cashapp/redwood/pull/465