### PR TITLE
Move our applier into Compose module, public API

### DIFF
--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
@@ -65,9 +65,10 @@ public inline fun <F : Widget.Factory<*>, W : Widget<*>> _RedwoodComposeNode(
 
   if (currentComposer.inserting) {
     @Suppress("UNCHECKED_CAST") // Safe so long as you use generated composition function.
-    val applier = currentComposer.applier as _RedwoodApplier<F>
+    val applier = currentComposer.applier as WidgetApplier<F>
     currentComposer.createNode {
-      factory(applier.factory)
+      @Suppress("UNCHECKED_CAST") // Safe so long as you use generated composition function.
+      factory(applier.factory as F)
     }
   } else {
     currentComposer.useNode()
@@ -89,10 +90,10 @@ public class _RedwoodComposeContent<out W : Widget<*>> {
     accessor: (W) -> Widget.Children<*>,
     content: @Composable () -> Unit,
   ) {
-    ComposeNode<_ChildrenWidget<*>, Applier<*>>(
+    ComposeNode<ChildrenWidget<*>, Applier<*>>(
       factory = {
         @Suppress("UNCHECKED_CAST")
-        _ChildrenWidget(accessor as (Widget<Any>) -> Widget.Children<Any>)
+        ChildrenWidget(accessor as (Widget<Any>) -> Widget.Children<Any>)
       },
       update = {},
       content = content,
@@ -116,25 +117,15 @@ public class _RedwoodComposeContent<out W : Widget<*>> {
  *
  * @suppress For generated code usage only.
  */
-// TODO Make this type private when the applier moves into this module.
-@Suppress("ClassName") // Hiding from auto-complete.
-public class _ChildrenWidget<W : Any> private constructor(
-  public var accessor: ((Widget<W>) -> Widget.Children<W>)?,
-  public var children: Widget.Children<W>?,
+internal class ChildrenWidget<W : Any> private constructor(
+  var accessor: ((Widget<W>) -> Widget.Children<W>)?,
+  var children: Widget.Children<W>?,
 ) : Widget<W> {
-  public constructor(accessor: (Widget<W>) -> Widget.Children<W>) : this(accessor, null)
-  public constructor(children: Widget.Children<W>) : this(null, children)
+  constructor(accessor: (Widget<W>) -> Widget.Children<W>) : this(accessor, null)
+  constructor(children: Widget.Children<W>) : this(null, children)
 
   override val value: Nothing get() = throw AssertionError()
   override var layoutModifiers: LayoutModifier
     get() = throw AssertionError()
     set(_) { throw AssertionError() }
-}
-
-/**
- * @suppress For generated code usage only.
- */
-@Suppress("ClassName") // Hiding from auto-complete.
-public interface _RedwoodApplier<F : Widget.Factory<*>> {
-  public val factory: F
 }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.snapshots.Snapshot
 import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.compose.RedwoodComposition
+import app.cash.redwood.compose.WidgetApplier
 import app.cash.redwood.protocol.ChildrenDiff
 import app.cash.redwood.protocol.DiffSink
 import app.cash.redwood.protocol.Id
@@ -44,7 +45,7 @@ public fun ProtocolRedwoodComposition(
 ): RedwoodComposition {
   val bridge = factory.bridge
   val root = DiffProducingWidgetChildren(Id.Root, ChildrenDiff.RootChildrenTag, bridge)
-  val applier = ProtocolApplier(factory, root) {
+  val applier = WidgetApplier(factory, root) {
     bridge.createDiffOrNull()?.let(diffSink::sendDiff)
   }
   return DiffProducingRedwoodComposition(scope, applier, widgetVersion)
@@ -52,7 +53,7 @@ public fun ProtocolRedwoodComposition(
 
 private class DiffProducingRedwoodComposition(
   private val scope: CoroutineScope,
-  applier: ProtocolApplier,
+  applier: WidgetApplier<Nothing>,
   private val widgetVersion: UInt,
 ) : RedwoodComposition {
   private val recomposer = Recomposer(scope.coroutineContext)


### PR DESCRIPTION
Since it no longer depends on protocol implementation details it can move upstream so that it can be used without the protocol in the future.

Refs #14.