### PR TITLE
Eliminate specialized `ProtocolRedwoodComposition` type

### DIFF
--- a/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
+++ b/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
@@ -48,9 +48,9 @@ class ProtocolTest {
     val composition = ProtocolRedwoodComposition(
       scope = this + clock,
       factory = DiffProducingExampleSchemaWidgetFactory(ProtocolBridge()),
+      diffSink = ::error,
       widgetVersion = 22U,
     )
-    composition.start { }
 
     var actualDisplayVersion = 0U
     composition.setContent {
@@ -63,13 +63,13 @@ class ProtocolTest {
 
   @Test fun childrenInheritIdFromSyntheticParent() = runTest {
     val clock = BroadcastFrameClock()
+    val diffs = ArrayDeque<Diff>()
     val composition = ProtocolRedwoodComposition(
       scope = this + clock,
       factory = DiffProducingExampleSchemaWidgetFactory(ProtocolBridge()),
+      diffSink = { diff -> diffs += diff },
       widgetVersion = 1U,
     )
-    val diffs = ArrayDeque<Diff>()
-    composition.start { diff -> diffs += diff }
 
     composition.setContent {
       Row {
@@ -110,13 +110,13 @@ class ProtocolTest {
     val clock = BroadcastFrameClock()
     var state by mutableStateOf(0)
     val bridge = ProtocolBridge()
+    val diffs = ArrayDeque<Diff>()
     val composition = ProtocolRedwoodComposition(
       scope = this + clock,
       factory = DiffProducingExampleSchemaWidgetFactory(bridge),
+      diffSink = { diff -> diffs += diff },
       widgetVersion = 1U,
     )
-    val diffs = ArrayDeque<Diff>()
-    composition.start { diff -> diffs += diff }
 
     composition.setContent {
       Button(

--- a/samples/counter/android-composeui/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android-composeui/src/main/java/example/android/MainActivity.kt
@@ -52,11 +52,6 @@ class MainActivity : AppCompatActivity() {
     val composeChildren = ComposeWidgetChildren()
 
     val composeBridge = ComposeProtocolBridge()
-    val composition = ProtocolRedwoodComposition(
-      scope = scope,
-      factory = DiffProducingSunspotWidgetFactory(composeBridge),
-      widgetVersion = 1U,
-    )
 
     val factory = DiffConsumingSunspotWidgetFactory(AndroidSunspotWidgetFactory())
     val widgetBridge = ProtocolBridge(
@@ -65,7 +60,12 @@ class MainActivity : AppCompatActivity() {
       eventSink = composeBridge,
     )
 
-    composition.start(widgetBridge)
+    val composition = ProtocolRedwoodComposition(
+      scope = scope,
+      factory = DiffProducingSunspotWidgetFactory(composeBridge),
+      diffSink = widgetBridge,
+      widgetVersion = 1U,
+    )
     composition.setContent(content)
 
     return composeChildren

--- a/samples/counter/android-views/src/main/java/example/android/MainActivity.kt
+++ b/samples/counter/android-views/src/main/java/example/android/MainActivity.kt
@@ -39,11 +39,6 @@ class MainActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val composeBridge = ComposeProtocolBridge()
-    val composition = ProtocolRedwoodComposition(
-      scope = scope,
-      factory = DiffProducingSunspotWidgetFactory(composeBridge),
-      widgetVersion = 1U,
-    )
 
     val root = FrameLayout(this).apply {
       layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
@@ -57,8 +52,12 @@ class MainActivity : AppCompatActivity() {
       eventSink = composeBridge,
     )
 
-    composition.start(widgetBridge)
-
+    val composition = ProtocolRedwoodComposition(
+      scope = scope,
+      factory = DiffProducingSunspotWidgetFactory(composeBridge),
+      diffSink = widgetBridge,
+      widgetVersion = 1U,
+    )
     composition.setContent {
       Counter()
     }

--- a/samples/counter/browser/src/main/kotlin/example/browser/main.kt
+++ b/samples/counter/browser/src/main/kotlin/example/browser/main.kt
@@ -31,14 +31,7 @@ import kotlinx.coroutines.plus
 import org.w3c.dom.HTMLElement
 
 fun main() {
-  @OptIn(DelicateCoroutinesApi::class)
-  val scope = GlobalScope + WindowAnimationFrameClock
   val composeBridge = ComposeProtocolBridge()
-  val composition = ProtocolRedwoodComposition(
-    scope = scope,
-    factory = DiffProducingSunspotWidgetFactory(composeBridge),
-    widgetVersion = 1U,
-  )
 
   val content = document.getElementById("content")!! as HTMLElement
   val factory = DiffConsumingSunspotWidgetFactory(HtmlSunspotNodeFactory(document))
@@ -48,8 +41,14 @@ fun main() {
     eventSink = composeBridge,
   )
 
-  composition.start(widgetBridge)
-
+  @OptIn(DelicateCoroutinesApi::class)
+  val scope = GlobalScope + WindowAnimationFrameClock
+  val composition = ProtocolRedwoodComposition(
+    scope = scope,
+    factory = DiffProducingSunspotWidgetFactory(composeBridge),
+    diffSink = widgetBridge,
+    widgetVersion = 1U,
+  )
   composition.setContent {
     Counter()
   }

--- a/samples/counter/ios/shared/src/commonMain/kotlin/example/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios/shared/src/commonMain/kotlin/example/ios/CounterViewControllerDelegate.kt
@@ -38,11 +38,6 @@ class CounterViewControllerDelegate(
 
   init {
     val composeBridge = ComposeProtocolBridge()
-    val composition = ProtocolRedwoodComposition(
-      scope = scope,
-      factory = DiffProducingSunspotWidgetFactory(composeBridge),
-      widgetVersion = 1U,
-    )
 
     val children = UIViewChildren(
       parent = root,
@@ -55,8 +50,12 @@ class CounterViewControllerDelegate(
       eventSink = composeBridge,
     )
 
-    composition.start(widgetBridge)
-
+    val composition = ProtocolRedwoodComposition(
+      scope = scope,
+      factory = DiffProducingSunspotWidgetFactory(composeBridge),
+      diffSink = widgetBridge,
+      widgetVersion = 1U,
+    )
     composition.setContent {
       Counter()
     }


### PR DESCRIPTION
We can accept the `DiffSink` in the factory function now that the `EventSink` is created before the function can be invoked. That means the function now launches the composition rather than needing an explicit start call.

Refs #14. Getting close!