### PR TITLE
Add OptIn annotation for generated code APIs

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -77,6 +77,7 @@ internal fun generateComposableTargetMarker(schema: Schema): FileSpec {
 /*
 @Composable
 @SunspotComposable
+@OptIn(RedwoodCodegenApi::class)
 fun Row(
   padding: Padding = Padding.Zero,
   overflow: Overflow = Overflow.Clip,
@@ -113,6 +114,11 @@ internal fun generateComposable(
         .addModifiers(PUBLIC)
         .addAnnotation(ComposeRuntime.Composable)
         .addAnnotation(composeTargetMarker)
+        .addAnnotation(
+          AnnotationSpec.builder(Stdlib.OptIn)
+            .addMember("%T::class", Redwood.RedwoodCodegenApi)
+            .build(),
+        )
         .apply {
           // Set the layout modifier as the last non-child lambda in the function signature.
           // This ensures you can still use trailing lambda syntax.

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
@@ -52,6 +52,7 @@ internal object Redwood {
   val LayoutModifier = ClassName("app.cash.redwood", "LayoutModifier")
   val LayoutModifierElement = LayoutModifier.nestedClass("Element")
   val LayoutScopeMarker = ClassName("app.cash.redwood", "LayoutScopeMarker")
+  val RedwoodCodegenApi = ClassName("app.cash.redwood", "RedwoodCodegenApi")
 }
 
 internal object RedwoodWidget {
@@ -62,7 +63,7 @@ internal object RedwoodWidget {
 }
 
 internal object RedwoodCompose {
-  val RedwoodComposeNode = MemberName("app.cash.redwood.compose", "_RedwoodComposeNode")
+  val RedwoodComposeNode = MemberName("app.cash.redwood.compose", "RedwoodComposeNode")
 }
 
 internal object ComposeRuntime {
@@ -88,6 +89,7 @@ internal fun composableLambda(
 
 internal object Stdlib {
   val AssertionError = ClassName("kotlin", "AssertionError")
+  val OptIn = ClassName("kotlin", "OptIn")
 }
 
 internal val typeVariableW = TypeVariableName("W", listOf(ANY))

--- a/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
@@ -48,6 +48,7 @@ class ComposeGenerationTest {
       """
       |@Composable
       |@ScopedAndUnscopedSchemaComposable
+      |@OptIn(RedwoodCodegenApi::class)
       |public fun
       """.trimMargin(),
     )

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.Updater
 import androidx.compose.runtime.currentComposer
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.widget.Widget
 import kotlin.DeprecationLevel.ERROR
 import kotlinx.coroutines.CoroutineScope
@@ -53,11 +54,11 @@ public fun <W : Any> RedwoodComposition(
  * @suppress For generated code usage only.
  */
 @Composable
-@Suppress("FunctionName") // Hiding from auto-complete.
-public inline fun <F : Widget.Factory<*>, W : Widget<*>> _RedwoodComposeNode(
+@RedwoodCodegenApi
+public inline fun <F : Widget.Factory<*>, W : Widget<*>> RedwoodComposeNode(
   crossinline factory: (F) -> W,
   update: @DisallowComposableCalls Updater<W>.() -> Unit,
-  content: @Composable _RedwoodComposeContent<W>.() -> Unit,
+  content: @Composable RedwoodComposeContent<W>.() -> Unit,
 ) {
   // NOTE: You MUST keep the implementation of this function (or more specifically, the interaction
   //  with currentComposer) in sync with ComposeNode.
@@ -75,7 +76,7 @@ public inline fun <F : Widget.Factory<*>, W : Widget<*>> _RedwoodComposeNode(
   }
 
   Updater<W>(currentComposer).update()
-  _RedwoodComposeContent.Instance.content()
+  RedwoodComposeContent.Instance.content()
 
   currentComposer.endNode()
 }
@@ -83,8 +84,8 @@ public inline fun <F : Widget.Factory<*>, W : Widget<*>> _RedwoodComposeNode(
 /**
  * @suppress For generated code usage only.
  */
-@Suppress("ClassName") // Hiding from auto-complete.
-public class _RedwoodComposeContent<out W : Widget<*>> {
+@RedwoodCodegenApi
+public class RedwoodComposeContent<out W : Widget<*>> {
   @Composable
   public fun into(
     accessor: (W) -> Widget.Children<*>,
@@ -101,7 +102,7 @@ public class _RedwoodComposeContent<out W : Widget<*>> {
   }
 
   public companion object {
-    public val Instance: _RedwoodComposeContent<Nothing> = _RedwoodComposeContent()
+    public val Instance: RedwoodComposeContent<Nothing> = RedwoodComposeContent()
   }
 }
 

--- a/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/annotations.kt
+++ b/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/annotations.kt
@@ -20,3 +20,11 @@ package app.cash.redwood
  */
 @DslMarker
 public annotation class LayoutScopeMarker
+
+/**
+ * Denote an API which should only be used by Redwood's generated code.
+ *
+ * @suppress
+ */
+@RequiresOptIn("This API is for use by Redwood's generated code only")
+public annotation class RedwoodCodegenApi


### PR DESCRIPTION
Speed bumps to try and prevent manual usage since interaction is delicate.

Closes #542. Even though it's only used by Compose code, I expect to use it in widget code after some refactorings so I chose to put it in 'runtime'.