### PR TITLE
Rename `ProtocolDisplay` to `ProtocolBridge`

### DIFF
--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
@@ -22,17 +22,25 @@ import app.cash.redwood.protocol.Diff
 import app.cash.redwood.protocol.DiffSink
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.Id
+import app.cash.redwood.protocol.LayoutModifiers
 import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.widget.Widget
 import kotlinx.serialization.json.JsonArray
 
-public class ProtocolDisplay<T : Any>(
+/**
+ * Bridges the serialized Redwood protocol back to widgets on the display side.
+ *
+ * This type will consume [Diff]s and apply their [ChildrenDiff] operations to the widget tree.
+ * [PropertyDiff]s and [LayoutModifiers]s are forwarded to their respective widgets. Events from
+ * widgets are forwarded to [eventSink].
+ */
+public class ProtocolBridge<T : Any>(
   container: Widget.Children<T>,
   private val factory: DiffConsumingWidget.Factory<T>,
   private val eventSink: EventSink,
 ) : DiffSink {
   private val nodes = mutableMapOf(
-    Id.Root to Node(ProtocolDisplayRoot(container), Id.Root, container),
+    Id.Root to Node(DiffConsumingProtocolRoot(container), Id.Root, container),
   )
 
   override fun sendDiff(diff: Diff) {
@@ -91,7 +99,7 @@ private class Node<T : Any>(
     get() = _childIds ?: mutableListOf<Id>().also { _childIds = it }
 }
 
-private class ProtocolDisplayRoot<T : Any>(
+private class DiffConsumingProtocolRoot<T : Any>(
   private val children: Widget.Children<T>,
 ) : DiffConsumingWidget<T> {
   override var layoutModifiers: LayoutModifier

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolBridgeTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolBridgeTest.kt
@@ -25,9 +25,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class ProtocolDisplayTest {
+class ProtocolBridgeTest {
   @Test fun insertRootIdThrows() {
-    val protocolDisplay = ProtocolDisplay(
+    val bridge = ProtocolBridge(
       container = MutableListChildren(),
       factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory()),
       eventSink = ::error,
@@ -44,13 +44,13 @@ class ProtocolDisplayTest {
       ),
     )
     val t = assertFailsWith<IllegalArgumentException> {
-      protocolDisplay.sendDiff(diff)
+      bridge.sendDiff(diff)
     }
     assertEquals("Insert attempted to replace existing widget with ID 0", t.message)
   }
 
   @Test fun duplicateIdThrows() {
-    val protocolDisplay = ProtocolDisplay(
+    val bridge = ProtocolBridge(
       container = MutableListChildren(),
       factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory()),
       eventSink = ::error,
@@ -66,9 +66,9 @@ class ProtocolDisplayTest {
         ),
       ),
     )
-    protocolDisplay.sendDiff(diff)
+    bridge.sendDiff(diff)
     val t = assertFailsWith<IllegalArgumentException> {
-      protocolDisplay.sendDiff(diff)
+      bridge.sendDiff(diff)
     }
     assertEquals("Insert attempted to replace existing widget with ID 1", t.message)
   }

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -18,7 +18,7 @@ package app.cash.redwood.treehouse
 import app.cash.redwood.protocol.Diff
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.widget.DiffConsumingWidget.Factory
-import app.cash.redwood.protocol.widget.ProtocolDisplay
+import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.widget.Widget
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineService
@@ -170,7 +170,7 @@ public class TreehouseApp<T : Any> internal constructor(
       }
 
       @Suppress("UNCHECKED_CAST") // We don't have a type parameter for the widget type.
-      val display = ProtocolDisplay(
+      val bridge = ProtocolBridge(
         container = view.children as Widget.Children<Any>,
         factory = spec.viewBinder.widgetFactory(
           view,
@@ -196,7 +196,7 @@ public class TreehouseApp<T : Any> internal constructor(
               }
             }
 
-            display.sendDiff(diff)
+            bridge.sendDiff(diff)
           }
         }
       }

--- a/samples/counter/android-composeui/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android-composeui/src/main/java/example/android/MainActivity.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import app.cash.redwood.compose.AndroidUiDispatcher
 import app.cash.redwood.protocol.compose.ProtocolRedwoodComposition
-import app.cash.redwood.protocol.widget.ProtocolDisplay
+import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import example.android.sunspot.AndroidSunspotWidgetFactory
 import example.shared.Counter
@@ -60,13 +60,13 @@ class MainActivity : AppCompatActivity() {
     )
 
     val factory = DiffConsumingSunspotWidgetFactory(AndroidSunspotWidgetFactory())
-    val display = ProtocolDisplay(
+    val bridge = ProtocolBridge(
       container = composeChildren,
       factory = factory,
       eventSink = composition,
     )
 
-    composition.start(display)
+    composition.start(bridge)
     composition.setContent(content)
 
     return composeChildren

--- a/samples/counter/android-views/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android-views/src/main/java/example/android/MainActivity.kt
@@ -23,7 +23,7 @@ import android.widget.LinearLayout.LayoutParams
 import androidx.appcompat.app.AppCompatActivity
 import app.cash.redwood.compose.AndroidUiDispatcher
 import app.cash.redwood.protocol.compose.ProtocolRedwoodComposition
-import app.cash.redwood.protocol.widget.ProtocolDisplay
+import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.widget.ViewGroupChildren
 import example.android.sunspot.AndroidSunspotWidgetFactory
 import example.shared.Counter
@@ -52,13 +52,13 @@ class MainActivity : AppCompatActivity() {
     setContentView(root)
 
     val factory = DiffConsumingSunspotWidgetFactory(AndroidSunspotWidgetFactory(this))
-    val display = ProtocolDisplay(
+    val bridge = ProtocolBridge(
       container = ViewGroupChildren(root),
       factory = factory,
       eventSink = composition,
     )
 
-    composition.start(display)
+    composition.start(bridge)
 
     composition.setContent {
       Counter()

--- a/samples/counter/browser/src/main/kotlin/example/browser/main.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/main.kt
@@ -17,7 +17,7 @@ package example.browser
 
 import app.cash.redwood.compose.WindowAnimationFrameClock
 import app.cash.redwood.protocol.compose.ProtocolRedwoodComposition
-import app.cash.redwood.protocol.widget.ProtocolDisplay
+import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.widget.HTMLElementChildren
 import example.browser.sunspot.HtmlSunspotNodeFactory
 import example.shared.Counter
@@ -41,13 +41,13 @@ fun main() {
 
   val content = document.getElementById("content")!! as HTMLElement
   val factory = DiffConsumingSunspotWidgetFactory(HtmlSunspotNodeFactory(document))
-  val display = ProtocolDisplay(
+  val bridge = ProtocolBridge(
     container = HTMLElementChildren(content),
     factory = factory,
     eventSink = composition,
   )
 
-  composition.start(display)
+  composition.start(bridge)
 
   composition.setContent {
     Counter()

--- a/samples/counter/ios/shared/src/commonMain/kotlin/example/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios/shared/src/commonMain/kotlin/example/ios/CounterViewControllerDelegate.kt
@@ -17,7 +17,7 @@ package example.ios
 
 import androidx.compose.runtime.BroadcastFrameClock
 import app.cash.redwood.protocol.compose.ProtocolRedwoodComposition
-import app.cash.redwood.protocol.widget.ProtocolDisplay
+import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.widget.UIViewChildren
 import example.ios.sunspot.IosSunspotNodeFactory
 import example.shared.Counter
@@ -50,13 +50,13 @@ class CounterViewControllerDelegate(
       insert = { view, index -> root.insertArrangedSubview(view, index.convert()) },
     )
     val factory = DiffConsumingSunspotWidgetFactory(IosSunspotNodeFactory)
-    val display = ProtocolDisplay(
+    val bridge = ProtocolBridge(
       container = children,
       factory = factory,
       eventSink = composition,
     )
 
-    composition.start(display)
+    composition.start(bridge)
 
     composition.setContent {
       Counter()


### PR DESCRIPTION
We are going to have a symmetric type on the Compose side soon which will share its name.

Going for
```mermaid
flowchart LR;
    Compose-->DiffProducingWidgetFactory;
    DiffProducingWidgetFactory-->PB1[ProtocolBridge];
    PB1[ProtocolBridge] --> Protocol;
    Protocol --> ProtocolBridge;
    ProtocolBridge -->DiffConsumingWidgetFactory;
    DiffConsumingWidgetFactory-->Widgets;

```