### PR TITLE
Throw an exception on duplicate widget ID

### DIFF
--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
@@ -43,7 +43,10 @@ public class ProtocolDisplay<T : Any>(
         is ChildrenDiff.Insert -> {
           val childWidget = factory.create(childrenDiff.kind) ?: continue
           children.insert(childrenDiff.index, childWidget)
-          nodes[childrenDiff.childId] = Node(childWidget, childrenDiff.id, children)
+          val old = nodes.put(childrenDiff.childId, Node(childWidget, childrenDiff.id, children))
+          require(old == null) {
+            "Insert attempted to replace existing widget with ID ${childrenDiff.childId.value}"
+          }
           node.childIds.add(childrenDiff.index, childrenDiff.childId)
         }
         is ChildrenDiff.Move -> {

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidgetFactoryTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidgetFactoryTest.kt
@@ -16,19 +16,12 @@
 package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.LayoutModifier
-import app.cash.redwood.layout.widget.RedwoodLayoutWidgetFactory
 import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.PropertyDiff
 import example.redwood.compose.TestScope
-import example.redwood.widget.Button
 import example.redwood.widget.DiffConsumingExampleSchemaWidgetFactory
-import example.redwood.widget.ExampleSchemaWidgetFactory
-import example.redwood.widget.Row
-import example.redwood.widget.ScopedRow
-import example.redwood.widget.Space
-import example.redwood.widget.Text
 import example.redwood.widget.TextInput
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -287,27 +280,6 @@ class DiffConsumingWidgetFactoryTest {
     recordingTextInput.onChangeCustomType!!.invoke(10.seconds)
 
     assertEquals(Event(Id(1U), 4U, JsonPrimitive("PT10S")), eventSink.events.single())
-  }
-
-  open class EmptyExampleSchemaWidgetFactory : ExampleSchemaWidgetFactory<Nothing> {
-    override val RedwoodLayout = object : RedwoodLayoutWidgetFactory<Nothing> {
-      override fun Column() = TODO("Not yet implemented")
-      override fun Row() = TODO("Not yet implemented")
-    }
-    override fun Row(): Row<Nothing> = TODO()
-    override fun ScopedRow(): ScopedRow<Nothing> = TODO()
-    override fun Text(): Text<Nothing> = TODO()
-    override fun Button() = object : Button<Nothing> {
-      override val value get() = TODO()
-      override var layoutModifiers: LayoutModifier
-        get() = TODO()
-        set(_) { TODO() }
-
-      override fun text(text: String?) = TODO()
-      override fun onClick(onClick: (() -> Unit)?) = TODO()
-    }
-    override fun TextInput(): TextInput<Nothing> = TODO()
-    override fun Space(): Space<Nothing> = TODO()
   }
 
   class RecordingTextInput : TextInput<Nothing> {

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import app.cash.redwood.LayoutModifier
+import app.cash.redwood.layout.widget.RedwoodLayoutWidgetFactory
+import example.redwood.widget.Button
+import example.redwood.widget.ExampleSchemaWidgetFactory
+import example.redwood.widget.Row
+import example.redwood.widget.ScopedRow
+import example.redwood.widget.Space
+import example.redwood.widget.Text
+import example.redwood.widget.TextInput
+
+open class EmptyExampleSchemaWidgetFactory : ExampleSchemaWidgetFactory<Nothing> {
+  override val RedwoodLayout = object : RedwoodLayoutWidgetFactory<Nothing> {
+    override fun Column() = TODO()
+    override fun Row() = TODO()
+  }
+  override fun Row(): Row<Nothing> = TODO()
+  override fun ScopedRow(): ScopedRow<Nothing> = TODO()
+  override fun Text(): Text<Nothing> = TODO()
+  override fun Button() = object : Button<Nothing> {
+    override val value get() = TODO()
+    override var layoutModifiers: LayoutModifier
+      get() = TODO()
+      set(_) { TODO() }
+
+    override fun text(text: String?) = TODO()
+    override fun onClick(onClick: (() -> Unit)?) = TODO()
+  }
+  override fun TextInput(): TextInput<Nothing> = TODO()
+  override fun Space(): Space<Nothing> = TODO()
+}

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplayTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplayTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import app.cash.redwood.protocol.ChildrenDiff
+import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
+import app.cash.redwood.protocol.Diff
+import app.cash.redwood.protocol.Id
+import app.cash.redwood.widget.MutableListChildren
+import example.redwood.widget.DiffConsumingExampleSchemaWidgetFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ProtocolDisplayTest {
+  @Test fun insertRootIdThrows() {
+    val protocolDisplay = ProtocolDisplay(
+      container = MutableListChildren(),
+      factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory()),
+      eventSink = ::error,
+    )
+    val diff = Diff(
+      childrenDiffs = listOf(
+        ChildrenDiff.Insert(
+          id = Id.Root,
+          tag = RootChildrenTag,
+          childId = Id.Root,
+          kind = 4 /* button */,
+          index = 0,
+        ),
+      ),
+    )
+    val t = assertFailsWith<IllegalArgumentException> {
+      protocolDisplay.sendDiff(diff)
+    }
+    assertEquals("Insert attempted to replace existing widget with ID 0", t.message)
+  }
+
+  @Test fun duplicateIdThrows() {
+    val protocolDisplay = ProtocolDisplay(
+      container = MutableListChildren(),
+      factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory()),
+      eventSink = ::error,
+    )
+    val diff = Diff(
+      childrenDiffs = listOf(
+        ChildrenDiff.Insert(
+          id = Id.Root,
+          tag = RootChildrenTag,
+          childId = Id(1U),
+          kind = 4 /* button */,
+          index = 0,
+        ),
+      ),
+    )
+    protocolDisplay.sendDiff(diff)
+    val t = assertFailsWith<IllegalArgumentException> {
+      protocolDisplay.sendDiff(diff)
+    }
+    assertEquals("Insert attempted to replace existing widget with ID 1", t.message)
+  }
+}


### PR DESCRIPTION
This happening is extremely implausible but technically possible and should only manifest in an insertion attempt for the root ID when the value wraps completely around. An insert for an existing non-zero ID should always be impossible, but is good to have covered.