### PR TITLE
Restore the TreehouseView parameter in ViewBinder.widgetFactory

### DIFF
--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -173,6 +173,7 @@ public class TreehouseApp<T : Any> internal constructor(
       val display = ProtocolDisplay(
         container = view.children as Widget.Children<Any>,
         factory = spec.viewBinder.widgetFactory(
+          view,
           zipline.json,
           eventPublisher.protocolMismatchHandler(this@TreehouseApp),
         ) as Factory<Any>,

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/ViewBinder.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/ViewBinder.kt
@@ -31,6 +31,7 @@ public interface ViewBinder {
 
   /** Returns a widget factory for encoding and decoding changes to the contents of [view]. */
   public fun widgetFactory(
+    view: TreehouseView<*>,
     json: Json,
     mismatchHandler: ProtocolMismatchHandler,
   ): DiffConsumingWidget.Factory<*>

--- a/samples/emoji-search/android/src/main/java/app/cash/zipline/samples/emojisearch/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android/src/main/java/app/cash/zipline/samples/emojisearch/EmojiSearchActivity.kt
@@ -70,6 +70,7 @@ class EmojiSearchActivity : ComponentActivity() {
         hostApi = RealHostApi(httpClient),
         viewBinder = object : ViewBinder {
           override fun widgetFactory(
+            view: TreehouseView<*>,
             json: Json,
             mismatchHandler: ProtocolMismatchHandler,
           ) = DiffConsumingEmojiSearchWidgetFactory<@Composable () -> Unit>(

--- a/samples/emoji-search/ios/shared/src/commonMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchLauncher.kt
+++ b/samples/emoji-search/ios/shared/src/commonMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearchLauncher.kt
@@ -18,6 +18,7 @@ package app.cash.zipline.samples.emojisearch
 import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseLauncher
+import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.ViewBinder
 import app.cash.zipline.loader.ManifestVerifier
 import app.cash.zipline.loader.asZiplineHttpClient
@@ -52,6 +53,7 @@ class EmojiSearchLauncher(
         hostApi = hostApi,
         viewBinder = object : ViewBinder {
           override fun widgetFactory(
+            view: TreehouseView<*>,
             json: Json,
             mismatchHandler: ProtocolMismatchHandler,
           ) = DiffConsumingEmojiSearchWidgetFactory(


### PR DESCRIPTION
This is necessary for View-based factories which need a Context to create the child views.