### PR TITLE
Drop the event and diff side-effects

### DIFF
--- a/samples/counter/android-composeui/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android-composeui/src/main/java/example/android/MainActivity.kt
@@ -16,7 +16,6 @@
 package example.android
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
@@ -55,8 +54,6 @@ class MainActivity : AppCompatActivity() {
       scope = scope,
       factory = DiffProducingSunspotWidgetFactory(),
       widgetVersion = 1U,
-      onDiff = { Log.d("RedwoodDiff", it.toString()) },
-      onEvent = { Log.d("RedwoodEvent", it.toString()) },
     )
 
     val factory = DiffConsumingSunspotWidgetFactory(AndroidSunspotWidgetFactory())

--- a/samples/counter/android-views/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android-views/src/main/java/example/android/MainActivity.kt
@@ -16,7 +16,6 @@
 package example.android
 
 import android.os.Bundle
-import android.util.Log
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import android.widget.LinearLayout.LayoutParams
@@ -42,8 +41,6 @@ class MainActivity : AppCompatActivity() {
       scope = scope,
       factory = DiffProducingSunspotWidgetFactory(),
       widgetVersion = 1U,
-      onDiff = { Log.d("RedwoodDiff", it.toString()) },
-      onEvent = { Log.d("RedwoodEvent", it.toString()) },
     )
 
     val root = FrameLayout(this).apply {

--- a/samples/counter/browser/src/main/kotlin/example/browser/main.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/main.kt
@@ -35,8 +35,6 @@ fun main() {
     scope = GlobalScope + WindowAnimationFrameClock,
     factory = DiffProducingSunspotWidgetFactory(),
     widgetVersion = 1U,
-    onDiff = { console.log("RedwoodDiff", it.toString()) },
-    onEvent = { console.log("RedwoodEvent", it.toString()) },
   )
 
   val content = document.getElementById("content")!! as HTMLElement

--- a/samples/counter/ios/shared/src/commonMain/kotlin/example/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios/shared/src/commonMain/kotlin/example/ios/CounterViewControllerDelegate.kt
@@ -27,7 +27,6 @@ import kotlinx.cinterop.convert
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.plus
-import platform.Foundation.NSLog
 import platform.UIKit.UIStackView
 
 class CounterViewControllerDelegate(
@@ -41,8 +40,6 @@ class CounterViewControllerDelegate(
       scope = scope,
       factory = DiffProducingSunspotWidgetFactory(),
       widgetVersion = 1U,
-      onDiff = { NSLog("RedwoodDiff: $it") },
-      onEvent = { NSLog("RedwoodEvent: $it") },
     )
 
     val children = UIViewChildren(


### PR DESCRIPTION
You can always wrap if you need these.

Do not lament the loss of the log statements in the samples, for these are the ones which will be migrated to not use the protocol altogether in a follow-up!