### PR TITLE
Ensure layoutModifier is the last non-@Children parameter in generated composable functions.

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -110,13 +110,9 @@ internal fun generateComposable(
         .addAnnotation(ComposeRuntime.Composable)
         .addAnnotation(composeTargetMarker)
         .apply {
-          // If the last trait is a child lambda move the layout modifier position to be
-          // second-to-last. This ensures you can still use trailing lambda syntax.
-          val layoutModifierIndex = if (widget.traits.lastOrNull() is Children) {
-            widget.traits.size - 1
-          } else {
-            widget.traits.size
-          }
+          // Set the layout modifier as the last non-child lambda in the function signature.
+          // This ensures you can still use trailing lambda syntax.
+          val layoutModifierIndex = widget.traits.indexOfLast { it !is Children } + 1
 
           var index = 0
           while (true) {

--- a/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.generator
 
+import androidx.compose.runtime.Composable
 import app.cash.redwood.schema.Children
 import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
@@ -100,5 +101,31 @@ class ComposeGenerationTest {
       contains("onEvent: (() -> Unit)? = { error(\"test\") }")
       contains("block: @Composable @DefaultSchemaComposable () -> Unit = {}")
     }
+  }
+
+  @Schema(
+    [
+      MultipleChildWidget::class,
+    ],
+  )
+  interface MultipleChildSchema
+
+  @Widget(1)
+  data class MultipleChildWidget(
+    @Children(1) val top: @Composable () -> Unit,
+    @Children(2) val bottom: @Composable () -> Unit,
+  )
+
+  @Test fun `layout modifier is the last non child parameter`() {
+    val schema = parseSchema(MultipleChildSchema::class)
+
+    val fileSpec = generateComposable(schema, schema.widgets.single())
+    assertThat(fileSpec.toString()).contains(
+      """
+      |  layoutModifier: LayoutModifier = LayoutModifier,
+      |  top: @Composable @MultipleChildSchemaComposable () -> Unit,
+      |  bottom: @Composable @MultipleChildSchemaComposable () -> Unit,
+      """.trimMargin(),
+    )
   }
 }


### PR DESCRIPTION
Noticed while upgrading to the latest Redwood that a widget with multiple `@Children` params is generated like so:

```kotlin
fun Widget(
  text: String,
  top: @Composable () -> Unit,
  layoutModifier: LayoutModifier = LayoutModifier,
  bottom: @Composable () -> Unit,
)
```

This updates the code to generate with the layout modifier as the last non-`@Children` param:

```kotlin
fun Widget(
  text: String,
  layoutModifier: LayoutModifier = LayoutModifier,
  top: @Composable () -> Unit,
  bottom: @Composable () -> Unit,
)
```