### PR TITLE
Fix dependency layout modifiers not being included in diff producing/consuming serialization.

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/GenerateCommand.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/GenerateCommand.kt
@@ -90,13 +90,13 @@ internal class GenerateCommand : CliktCommand(name = "generate") {
       }
       ComposeProtocol -> {
         generateDiffProducingWidgetFactory(schema).writeTo(out)
-        generateDiffProducingLayoutModifier(schema).writeTo(out)
+        generateDiffProducingLayoutModifiers(schema).writeTo(out)
         for (widget in schema.widgets) {
           generateDiffProducingWidget(schema, widget).writeTo(out)
         }
         for (dependency in schema.dependencies) {
           generateDiffProducingWidgetFactory(dependency, host = schema).writeTo(out)
-          generateDiffProducingLayoutModifier(dependency, host = schema).writeTo(out)
+          generateDiffProducingLayoutModifiers(dependency, host = schema).writeTo(out)
           for (widget in dependency.widgets) {
             generateDiffProducingWidget(dependency, widget, host = schema).writeTo(out)
           }
@@ -115,13 +115,13 @@ internal class GenerateCommand : CliktCommand(name = "generate") {
       }
       WidgetProtocol -> {
         generateDiffConsumingWidgetFactory(schema).writeTo(out)
-        generateDiffConsumingLayoutModifier(schema).writeTo(out)
+        generateDiffConsumingLayoutModifiers(schema).writeTo(out)
         for (widget in schema.widgets) {
           generateDiffConsumingWidget(schema, widget).writeTo(out)
         }
         for (dependency in schema.dependencies) {
           generateDiffConsumingWidgetFactory(dependency, host = schema).writeTo(out)
-          generateDiffConsumingLayoutModifier(dependency, host = schema).writeTo(out)
+          generateDiffConsumingLayoutModifiers(dependency, host = schema).writeTo(out)
           for (widget in dependency.widgets) {
             generateDiffConsumingWidget(dependency, widget, host = schema).writeTo(out)
           }

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
@@ -475,8 +475,8 @@ private fun generateJsonElementToLayoutModifier(schema: Schema): FunSpec {
             .build(),
         )
       } else {
-        for ((layoutModifierSchema, layoutModifier) in layoutModifiers) {
-          val typeName = ClassName(layoutModifierSchema.widgetPackage(schema), layoutModifier.type.simpleName!! + "Impl")
+        for ((localSchema, layoutModifier) in layoutModifiers) {
+          val typeName = ClassName(localSchema.widgetPackage(schema), layoutModifier.type.simpleName!! + "Impl")
           if (layoutModifier.properties.isEmpty()) {
             addStatement("%L -> return %T", layoutModifier.tag, typeName)
           } else {

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffConsumingGeneration.kt
@@ -25,7 +25,6 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.INT
-import com.squareup.kotlinpoet.KModifier.DATA
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
@@ -371,16 +370,7 @@ internal fun generateDiffConsumingWidget(schema: Schema, widget: Widget, host: S
           FunSpec.builder("updateLayoutModifier")
             .addModifiers(OVERRIDE)
             .addParameter("value", KotlinxSerialization.JsonArray)
-            .addStatement(
-              """
-              |layoutModifiers = value.fold<%1T, %2T>(%2T) { modifier, element ->
-              |  modifier then element.%3M(json, mismatchHandler)
-              |}
-              """.trimMargin(),
-              KotlinxSerialization.JsonElement,
-              Redwood.LayoutModifier,
-              host.toLayoutModifier,
-            )
+            .addStatement("layoutModifiers = value.%M(json, mismatchHandler)", host.toLayoutModifier)
             .build(),
         )
         .build(),
@@ -388,62 +378,20 @@ internal fun generateDiffConsumingWidget(schema: Schema, widget: Widget, host: S
     .build()
 }
 
-internal fun generateDiffConsumingLayoutModifier(schema: Schema, host: Schema = schema): FileSpec {
+internal fun generateDiffConsumingLayoutModifiers(schema: Schema, host: Schema = schema): FileSpec {
   return FileSpec.builder(schema.widgetPackage(host), "layoutModifierSerialization")
     .apply {
       if (schema === host) {
-        addFunction(
-          FunSpec.builder("toLayoutModifier")
-            .addModifiers(INTERNAL)
-            .receiver(KotlinxSerialization.JsonElement)
-            .addParameter("json", KotlinxSerialization.Json)
-            .addParameter("mismatchHandler", WidgetProtocol.ProtocolMismatchHandler)
-            .returns(Redwood.LayoutModifier)
-            .addStatement("val array = %M", KotlinxSerialization.jsonArray)
-            .addStatement("require(array.size == 2) { \"Layout modifier JSON array length != 2: \${array.size}\" }")
-            .addStatement("")
-            .beginControlFlow(
-              "val serializer = when (val tag = array[0].%M.%M)",
-              KotlinxSerialization.jsonPrimitive,
-              KotlinxSerialization.jsonInt,
-            )
-            .apply {
-              if (schema.layoutModifiers.isEmpty()) {
-                addAnnotation(
-                  AnnotationSpec.builder(Suppress::class)
-                    .addMember("%S, %S, %S, %S", "UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNUSED_VARIABLE", "UNREACHABLE_CODE")
-                    .build(),
-                )
-              }
-              for (layoutModifier in schema.layoutModifiers) {
-                val typeName = ClassName(schema.widgetPackage(host), layoutModifier.type.simpleName!! + "Impl")
-                if (layoutModifier.properties.isEmpty()) {
-                  addStatement("%L -> return %T", layoutModifier.tag, typeName)
-                } else {
-                  addStatement("%L -> %T.serializer()", layoutModifier.tag, typeName)
-                }
-              }
-            }
-            .beginControlFlow("else ->")
-            .addStatement("mismatchHandler.onUnknownLayoutModifier(tag)")
-            .addStatement("return %T", Redwood.LayoutModifier)
-            .endControlFlow()
-            .endControlFlow()
-            .addStatement("")
-            .addStatement("val value = array[1].%M", KotlinxSerialization.jsonObject)
-            .addStatement("return json.decodeFromJsonElement(serializer, value)")
-            .build(),
-        )
+        addFunction(generateJsonArrayToLayoutModifier(schema))
+        addFunction(generateJsonElementToLayoutModifier(schema))
       }
 
       for (layoutModifier in schema.layoutModifiers) {
-        val typeName =
-          ClassName(schema.widgetPackage(host), layoutModifier.type.simpleName!! + "Impl")
+        val typeName = ClassName(schema.widgetPackage(host), layoutModifier.type.simpleName!! + "Impl")
         val typeBuilder = if (layoutModifier.properties.isEmpty()) {
           TypeSpec.objectBuilder(typeName)
         } else {
           TypeSpec.classBuilder(typeName)
-            .addModifiers(DATA)
             .addAnnotation(KotlinxSerialization.Serializable)
             .apply {
               val primaryConstructor = FunSpec.constructorBuilder()
@@ -480,5 +428,70 @@ internal fun generateDiffConsumingLayoutModifier(schema: Schema, host: Schema = 
         )
       }
     }
+    .build()
+}
+
+private fun generateJsonArrayToLayoutModifier(schema: Schema): FunSpec {
+  return FunSpec.builder("toLayoutModifier")
+    .addModifiers(INTERNAL)
+    .receiver(KotlinxSerialization.JsonArray)
+    .addParameter("json", KotlinxSerialization.Json)
+    .addParameter("mismatchHandler", WidgetProtocol.ProtocolMismatchHandler)
+    .addStatement(
+      """
+      |return fold<%1T, %2T>(%2T) { modifier, element ->
+      |  modifier then element.%3M(json, mismatchHandler)
+      |}
+      """.trimMargin(),
+      KotlinxSerialization.JsonElement,
+      Redwood.LayoutModifier,
+      schema.toLayoutModifier,
+    )
+    .returns(Redwood.LayoutModifier)
+    .build()
+}
+
+private fun generateJsonElementToLayoutModifier(schema: Schema): FunSpec {
+  return FunSpec.builder("toLayoutModifier")
+    .addModifiers(PRIVATE)
+    .receiver(KotlinxSerialization.JsonElement)
+    .addParameter("json", KotlinxSerialization.Json)
+    .addParameter("mismatchHandler", WidgetProtocol.ProtocolMismatchHandler)
+    .returns(Redwood.LayoutModifier)
+    .addStatement("val array = %M", KotlinxSerialization.jsonArray)
+    .addStatement("require(array.size == 2) { \"Layout modifier JSON array length != 2: \${array.size}\" }")
+    .addStatement("")
+    .beginControlFlow(
+      "val serializer = when (val tag = array[0].%M.%M)",
+      KotlinxSerialization.jsonPrimitive,
+      KotlinxSerialization.jsonInt,
+    )
+    .apply {
+      val layoutModifiers = schema.allLayoutModifiers()
+      if (layoutModifiers.isEmpty()) {
+        addAnnotation(
+          AnnotationSpec.builder(Suppress::class)
+            .addMember("%S, %S, %S, %S", "UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNUSED_VARIABLE", "UNREACHABLE_CODE")
+            .build(),
+        )
+      } else {
+        for ((layoutModifierSchema, layoutModifier) in layoutModifiers) {
+          val typeName = ClassName(layoutModifierSchema.widgetPackage(schema), layoutModifier.type.simpleName!! + "Impl")
+          if (layoutModifier.properties.isEmpty()) {
+            addStatement("%L -> return %T", layoutModifier.tag, typeName)
+          } else {
+            addStatement("%L -> %T.serializer()", layoutModifier.tag, typeName)
+          }
+        }
+      }
+    }
+    .beginControlFlow("else ->")
+    .addStatement("mismatchHandler.onUnknownLayoutModifier(tag)")
+    .addStatement("return %T", Redwood.LayoutModifier)
+    .endControlFlow()
+    .endControlFlow()
+    .addStatement("")
+    .addStatement("val value = array[1].%M", KotlinxSerialization.jsonObject)
+    .addStatement("return json.decodeFromJsonElement(serializer, value)")
     .build()
 }

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
@@ -421,9 +421,9 @@ private fun generateToJsonElement(schema: Schema): FunSpec {
             .build(),
         )
       } else {
-        for ((layoutModifierSchema, layoutModifier) in layoutModifiers) {
-          val modifierType = layoutModifierSchema.layoutModifierType(layoutModifier)
-          val surrogate = layoutModifierSchema.layoutModifierSurrogate(layoutModifier, schema)
+        for ((localSchema, layoutModifier) in layoutModifiers) {
+          val modifierType = localSchema.layoutModifierType(layoutModifier)
+          val surrogate = localSchema.layoutModifierSurrogate(layoutModifier, schema)
           if (layoutModifier.properties.isEmpty()) {
             addStatement("is %T -> %T.encode()", modifierType, surrogate)
           } else {

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
@@ -290,10 +290,7 @@ internal fun generateDiffProducingWidget(schema: Schema, widget: Widget, host: S
             .setter(
               FunSpec.setterBuilder()
                 .addParameter("value", Redwood.LayoutModifier)
-                .beginControlFlow("val json = %M", KotlinxSerialization.buildJsonArray)
-                .addStatement("value.forEach { element -> add(element.toJsonElement(json)) }")
-                .endControlFlow()
-                .addStatement("appendDiff(%T(id, json))", Protocol.LayoutModifiers)
+                .addStatement("appendDiff(%T(id, value.%M(json)))", Protocol.LayoutModifiers, host.toJsonArray)
                 .build(),
             )
             .build(),
@@ -303,39 +300,14 @@ internal fun generateDiffProducingWidget(schema: Schema, widget: Widget, host: S
     .build()
 }
 
-internal fun generateDiffProducingLayoutModifier(schema: Schema, host: Schema = schema): FileSpec {
+internal fun generateDiffProducingLayoutModifiers(schema: Schema, host: Schema = schema): FileSpec {
   return FileSpec.builder(schema.composePackage(host), "layoutModifierSerialization")
-    .addFunction(
-      FunSpec.builder("toJsonElement")
-        .addModifiers(INTERNAL)
-        .receiver(Redwood.LayoutModifierElement)
-        .addParameter("json", KotlinxSerialization.Json)
-        .returns(KotlinxSerialization.JsonElement)
-        .beginControlFlow("return when (this)")
-        .apply {
-          if (schema.layoutModifiers.isEmpty()) {
-            addAnnotation(
-              AnnotationSpec.builder(Suppress::class)
-                .addMember("%S, %S", "UNUSED_PARAMETER", "UNUSED_EXPRESSION")
-                .build(),
-            )
-          }
-
-          for (layoutModifier in schema.layoutModifiers) {
-            val modifierType = schema.layoutModifierType(layoutModifier)
-            val surrogate = schema.layoutModifierSurrogate(layoutModifier, host)
-            if (layoutModifier.properties.isEmpty()) {
-              addStatement("is %T -> %T.encode()", modifierType, surrogate)
-            } else {
-              addStatement("is %T -> %T.encode(json, this)", modifierType, surrogate)
-            }
-          }
-        }
-        .addStatement("else -> throw %T()", Stdlib.AssertionError)
-        .endControlFlow()
-        .build(),
-    )
     .apply {
+      if (schema === host) {
+        addFunction(generateToJsonArray(schema))
+        addFunction(generateToJsonElement(schema))
+      }
+
       for (layoutModifier in schema.layoutModifiers) {
         val surrogateName = schema.layoutModifierSurrogate(layoutModifier, host)
         val modifierType = schema.layoutModifierType(layoutModifier)
@@ -361,7 +333,7 @@ internal fun generateDiffProducingLayoutModifier(schema: Schema, host: Schema = 
           } else {
             TypeSpec.classBuilder(surrogateName)
               .addAnnotation(KotlinxSerialization.Serializable)
-              .addModifiers(PRIVATE)
+              .addModifiers(INTERNAL)
               .addSuperinterface(modifierType)
               .apply {
                 val primaryConstructor = FunSpec.constructorBuilder()
@@ -418,5 +390,49 @@ internal fun generateDiffProducingLayoutModifier(schema: Schema, host: Schema = 
         )
       }
     }
+    .build()
+}
+
+private fun generateToJsonArray(schema: Schema): FunSpec {
+  return FunSpec.builder("toJsonArray")
+    .addModifiers(INTERNAL)
+    .receiver(Redwood.LayoutModifier)
+    .addParameter("json", KotlinxSerialization.Json)
+    .beginControlFlow("return %M", KotlinxSerialization.buildJsonArray)
+    .addStatement("forEach { element -> add(element.%M(json)) }", schema.toJsonElement)
+    .endControlFlow()
+    .returns(KotlinxSerialization.JsonArray)
+    .build()
+}
+
+private fun generateToJsonElement(schema: Schema): FunSpec {
+  return FunSpec.builder("toJsonElement")
+    .addModifiers(PRIVATE)
+    .receiver(Redwood.LayoutModifierElement)
+    .addParameter("json", KotlinxSerialization.Json)
+    .returns(KotlinxSerialization.JsonElement)
+    .beginControlFlow("return when (this)")
+    .apply {
+      val layoutModifiers = schema.allLayoutModifiers()
+      if (layoutModifiers.isEmpty()) {
+        addAnnotation(
+          AnnotationSpec.builder(Suppress::class)
+            .addMember("%S, %S", "UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+            .build(),
+        )
+      } else {
+        for ((layoutModifierSchema, layoutModifier) in layoutModifiers) {
+          val modifierType = layoutModifierSchema.layoutModifierType(layoutModifier)
+          val surrogate = layoutModifierSchema.layoutModifierSurrogate(layoutModifier, schema)
+          if (layoutModifier.properties.isEmpty()) {
+            addStatement("is %T -> %T.encode()", modifierType, surrogate)
+          } else {
+            addStatement("is %T -> %T.encode(json, this)", modifierType, surrogate)
+          }
+        }
+      }
+    }
+    .addStatement("else -> throw %T()", Stdlib.AssertionError)
+    .endControlFlow()
     .build()
 }

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
@@ -111,6 +111,18 @@ internal fun Schema.layoutModifierImpl(layoutModifier: LayoutModifier): ClassNam
 internal val Schema.toLayoutModifier: MemberName get() =
   MemberName(widgetPackage(this), "toLayoutModifier")
 
+internal val Schema.toJsonArray: MemberName get() =
+  MemberName(composePackage(this), "toJsonArray")
+
+internal val Schema.toJsonElement: MemberName get() =
+  MemberName(composePackage(this), "toJsonElement")
+
+internal fun Schema.allLayoutModifiers(): List<Pair<Schema, LayoutModifier>> {
+  return (listOf(this) + dependencies).flatMap { schema ->
+    schema.layoutModifiers.map { schema to it }
+  }
+}
+
 internal fun layoutModifierEquals(schema: Schema, layoutModifier: LayoutModifier): FunSpec {
   val interfaceType = schema.layoutModifierType(layoutModifier)
   return FunSpec.builder("equals")

--- a/redwood-cli/src/test/kotlin/app/cash/redwood/generator/DiffConsumingGenerationTest.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/generator/DiffConsumingGenerationTest.kt
@@ -55,4 +55,14 @@ class DiffConsumingGenerationTest {
       Pattern.compile("1 ->[^2]+2 ->[^3]+3 ->[^1]+12 ->", MULTILINE),
     )
   }
+
+  @Test fun `dependency layout modifiers are included in serialization`() {
+    val schema = parseSchema(PrimarySchema::class)
+
+    val fileSpec = generateDiffConsumingLayoutModifiers(schema)
+    assertThat(fileSpec.toString()).apply {
+      contains("1 -> PrimaryModifierImpl.serializer()")
+      contains("1000001 -> SecondaryModifierImpl.serializer()")
+    }
+  }
 }

--- a/redwood-cli/src/test/kotlin/app/cash/redwood/generator/DiffProducingGenerationTest.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/generator/DiffProducingGenerationTest.kt
@@ -49,4 +49,14 @@ class DiffProducingGenerationTest {
       """.trimMargin(),
     )
   }
+
+  @Test fun `dependency layout modifiers are included in serialization`() {
+    val schema = parseSchema(PrimarySchema::class)
+
+    val fileSpec = generateDiffProducingLayoutModifiers(schema)
+    assertThat(fileSpec.toString()).apply {
+      contains("is PrimaryModifier -> PrimaryModifierSurrogate.encode(json, this)")
+      contains("is SecondaryModifier -> SecondaryModifierSurrogate.encode(json, this)")
+    }
+  }
 }

--- a/redwood-cli/src/test/kotlin/app/cash/redwood/generator/commonSchema.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/generator/commonSchema.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.generator
+
+import app.cash.redwood.schema.LayoutModifier
+import app.cash.redwood.schema.Property
+import app.cash.redwood.schema.Schema
+
+@Schema(
+  members = [
+    PrimaryModifier::class,
+  ],
+  dependencies = [
+    Schema.Dependency(1, SecondarySchema::class),
+  ],
+)
+interface PrimarySchema
+
+object PrimaryScope
+
+@LayoutModifier(1, PrimaryScope::class)
+data class PrimaryModifier(@Property(1) val text: String)
+
+@Schema(
+  members = [
+    SecondaryModifier::class,
+  ],
+)
+interface SecondarySchema
+
+object SecondaryScope
+
+@LayoutModifier(1, SecondaryScope::class)
+data class SecondaryModifier(@Property(1) val valid: Boolean)


### PR DESCRIPTION
Currently layout modifiers from schema dependencies throw an exception if they're applied to a widget that isn't part of that schema dependency. For example:

```kotlin
Column {
    Image("watch", layoutModifier = LayoutModifier.padding(5))
}
```

will throw because the `Padding` layout modifier is part of the `RedwoodLayout` schema whereas `Image` is from the main schema. This is because the generated code uses separate `toJsonElement` and `toLayoutModifier` functions for the main schema and each child dependency.

This PR updates the generated code to use one `toJsonElement` and one `toLayoutModifier` for all layout modifiers. Example generated output:

<details>
    <summary>diff producing generated code</summary>

  ```kotlin
  internal fun LayoutModifier.toJsonArray(json: Json): JsonArray = buildJsonArray {
    forEach { element -> add(element.toJsonElement(json)) }
  }

  private fun LayoutModifier.Element.toJsonElement(json: Json): JsonElement = when (this) {
    is RowVerticalAlignment -> RowVerticalAlignmentSurrogate.encode(json, this)
    is AccessibilityDescription -> AccessibilityDescriptionSurrogate.encode(json, this)
    is CustomType -> CustomTypeSurrogate.encode(json, this)
    is CustomTypeStateless -> CustomTypeStatelessSurrogate.encode()
    is CustomTypeWithDefault -> CustomTypeWithDefaultSurrogate.encode(json, this)
    is CustomTypeWithMultipleScopes -> CustomTypeWithMultipleScopesSurrogate.encode()
    is Grow -> GrowSurrogate.encode(json, this)
    is Shrink -> ShrinkSurrogate.encode(json, this)
    is Padding -> PaddingSurrogate.encode(json, this)
    is HorizontalAlignment -> HorizontalAlignmentSurrogate.encode(json, this)
    is VerticalAlignment -> VerticalAlignmentSurrogate.encode(json, this)
    else -> throw AssertionError()
  }
  ```
</details>

<details>
    <summary>diff consuming generated code</summary>

  ```kotlin
  internal fun JsonArray.toLayoutModifier(json: Json, mismatchHandler: ProtocolMismatchHandler):
      LayoutModifier = fold<JsonElement, LayoutModifier>(LayoutModifier) { modifier, element ->
    modifier then element.toLayoutModifier(json, mismatchHandler)
  }
  
  private fun JsonElement.toLayoutModifier(json: Json, mismatchHandler: ProtocolMismatchHandler):
      LayoutModifier {
    val array = jsonArray
    require(array.size == 2) { "Layout modifier JSON array length != 2: ${array.size}" }
  
    val serializer = when (val tag = array[0].jsonPrimitive.int) {
      1 -> RowVerticalAlignmentImpl.serializer()
      2 -> AccessibilityDescriptionImpl.serializer()
      3 -> CustomTypeImpl.serializer()
      4 -> return CustomTypeStatelessImpl
      5 -> CustomTypeWithDefaultImpl.serializer()
      6 -> return CustomTypeWithMultipleScopesImpl
      1000001 -> GrowImpl.serializer()
      1000002 -> ShrinkImpl.serializer()
      1000003 -> PaddingImpl.serializer()
      1000004 -> HorizontalAlignmentImpl.serializer()
      1000005 -> VerticalAlignmentImpl.serializer()
      else -> {
        mismatchHandler.onUnknownLayoutModifier(tag)
        return LayoutModifier
      }
    }
  
    val value = array[1].jsonObject
    return json.decodeFromJsonElement(serializer, value)
  }
  ```
</details>