### PR TITLE
Move ID generation out of applier

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
@@ -28,6 +28,7 @@ import com.squareup.kotlinpoet.UNIT
 internal object Protocol {
   val Event = ClassName("app.cash.redwood.protocol", "Event")
   val EventSink = ClassName("app.cash.redwood.protocol", "EventSink")
+  val Id = ClassName("app.cash.redwood.protocol", "Id")
   val PropertyDiff = ClassName("app.cash.redwood.protocol", "PropertyDiff")
   val LayoutModifiers = ClassName("app.cash.redwood.protocol", "LayoutModifiers")
 }
@@ -37,6 +38,7 @@ internal object ComposeProtocol {
     ClassName("app.cash.redwood.protocol.compose", "AbstractDiffProducingWidget")
   val DiffProducingWidget = ClassName("app.cash.redwood.protocol.compose", "DiffProducingWidget")
   val DiffProducingWidgetFactory = DiffProducingWidget.nestedClass("Factory")
+  val IdAllocator = ClassName("app.cash.redwood.protocol.compose", "IdAllocator")
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.compose", "ProtocolMismatchHandler")
 }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/AbstractDiffProducingWidget.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/AbstractDiffProducingWidget.kt
@@ -15,8 +15,6 @@
  */
 package app.cash.redwood.protocol.compose
 
-import app.cash.redwood.protocol.Event
-import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.LayoutModifiers
 import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.widget.Widget.Children
@@ -24,15 +22,7 @@ import app.cash.redwood.widget.Widget.Children
 /**
  * @suppress For generated code usage only.
  */
-public abstract class AbstractDiffProducingWidget(
-  public val type: Int,
-) : DiffProducingWidget {
-  override val value: Nothing
-    get() = throw AssertionError()
-
-  public var id: Id = Id(ULong.MAX_VALUE)
-    internal set
-
+public abstract class AbstractDiffProducingWidget : DiffProducingWidget {
   @Suppress("PropertyName") // Avoiding potential collision with subtype properties.
   internal lateinit var _diffAppender: DiffAppender
 
@@ -47,6 +37,4 @@ public abstract class AbstractDiffProducingWidget(
   protected fun diffProducingWidgetChildren(tag: UInt): Children<Nothing> {
     return DiffProducingWidgetChildren(id, tag, _diffAppender)
   }
-
-  public abstract fun sendEvent(event: Event)
 }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
@@ -27,7 +27,7 @@ internal class DiffProducingWidgetChildren(
   val ids = mutableListOf<Id>()
 
   override fun insert(index: Int, widget: Widget<Nothing>) {
-    widget as AbstractDiffProducingWidget
+    widget as DiffProducingWidget
     ids.add(index, widget.id)
     diffAppender.append(ChildrenDiff.Insert(id, tag, widget.id, widget.type, index))
   }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/IdAllocator.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/IdAllocator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2022 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,17 @@
  */
 package app.cash.redwood.protocol.compose
 
-import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.Id
-import app.cash.redwood.widget.Widget
 
 /**
- * A [Widget] with no platform-specific representation which instead produces protocol diffs
- * based on its properties.
+ * @suppress For generated code usage only.
  */
-public interface DiffProducingWidget : Widget<Nothing> {
-  public val id: Id
-  public val type: Int
+public class IdAllocator {
+  private var nextValue = Id.Root.value + 1U
 
-  override val value: Nothing
-    get() = throw AssertionError()
-
-  public fun sendEvent(event: Event)
-
-  /**
-   * Marker interface for types whose functions create [DiffProducingWidget]s.
-   */
-  public interface Factory : Widget.Factory<Nothing>
+  public fun next(): Id {
+    val value = nextValue
+    nextValue = value + 1U
+    return Id(value)
+  }
 }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolApplier.kt
@@ -67,7 +67,6 @@ internal class ProtocolApplier(
     DiffProducingWidgetChildren(Id.Root, RootChildrenTag, diffAppender),
   ),
 ) {
-  private var nextId = Id.Root.next()
   internal val nodes = mutableMapOf(Id.Root to root)
   private var closed = false
 
@@ -84,14 +83,10 @@ internal class ProtocolApplier(
       instance.children = instance.accessor!!.invoke(current)
       instance.accessor = null
     } else {
-      val id = nextId
-      nextId = id.next()
-
       instance as AbstractDiffProducingWidget
-      instance.id = id
       instance._diffAppender = diffAppender
 
-      nodes[id] = instance
+      nodes[instance.id] = instance
 
       val current = current as _ChildrenWidget
       current.children!!.insert(index, instance)
@@ -126,6 +121,4 @@ internal class ProtocolApplier(
   override fun onClear() {
     closed = true
   }
-
-  private fun Id.next(): Id = Id(value + 1UL)
 }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -103,7 +103,7 @@ private class DiffProducingRedwoodComposition(
 
     onEvent.sendEvent(event)
 
-    val node = applier.nodes[event.id] as AbstractDiffProducingWidget?
+    val node = applier.nodes[event.id] as DiffProducingWidget?
     if (node == null) {
       // TODO how to handle race where an incoming event targets this removed node?
       throw IllegalArgumentException("Unknown node ${event.id} for event with tag ${event.tag}")

--- a/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetFactoryTest.kt
+++ b/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetFactoryTest.kt
@@ -47,7 +47,6 @@ class DiffProducingWidgetFactoryTest {
     val diffProducingWidget = textInput as AbstractDiffProducingWidget
     val diffSink = RecordingDiffSink()
     val diffAppender = DiffAppender(diffSink)
-    diffProducingWidget.id = Id(1U)
     diffProducingWidget._diffAppender = diffAppender
 
     textInput.customType(10.seconds)
@@ -73,7 +72,6 @@ class DiffProducingWidgetFactoryTest {
     val diffProducingWidget = button as AbstractDiffProducingWidget
     val diffSink = RecordingDiffSink()
     val diffAppender = DiffAppender(diffSink)
-    diffProducingWidget.id = Id(1U)
     diffProducingWidget._diffAppender = diffAppender
 
     button.layoutModifiers = with(object : TestScope {}) {
@@ -115,7 +113,6 @@ class DiffProducingWidgetFactoryTest {
     val diffProducingWidget = button as AbstractDiffProducingWidget
     val diffSink = RecordingDiffSink()
     val diffAppender = DiffAppender(diffSink)
-    diffProducingWidget.id = Id(1U)
     diffProducingWidget._diffAppender = diffAppender
 
     button.layoutModifiers = with(object : TestScope {}) {


### PR DESCRIPTION
An `IdAllocator` type creates IDs and is owned by the root factory. This allows IDs to be created synchronously at construction time.

Some other small changes that are tangentially related are included in this change:
- The type is not longer held in a backing field and instead each subtype has a property getter to return its value.
- Elements of the diff-producing widgets have been moved to the `DiffProducingWidget` interface such as ID, type, and the ability to send an event.

This is the first in many steps toward sharing an Applier implementation between protocol-based and non-protocol-based usage.

Refs #14.