### PR TITLE
Revert to using 'build' on CI.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
           java-version: 18
       - uses: gradle/gradle-build-action@v2
 
-      - run: ./gradlew build allTests verifyPaparazziDebug dokkaHtmlMultiModule --parallel
+      - run: ./gradlew build verifyPaparazziDebug dokkaHtmlMultiModule --parallel
 
       - name: Build Counter iOS sample
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
           java-version: 18
       - uses: gradle/gradle-build-action@v2
 
-      - run: ./gradlew assemble lint allTests verifyPaparazziDebug dokkaHtmlMultiModule --parallel
+      - run: ./gradlew build allTests verifyPaparazziDebug dokkaHtmlMultiModule --parallel
 
       - name: Build Counter iOS sample
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -30,13 +30,15 @@ allprojects {
     google()
   }
 
-  tasks.withType(Test).configureEach {
+  tasks.withType(AbstractTestTask).configureEach {
     testLogging {
       if (System.getenv("CI") == "true") {
         events = ["failed", "skipped", "passed"]
       }
       exceptionFormat "full"
     }
+    // Force tests to always run to avoid caching issues.
+    outputs.upToDateWhen { false }
   }
 
   plugins.withId('java-base') {


### PR DESCRIPTION
Follow up: https://github.com/cashapp/redwood/pull/477#discussion_r1008771892

`gradle build` and `gradle test` do not run `:redwood-widget:iosSimulatorArm64Test` whereas `gradle check` does. Investigating...