### PR TITLE
Remove the concept of clear

### DIFF
--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
@@ -42,11 +42,6 @@ internal class DiffProducingWidgetChildren(
     diffAppender.append(ChildrenDiff.Move(id, tag, fromIndex, toIndex, count))
   }
 
-  override fun clear() {
-    ids.clear()
-    diffAppender.append(ChildrenDiff.Clear)
-  }
-
   override fun onLayoutModifierUpdated(index: Int) {
     throw AssertionError()
   }

--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolDisplay.kt
@@ -61,12 +61,6 @@ public class ProtocolDisplay<T : Any>(
           }
           node.childIds.remove(childrenDiff.index, childrenDiff.count)
         }
-        ChildrenDiff.Clear -> {
-          children.clear()
-          node.childIds.clear()
-          nodes.clear()
-          nodes[Id.Root] = node
-        }
       }
     }
 

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
@@ -84,13 +84,6 @@ public sealed class ChildrenDiff {
   public abstract val tag: UInt
 
   @Serializable
-  @SerialName("clear")
-  public object Clear : ChildrenDiff() {
-    override val id: Id get() = Id.Root
-    override val tag: UInt get() = RootChildrenTag
-  }
-
-  @Serializable
   @SerialName("insert")
   public data class Insert(
     override val id: Id,

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
@@ -44,7 +44,6 @@ class ProtocolTest {
   @Test fun diff() {
     val model = Diff(
       childrenDiffs = listOf(
-        ChildrenDiff.Clear,
         ChildrenDiff.Insert(Id(1U), 2U, Id(3U), 4, 5),
         ChildrenDiff.Move(Id(1U), 2U, 3, 4, 5),
         ChildrenDiff.Remove(Id(1U), 2U, 3, 4),
@@ -69,7 +68,6 @@ class ProtocolTest {
     )
     val json = "" +
       """{"childrenDiffs":[""" +
-      """["clear",{}],""" +
       """["insert",{"id":1,"tag":2,"childId":3,"kind":4,"index":5}],""" +
       """["move",{"id":1,"tag":2,"fromIndex":3,"toIndex":4,"count":5}],""" +
       """["remove",{"id":1,"tag":2,"index":3,"count":4}]""" +

--- a/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -42,6 +42,7 @@ public fun <T : Any> TreehouseContent(
       override val boundContent: TreehouseView.Content<T> get() = rememberedContent.value
       override val children = ComposeWidgetChildren()
       override val hostConfiguration = MutableStateFlow(hostConfiguration)
+      override fun reset() = children.remove(0, children.widgets.size)
     }
   }
 

--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -50,6 +50,10 @@ public class TreehouseWidgetView<T : Any>(
   override val hostConfiguration: StateFlow<HostConfiguration>
     get() = mutableHostConfiguration
 
+  override fun reset() {
+    children.remove(0, childCount)
+  }
+
   public fun setContent(content: TreehouseView.Content<T>) {
     treehouseApp.dispatchers.checkUi()
     this.content = content

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -187,7 +187,7 @@ public class TreehouseApp<T : Any> internal constructor(
           scope.launch(dispatchers.ui) {
             if (firstDiff) {
               firstDiff = false
-              view.children.clear()
+              view.reset()
 
               when {
                 isInitialLaunch -> spec.viewBinder.beforeInitialCode(view)

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -24,6 +24,9 @@ public interface TreehouseView<T : Any> {
   public val children: Widget.Children<*>
   public val hostConfiguration: StateFlow<HostConfiguration>
 
+  /** Invoked when new code is loaded. This should at minimum clear all [children]. */
+  public fun reset()
+
   public fun interface Content<T : Any> {
     public fun get(app: T): ZiplineTreehouseUi
   }

--- a/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -50,6 +50,10 @@ public class TreehouseUIKitView<T : Any>(
   override val hostConfiguration: StateFlow<HostConfiguration>
     get() = mutableHostConfiguration
 
+  override fun reset() {
+    children.remove(0, view.subviews.size)
+  }
+
   public fun setContent(content: TreehouseView.Content<T>) {
     treehouseApp.dispatchers.checkUi()
     this.content = content

--- a/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
+++ b/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
@@ -50,11 +50,6 @@ public class ComposeWidgetChildren : Widget.Children<@Composable () -> Unit> {
     layoutModifiers.remove(index, count)
   }
 
-  override fun clear() {
-    _widgets.clear()
-    layoutModifiers.clear()
-  }
-
   override fun onLayoutModifierUpdated(index: Int) {
     layoutModifiers.set(index, _widgets[index].layoutModifiers)
   }

--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
@@ -52,11 +52,6 @@ public class ViewGroupChildren(
     parent.removeViews(index, count)
   }
 
-  override fun clear() {
-    _widgets.clear()
-    parent.removeAllViews()
-  }
-
   override fun onLayoutModifierUpdated(index: Int) {
     val view = parent.getChildAt(index)
     view.invalidate()

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
@@ -35,9 +35,5 @@ public class MutableListChildren<T : Any>(
     list.remove(index, count)
   }
 
-  override fun clear() {
-    list.clear()
-  }
-
   override fun onLayoutModifierUpdated(index: Int) {}
 }

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -57,9 +57,6 @@ public interface Widget<T : Any> {
     /** Remove [count] child widgets starting from [index]. */
     public fun remove(index: Int, count: Int)
 
-    /** Remove all child widgets. */
-    public fun clear()
-
     /** Indicates that the [LayoutModifier] for the widget at [index] has changed. */
     public fun onLayoutModifierUpdated(index: Int)
   }

--- a/redwood-widget/src/commonTest/kotlin/app/cash/redwood/widget/AbstractWidgetChildrenTest.kt
+++ b/redwood-widget/src/commonTest/kotlin/app/cash/redwood/widget/AbstractWidgetChildrenTest.kt
@@ -138,19 +138,7 @@ abstract class AbstractWidgetChildrenTest<T : Any> {
     assertEquals(listOf("one", "two", "three"), names())
   }
 
-  @Test fun clearWhenEmpty() {
-    children.clear()
-    assertEquals(listOf(), names())
-  }
-
-  @Test fun clearWhenNonEmpty() {
-    children.insert(0, widget("one"))
-    children.insert(1, widget("two"))
-    children.clear()
-    assertEquals(listOf(), names())
-  }
-
-  protected fun <T : Any> Widget.Children<T>.insert(index: Int, widget: T) {
+  private fun <T : Any> Widget.Children<T>.insert(index: Int, widget: T) {
     insert(
       index = index,
       widget = object : Widget<T> {

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -65,15 +65,6 @@ public class UIViewChildren(
     invalidate()
   }
 
-  override fun clear() {
-    _widgets.clear()
-
-    for (subview in parent.typedSubviews) {
-      subview.removeFromSuperview()
-    }
-    invalidate()
-  }
-
   override fun onLayoutModifierUpdated(index: Int) {
     invalidate()
   }

--- a/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
+++ b/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.widget
 
-import kotlinx.dom.clear
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
 
@@ -60,11 +59,6 @@ public class HTMLElementChildren(
     repeat(count) {
       parent.removeChild(parent.children[index]!!)
     }
-  }
-
-  override fun clear() {
-    _widgets.clear()
-    parent.clear()
   }
 
   override fun onLayoutModifierUpdated(index: Int) {


### PR DESCRIPTION
For Compose, this Applier function is only invoked when the Composition is going away and a new one is going to attach to an existing Applier. We never do that, thus, this function will never be invoked. Clear was used by Treehouse so a similar mechanism is introduced at that layer.