### PR TITLE
Treehouse EventListener

### DIFF
--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherAndroid.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherAndroid.kt
@@ -35,6 +35,7 @@ public fun TreehouseLauncher(
   context: Context,
   httpClient: OkHttpClient,
   manifestVerifier: ManifestVerifier,
+  eventListener: EventListener = EventListener.NONE,
   embeddedDir: Path = "/".toPath(),
   embeddedFileSystem: FileSystem = FileSystem.SYSTEM,
   cacheName: String = "zipline",
@@ -42,6 +43,7 @@ public fun TreehouseLauncher(
 ): TreehouseLauncher = TreehouseLauncher(
   platform = AndroidTreehousePlatform(context),
   dispatchers = AndroidTreehouseDispatchers(),
+  eventListener = eventListener,
   httpClient = httpClient.asZiplineHttpClient(),
   manifestVerifier = manifestVerifier,
   embeddedDir = embeddedDir,

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.redwood.treehouse
+
+import app.cash.zipline.Call
+import app.cash.zipline.CallResult
+import app.cash.zipline.ZiplineService
+
+public abstract class EventListener {
+  public open fun appCreated(
+    app: TreehouseApp<*>,
+  ) {
+  }
+
+  public open fun appCanceled(
+    app: TreehouseApp<*>,
+  ) {
+  }
+
+  public open fun codeLoadStart(
+    app: TreehouseApp<*>,
+    manifestUrl: String?,
+  ): Any? = Unit
+
+  public open fun codeLoadEnd(
+    app: TreehouseApp<*>,
+    manifestUrl: String?,
+    startValue: Any?,
+  ) {
+  }
+
+  public open fun codeLoadFailed(
+    app: TreehouseApp<*>,
+    manifestUrl: String?,
+    exception: Exception,
+    startValue: Any?,
+  ) {
+  }
+
+  public open fun onUnknownWidget(
+    app: TreehouseApp<*>,
+    kind: Int,
+  ) {
+  }
+
+  public open fun onUnknownLayoutModifier(
+    app: TreehouseApp<*>,
+    tag: Int,
+  ) {
+  }
+
+  public open fun onUnknownChildren(
+    app: TreehouseApp<*>,
+    kind: Int,
+    tag: Int,
+  ) {
+  }
+
+  public open fun onUnknownProperty(
+    app: TreehouseApp<*>,
+    kind: Int,
+    tag: Int,
+  ) {
+  }
+
+  public open fun downloadStart(
+    app: TreehouseApp<*>,
+    url: String,
+  ): Any? = Unit
+
+  public open fun downloadEnd(
+    app: TreehouseApp<*>,
+    url: String,
+    startValue: Any?,
+  ) {
+  }
+
+  public open fun downloadFailed(
+    app: TreehouseApp<*>,
+    url: String,
+    exception: Exception,
+    startValue: Any?,
+  ) {
+  }
+
+  public open fun manifestParseFailed(
+    app: TreehouseApp<*>,
+    url: String?,
+    exception: Exception,
+  ) {
+  }
+
+  public open fun bindService(
+    name: String,
+    service: ZiplineService,
+  ) {
+  }
+
+  public open fun takeService(
+    name: String,
+    service: ZiplineService,
+  ) {
+  }
+
+  public open fun callStart(
+    call: Call,
+  ): Any? = Unit
+
+  public open fun callEnd(
+    call: Call,
+    result: CallResult,
+    startValue: Any?,
+  ) {
+  }
+
+  public open fun serviceLeaked(
+    name: String,
+  ) {
+  }
+
+  public companion object {
+    public val NONE: EventListener = object : EventListener() {
+    }
+  }
+}

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package app.cash.redwood.treehouse
 
 import app.cash.zipline.Call

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseLauncher.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseLauncher.kt
@@ -37,6 +37,7 @@ import okio.Path
 public class TreehouseLauncher internal constructor(
   private val platform: TreehousePlatform,
   public val dispatchers: TreehouseDispatchers,
+  private val eventListener: EventListener,
   httpClient: ZiplineHttpClient,
   manifestVerifier: ManifestVerifier,
   private val embeddedDir: Path,

--- a/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherIos.kt
+++ b/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseLauncherIos.kt
@@ -30,6 +30,7 @@ import platform.Foundation.NSThread
 public fun TreehouseLauncher(
   httpClient: ZiplineHttpClient,
   manifestVerifier: ManifestVerifier,
+  eventListener: EventListener = EventListener.NONE,
   embeddedDir: Path = "/".toPath(),
   embeddedFileSystem: FileSystem = FileSystem.SYSTEM,
   cacheName: String = "zipline",
@@ -37,6 +38,7 @@ public fun TreehouseLauncher(
 ): TreehouseLauncher = TreehouseLauncher(
   platform = IosTreehousePlatform(),
   dispatchers = IosTreehouseDispatchers(),
+  eventListener = eventListener,
   httpClient = httpClient,
   manifestVerifier = manifestVerifier,
   embeddedDir = embeddedDir,


### PR DESCRIPTION
This combines features of Zipline's EventListener and Redwood's ProtocolMismatchHandler.

It changes the Zipline APIs to use Redwood's types.

I expect distinct implementations on each target platform, and I expect end-users to adapt this during debugging.