### PR TITLE
Remove knowledge of protocol from generated code

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -77,19 +77,23 @@ internal fun generateComposableTargetMarker(schema: Schema): FileSpec {
 /*
 @Composable
 @SunspotComposable
-fun SunspotButton(
-  text: String?,
-  enabled: Boolean = true,
-  onClick: (() -> Unit)? = null,
+fun Row(
+  padding: Padding = Padding.Zero,
+  overflow: Overflow = Overflow.Clip,
   layoutModifier: LayoutModifier = LayoutModifier,
+  children: @Composable @SunspotComposable RowScope.() -> Unit,
 ): Unit {
-  RedwoodComposeNode<SunspotWidgetFactory<*>, SunspotButton<*>>(
-    factory = SunspotWidgetFactory<*>::SunspotButton,
+  _RedwoodComposeNode<SunspotWidgetFactory<*>, Row<*>>(
+    factory = { it.RedwoodLayout.Row() },
     update = {
       set(layoutModifier) { layoutModifiers = it }
-      set(text, SunspotButton<*>::text)
-      set(enabled, SunspotButton<*>::enabled)
-      set(onClick, SunspotButton<*>::onClick)
+      set(padding, Row<*>::padding)
+      set(overflow, Row<*>::overflow)
+    },
+    content = {
+      into(Row<*>::children) {
+        RowScopeImpl.children()
+      }
     },
   )
 }
@@ -178,7 +182,7 @@ internal fun generateComposable(
               }
               is Children -> {
                 childrenLambda.apply {
-                  add("%M(%LU) {\n", ComposeProtocol.SyntheticChildren, trait.tag)
+                  add("into(%T::%N) {\n", widgetType, trait.name)
                   indent()
                   trait.scope?.let { scope ->
                     add("%T.", ClassName(schema.composePackage(), scope.simpleName!! + "Impl"))

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/diffProducingGeneration.kt
@@ -227,10 +227,11 @@ internal fun generateDiffProducingWidget(schema: Schema, widget: Widget, host: S
               }
               is Children -> {
                 addProperty(
-                  PropertySpec.builder(trait.name, NOTHING, OVERRIDE)
+                  PropertySpec.builder(trait.name, RedwoodWidget.WidgetChildren.parameterizedBy(NOTHING))
+                    .addModifiers(OVERRIDE)
                     .getter(
                       FunSpec.getterBuilder()
-                        .addStatement("throw %T()", Stdlib.AssertionError)
+                        .addStatement("return diffProducingWidgetChildren(%LU)", trait.tag)
                         .build(),
                     )
                     .build(),

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
@@ -37,7 +37,6 @@ internal object ComposeProtocol {
     ClassName("app.cash.redwood.protocol.compose", "AbstractDiffProducingWidget")
   val DiffProducingWidget = ClassName("app.cash.redwood.protocol.compose", "DiffProducingWidget")
   val DiffProducingWidgetFactory = DiffProducingWidget.nestedClass("Factory")
-  val SyntheticChildren = MemberName("app.cash.redwood.protocol.compose", "_SyntheticChildren")
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.compose", "ProtocolMismatchHandler")
 }
@@ -63,7 +62,7 @@ internal object RedwoodWidget {
 }
 
 internal object RedwoodCompose {
-  val RedwoodComposeNode = MemberName("app.cash.redwood.compose", "RedwoodComposeNode")
+  val RedwoodComposeNode = MemberName("app.cash.redwood.compose", "_RedwoodComposeNode")
 }
 
 internal object ComposeRuntime {

--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -11,7 +11,6 @@ kotlin {
     commonMain {
       dependencies {
         api libs.kotlinx.coroutines.core
-        api projects.redwoodProtocol // TODO Remove and create redwoodProtocolCompose!
         api projects.redwoodRuntime
         api projects.redwoodWidget
         api libs.jetbrains.compose.runtime

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
@@ -47,8 +47,7 @@ public abstract class RedwoodGeneratorPlugin(
     internal val generatorFlag: String,
     internal val dependencyArtifactId: String,
   ) {
-    // TODO This should only rely on redwood-compose and not redwood-protocol-compose.
-    Compose("--compose", "redwood-protocol-compose"),
+    Compose("--compose", "redwood-compose"),
     ComposeProtocol("--compose-protocol", "redwood-protocol-compose"),
     LayoutModifiers("--layout-modifiers", "redwood-runtime"),
     Widget("--widget", "redwood-widget"),

--- a/redwood-protocol-compose/build.gradle
+++ b/redwood-protocol-compose/build.gradle
@@ -32,3 +32,12 @@ android {
     unitTests.returnDefaultValues = true
   }
 }
+
+spotless {
+  kotlin {
+    targetExclude(
+      // Apache 2-licensed files from AOSP.
+      "src/commonMain/kotlin/app/cash/redwood/protocol/compose/utils.kt",
+    )
+  }
+}

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/AbstractDiffProducingWidget.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/AbstractDiffProducingWidget.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+import app.cash.redwood.protocol.Event
+import app.cash.redwood.protocol.Id
+import app.cash.redwood.protocol.LayoutModifiers
+import app.cash.redwood.protocol.PropertyDiff
+import app.cash.redwood.widget.Widget.Children
+
+/**
+ * @suppress For generated code usage only.
+ */
+public abstract class AbstractDiffProducingWidget(
+  public val type: Int,
+) : DiffProducingWidget {
+  override val value: Nothing
+    get() = throw AssertionError()
+
+  public var id: Id = Id(ULong.MAX_VALUE)
+    internal set
+
+  @Suppress("PropertyName") // Avoiding potential collision with subtype properties.
+  internal lateinit var _diffAppender: DiffAppender
+
+  protected fun appendDiff(layoutModifiers: LayoutModifiers) {
+    _diffAppender.append(layoutModifiers)
+  }
+
+  protected fun appendDiff(diff: PropertyDiff) {
+    _diffAppender.append(diff)
+  }
+
+  protected fun diffProducingWidgetChildren(tag: UInt): Children<Nothing> {
+    return DiffProducingWidgetChildren(id, tag, _diffAppender)
+  }
+
+  public abstract fun sendEvent(event: Event)
+}

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+import app.cash.redwood.protocol.ChildrenDiff
+import app.cash.redwood.protocol.Id
+import app.cash.redwood.widget.Widget
+
+internal class DiffProducingWidgetChildren(
+  private val id: Id,
+  private val tag: UInt,
+  private val diffAppender: DiffAppender,
+) : Widget.Children<Nothing> {
+  val ids = mutableListOf<Id>()
+
+  override fun insert(index: Int, widget: Widget<Nothing>) {
+    widget as AbstractDiffProducingWidget
+    ids.add(index, widget.id)
+    diffAppender.append(ChildrenDiff.Insert(id, tag, widget.id, widget.type, index))
+  }
+
+  override fun remove(index: Int, count: Int) {
+    ids.remove(index, count)
+    diffAppender.append(ChildrenDiff.Remove(id, tag, index, count))
+  }
+
+  override fun move(fromIndex: Int, toIndex: Int, count: Int) {
+    ids.move(fromIndex, toIndex, count)
+    diffAppender.append(ChildrenDiff.Move(id, tag, fromIndex, toIndex, count))
+  }
+
+  override fun clear() {
+    ids.clear()
+    diffAppender.append(ChildrenDiff.Clear)
+  }
+
+  override fun onLayoutModifierUpdated(index: Int) {
+    throw AssertionError()
+  }
+}

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
@@ -17,100 +17,20 @@ package app.cash.redwood.protocol.compose
 
 import androidx.compose.runtime.AbstractApplier
 import androidx.compose.runtime.Applier
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ComposeNode
-import app.cash.redwood.LayoutModifier
-import app.cash.redwood.compose.RedwoodApplier
-import app.cash.redwood.protocol.ChildrenDiff
+import app.cash.redwood.compose._ChildrenWidget
+import app.cash.redwood.compose._RedwoodApplier
 import app.cash.redwood.protocol.ChildrenDiff.Companion.RootChildrenTag
-import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.Id
-import app.cash.redwood.protocol.LayoutModifiers
-import app.cash.redwood.protocol.PropertyDiff
-
-/**
- * A synthetic node which allows the applier to differentiate between multiple groups of children.
- *
- * Compose's tree assumes each node only has single list of children. Or, put another way, even if
- * you apply multiple children Compose treats them as a single list of child nodes. In order to
- * differentiate between these children lists we introduce synthetic nodes. Every real node which
- * supports one or more groups of children will have one or more of these synthetic nodes as its
- * direct descendants. The nodes which are produced by each group of children will then become the
- * descendants of those synthetic nodes.
- *
- * This function is named weirdly to prevent normal usage since bad things will happen.
- *
- * @see ProtocolApplier
- * @suppress For generated code usage only.
- */
-@Composable
-@Suppress("FunctionName") // Hiding from auto-complete.
-public fun _SyntheticChildren(tag: UInt, content: @Composable () -> Unit) {
-  ComposeNode<DiffProducingChildrenWidget, Applier<*>>(
-    factory = {
-      DiffProducingChildrenWidget(tag)
-    },
-    update = {
-    },
-    content = content,
-  )
-}
-
-/**
- * A node which exists in the tree to emulate supporting multiple children sets but which does not
- * appear directly in the protocol. The ID of these nodes mirrors that of its parent to simplify
- * creation of the protocol diffs. This is safe because these types never appears in the node map.
- */
-private class DiffProducingChildrenWidget(
-  val tag: UInt,
-) : AbstractDiffProducingWidget(-1) {
-  val children = mutableListOf<AbstractDiffProducingWidget>()
-
-  override var layoutModifiers: LayoutModifier
-    get() = throw AssertionError()
-    set(_) = throw AssertionError()
-
-  override fun sendEvent(event: Event) {
-    // These types should never make it into the node map and thus cannot be targeted by events.
-    throw AssertionError()
-  }
-}
-
-/**
- * @suppress For generated code usage only.
- */
-public abstract class AbstractDiffProducingWidget(
-  public val type: Int,
-) : DiffProducingWidget {
-  override val value: Nothing
-    get() = throw AssertionError()
-
-  public var id: Id = Id(ULong.MAX_VALUE)
-    internal set
-
-  @Suppress("PropertyName") // Avoiding potential collision with subtype properties.
-  internal lateinit var _diffAppender: DiffAppender
-
-  protected fun appendDiff(layoutModifiers: LayoutModifiers) {
-    _diffAppender.append(layoutModifiers)
-  }
-
-  protected fun appendDiff(diff: PropertyDiff) {
-    _diffAppender.append(diff)
-  }
-
-  public abstract fun sendEvent(event: Event)
-}
+import app.cash.redwood.widget.Widget
 
 /**
  * An [Applier] which records operations on the tree as models which can then be separately applied
  * by the display layer. Additionally, it has special handling for emulating nodes which contain
  * multiple children.
  *
- * Nodes in the tree are required to alternate between [DiffProducingChildrenWidget] instances
- * and non-[DiffProducingChildrenWidget] [AbstractDiffProducingWidget] subtypes starting
- * from the root. This invariant is maintained by virtue of the fact that all of the input
- * `@Composables` should be generated code.
+ * Nodes in the tree are required to alternate between [_ChildrenWidget] instances and
+ * [AbstractDiffProducingWidget] subtypes starting from the root. This invariant is maintained by
+ * virtue of the fact that all of the input `@Composables` should be generated code.
  *
  * For example, a node tree may look like this:
  * ```
@@ -125,8 +45,8 @@ public abstract class AbstractDiffProducingWidget(
  *        |              |              /         \
  *   ButtonNode     ButtonNode     TextNode     TextNode
  * ```
- * But the protocol diff output would only record non-[DiffProducingChildrenWidget] nodes using
- * their [DiffProducingChildrenWidget.tag] value:
+ * But the protocol diff output would only record [AbstractDiffProducingWidget] nodes using
+ * their [AbstractDiffProducingWidget.id] and [AbstractDiffProducingWidget.type] value:
  * ```
  * Insert(id=<root-id>, tag=1, type=<toolbar-type>, childId=<toolbar-id>)
  * Insert(id=<toolbar-id>, tag=1, type=<button-type>, childId=..)
@@ -142,71 +62,65 @@ public abstract class AbstractDiffProducingWidget(
 internal class ProtocolApplier(
   override val factory: DiffProducingWidget.Factory,
   private val diffAppender: DiffAppender,
-) : AbstractApplier<AbstractDiffProducingWidget>(
-  root = DiffProducingChildrenWidget(RootChildrenTag).apply { id = Id.Root },
-),
-  RedwoodApplier<DiffProducingWidget.Factory> {
+) : _RedwoodApplier<DiffProducingWidget.Factory>, AbstractApplier<Widget<Nothing>>(
+  root = _ChildrenWidget(
+    DiffProducingWidgetChildren(Id.Root, RootChildrenTag, diffAppender),
+  ),
+) {
   private var nextId = Id.Root.next()
-  internal val nodes = mutableMapOf(root.id to root)
+  internal val nodes = mutableMapOf(Id.Root to root)
 
   override fun onEndChanges() {
     diffAppender.trySend()
   }
 
-  override fun insertTopDown(index: Int, instance: AbstractDiffProducingWidget) {
-    if (instance is DiffProducingChildrenWidget) {
-      // Inherit the ID from the current node such that changes to the children can be reported
-      // as if they occurred directly on the parent.
-      instance.id = current.id
-      // We do not add children instances to the map (they have no unique IDs and are only
-      // available through indexing on the parent) and we do not send them over the wire to the
-      // display (they are always implied by the display interfaces).
+  override fun insertTopDown(index: Int, instance: Widget<Nothing>) {
+    if (instance is _ChildrenWidget) {
+      instance.children = instance.accessor!!.invoke(current)
+      instance.accessor = null
     } else {
-      val current = current as DiffProducingChildrenWidget
-      current.children.add(index, instance)
-
       val id = nextId
       nextId = id.next()
 
+      instance as AbstractDiffProducingWidget
       instance.id = id
       instance._diffAppender = diffAppender
 
       nodes[id] = instance
-      diffAppender.append(ChildrenDiff.Insert(current.id, current.tag, id, instance.type, index))
+
+      val current = current as _ChildrenWidget
+      current.children!!.insert(index, instance)
     }
   }
 
-  override fun insertBottomUp(index: Int, instance: AbstractDiffProducingWidget) {
+  override fun insertBottomUp(index: Int, instance: Widget<Nothing>) {
     // Ignored, we insert top-down for now.
   }
 
   override fun remove(index: Int, count: Int) {
     // Children instances are never removed from their parents.
-    val current = current as DiffProducingChildrenWidget
-    val children = current.children
+    val current = current as _ChildrenWidget
+    val children = current.children as DiffProducingWidgetChildren
 
     for (i in index until index + count) {
-      nodes.remove(children[i].id)
+      nodes.remove(children.ids[i])
     }
     children.remove(index, count)
-    diffAppender.append(ChildrenDiff.Remove(current.id, current.tag, index, count))
   }
 
   override fun move(from: Int, to: Int, count: Int) {
     // Children instances are never moved within their parents.
-    val current = current as DiffProducingChildrenWidget
-
-    current.children.move(from, to, count)
-    diffAppender.append(ChildrenDiff.Move(current.id, current.tag, from, to, count))
+    val current = current as _ChildrenWidget
+    current.children!!.move(from, to, count)
   }
 
   override fun onClear() {
-    val current = current as DiffProducingChildrenWidget
-    current.children.clear()
     nodes.clear()
-    nodes[current.id] = current // Restore root node into map.
-    diffAppender.append(ChildrenDiff.Clear)
-  }
-}
+    nodes[Id.Root] = current // Restore root node into map.
 
-private fun Id.next(): Id = Id(value + 1UL)
+    val current = current as _ChildrenWidget
+    current.children!!.clear()
+  }
+
+  private fun Id.next(): Id = Id(value + 1UL)
+}

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -103,7 +103,7 @@ private class DiffProducingRedwoodComposition(
 
     onEvent.sendEvent(event)
 
-    val node = applier.nodes[event.id]
+    val node = applier.nodes[event.id] as AbstractDiffProducingWidget?
     if (node == null) {
       // TODO how to handle race where an incoming event targets this removed node?
       throw IllegalArgumentException("Unknown node ${event.id} for event with tag ${event.tag}")

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/utils.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/utils.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+internal fun <T> MutableList<T>.move(fromIndex: Int, toIndex: Int, count: Int) {
+  val dest = if (fromIndex > toIndex) toIndex else toIndex - count
+  if (count == 1) {
+    if (fromIndex == toIndex + 1 || fromIndex == toIndex - 1) {
+      // Adjacent elements, perform swap to avoid backing array manipulations.
+      val fromEl = get(fromIndex)
+      val toEl = set(toIndex, fromEl)
+      set(fromIndex, toEl)
+    } else {
+      val fromEl = removeAt(fromIndex)
+      add(dest, fromEl)
+    }
+  } else {
+    val subView = subList(fromIndex, fromIndex + count)
+    val subCopy = subView.toMutableList()
+    subView.clear()
+    addAll(dest, subCopy)
+  }
+}
+
+internal fun <T> MutableList<T>.remove(index: Int, count: Int) {
+  if (count == 1) {
+    removeAt(index)
+  } else {
+    subList(index, index + count).clear()
+  }
+}


### PR DESCRIPTION
Instead of an intermediate children node which is aware of the protocol tag, use an intermediate node which can select the appropriate `Widget.Children` instance from its parent. Then, the diff-producing widgets now return `Widget.Children` instances which record operations to the diff.

This completely unblocks using Redwood without the protocol. All that's left is to decide whether we duplicate the applier and composition setup or try to share it.

Refs #14 