### PR TITLE
Do not double wrap native widgets for diff consumption

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
@@ -42,8 +42,8 @@ internal object ComposeProtocol {
 }
 
 internal object WidgetProtocol {
-  val DiffConsumingWidget = ClassName("app.cash.redwood.protocol.widget", "DiffConsumingWidget")
-  val DiffConsumingWidgetFactory = DiffConsumingWidget.nestedClass("Factory")
+  val DiffConsumingNode = ClassName("app.cash.redwood.protocol.widget", "DiffConsumingNode")
+  val DiffConsumingNodeFactory = DiffConsumingNode.nestedClass("Factory")
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.widget", "ProtocolMismatchHandler")
 }
@@ -58,7 +58,7 @@ internal object Redwood {
 internal object RedwoodWidget {
   val Widget = ClassName("app.cash.redwood.widget", "Widget")
   val WidgetChildren = Widget.nestedClass("Children")
-  val WidgetChildrenOfT = WidgetChildren.parameterizedBy(typeVariableW)
+  val WidgetChildrenOfW = WidgetChildren.parameterizedBy(typeVariableW)
   val WidgetFactory = Widget.nestedClass("Factory")
 }
 

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/widgetGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/widgetGeneration.kt
@@ -111,7 +111,7 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
               }
               is Children -> {
                 addProperty(
-                  PropertySpec.builder(trait.name, RedwoodWidget.WidgetChildrenOfT)
+                  PropertySpec.builder(trait.name, RedwoodWidget.WidgetChildrenOfW)
                     .addModifiers(PUBLIC, ABSTRACT)
                     .addKdoc("{tag=${trait.tag}}")
                     .build(),

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidgetFactoryTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingWidgetFactoryTest.kt
@@ -42,7 +42,7 @@ class DiffConsumingWidgetFactoryTest {
     val factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory())
 
     val t = assertFailsWith<IllegalArgumentException> {
-      factory.create(345432)
+      factory.create(Id.Root, ThrowingWidgetChildren(), 345432)
     }
     assertEquals("Unknown widget kind 345432", t.message)
   }
@@ -54,7 +54,7 @@ class DiffConsumingWidgetFactoryTest {
       mismatchHandler = handler,
     )
 
-    assertNull(factory.create(345432))
+    assertNull(factory.create(Id.Root, ThrowingWidgetChildren(), 345432))
 
     assertEquals("Unknown widget 345432", handler.events.single())
   }
@@ -72,7 +72,7 @@ class DiffConsumingWidgetFactoryTest {
       },
       json = json,
     )
-    val textInput = factory.create(5)!!
+    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), 5)!!
 
     textInput.updateLayoutModifier(
       buildJsonArray {
@@ -90,7 +90,7 @@ class DiffConsumingWidgetFactoryTest {
     )
 
     with(object : TestScope {}) {
-      assertEquals(LayoutModifier.customType(10.seconds), textInput.layoutModifiers)
+      assertEquals(LayoutModifier.customType(10.seconds), recordingTextInput.layoutModifiers)
     }
   }
 
@@ -107,7 +107,7 @@ class DiffConsumingWidgetFactoryTest {
       },
       json = json,
     )
-    val textInput = factory.create(5)!!
+    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), 5)!!
 
     textInput.updateLayoutModifier(
       buildJsonArray {
@@ -125,13 +125,13 @@ class DiffConsumingWidgetFactoryTest {
     )
 
     with(object : TestScope {}) {
-      assertEquals(LayoutModifier.customTypeWithDefault(10.seconds, "sup"), textInput.layoutModifiers)
+      assertEquals(LayoutModifier.customTypeWithDefault(10.seconds, "sup"), recordingTextInput.layoutModifiers)
     }
   }
 
   @Test fun unknownLayoutModifierThrowsDefault() {
     val factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory())
-    val button = factory.create(4)!!
+    val button = factory.create(Id.Root, ThrowingWidgetChildren(), 4)!!
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.updateLayoutModifier(
@@ -164,7 +164,7 @@ class DiffConsumingWidgetFactoryTest {
       mismatchHandler = handler,
     )
 
-    val textInput = factory.create(5)!!
+    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), 5)!!
     textInput.updateLayoutModifier(
       buildJsonArray {
         add(
@@ -192,7 +192,7 @@ class DiffConsumingWidgetFactoryTest {
 
   @Test fun unknownChildrenThrowsDefault() {
     val factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory())
-    val button = factory.create(4)!!
+    val button = factory.create(Id.Root, ThrowingWidgetChildren(), 4)!!
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.children(345432U)
@@ -207,7 +207,7 @@ class DiffConsumingWidgetFactoryTest {
       mismatchHandler = handler,
     )
 
-    val button = factory.create(4)!!
+    val button = factory.create(Id.Root, ThrowingWidgetChildren(), 4)!!
     assertNull(button.children(345432U))
 
     assertEquals("Unknown children 345432 for 4", handler.events.single())
@@ -226,7 +226,7 @@ class DiffConsumingWidgetFactoryTest {
       },
       json = json,
     )
-    val textInput = factory.create(5)!!
+    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), 5)!!
 
     val throwingEventSink = EventSink { error(it) }
     textInput.apply(PropertyDiff(Id(1U), 2U, JsonPrimitive("PT10S")), throwingEventSink)
@@ -236,7 +236,7 @@ class DiffConsumingWidgetFactoryTest {
 
   @Test fun unknownPropertyThrowsDefaults() {
     val factory = DiffConsumingExampleSchemaWidgetFactory(EmptyExampleSchemaWidgetFactory())
-    val button = factory.create(4) as DiffConsumingWidget<*>
+    val button = factory.create(Id.Root, ThrowingWidgetChildren(), 4)!!
 
     val diff = PropertyDiff(Id(1U), 345432U)
     val eventSink = EventSink { throw UnsupportedOperationException() }
@@ -252,7 +252,7 @@ class DiffConsumingWidgetFactoryTest {
       delegate = EmptyExampleSchemaWidgetFactory(),
       mismatchHandler = handler,
     )
-    val button = factory.create(4) as DiffConsumingWidget<*>
+    val button = factory.create(Id.Root, ThrowingWidgetChildren(), 4)!!
 
     button.apply(PropertyDiff(Id(1U), 345432U)) { throw UnsupportedOperationException() }
 
@@ -272,7 +272,7 @@ class DiffConsumingWidgetFactoryTest {
       },
       json = json,
     )
-    val textInput = factory.create(5)!!
+    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), 5)!!
 
     val eventSink = RecordingEventSink()
     textInput.apply(PropertyDiff(Id(1U), 4U, JsonPrimitive(true)), eventSink)

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ThrowingWidgetChildren.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ThrowingWidgetChildren.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import app.cash.redwood.widget.Widget
+
+class ThrowingWidgetChildren<W : Any> : Widget.Children<W> {
+  override fun insert(index: Int, widget: Widget<W>) = throw AssertionError()
+  override fun move(fromIndex: Int, toIndex: Int, count: Int) = throw AssertionError()
+  override fun remove(index: Int, count: Int) = throw AssertionError()
+  override fun onLayoutModifierUpdated(index: Int) = throw AssertionError()
+}

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -17,7 +17,7 @@ package app.cash.redwood.treehouse
 
 import app.cash.redwood.protocol.Diff
 import app.cash.redwood.protocol.EventSink
-import app.cash.redwood.protocol.widget.DiffConsumingWidget
+import app.cash.redwood.protocol.widget.DiffConsumingNode
 import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.widget.Widget
 import app.cash.zipline.Zipline
@@ -178,7 +178,7 @@ public class TreehouseApp<A : Any> internal constructor(
       @Suppress("UNCHECKED_CAST") // We don't have a type parameter for the widget type.
       val bridge = ProtocolBridge(
         container = view.children as Widget.Children<Any>,
-        factory = widgetFactory as DiffConsumingWidget.Factory<Any>,
+        factory = widgetFactory as DiffConsumingNode.Factory<Any>,
         eventSink = eventSink,
       )
 

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -15,7 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.protocol.widget.DiffConsumingWidget
+import app.cash.redwood.protocol.widget.DiffConsumingNode
 import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
 import app.cash.redwood.widget.Widget
 import kotlinx.coroutines.flow.StateFlow
@@ -42,7 +42,7 @@ public interface TreehouseView<A : Any> {
       app: TreehouseApp<A>,
       json: Json,
       protocolMismatchHandler: ProtocolMismatchHandler,
-    ): DiffConsumingWidget.Factory<*>
+    ): DiffConsumingNode.Factory<*>
   }
 
   public open class CodeListener {

--- a/samples/emoji-search/android-views/src/main/java/app/cash/zipline/samples/emojisearch/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/java/app/cash/zipline/samples/emojisearch/views/EmojiSearchActivity.kt
@@ -18,7 +18,7 @@ package app.cash.zipline.samples.emojisearch.views
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import app.cash.redwood.compose.AndroidUiDispatcher.Companion.Main
-import app.cash.redwood.protocol.widget.DiffConsumingWidget
+import app.cash.redwood.protocol.widget.DiffConsumingNode
 import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseLauncher
@@ -47,7 +47,7 @@ class EmojiSearchActivity : ComponentActivity() {
         app: TreehouseApp<EmojiSearchPresenter>,
         json: Json,
         protocolMismatchHandler: ProtocolMismatchHandler,
-      ): DiffConsumingWidget.Factory<*> {
+      ): DiffConsumingNode.Factory<*> {
         return DiffConsumingEmojiSearchWidgetFactory(
           delegate = AndroidViewEmojiSearchWidgetFactory(
             context = this@EmojiSearchActivity,

--- a/samples/emoji-search/ios/app/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios/app/EmojiSearchApp/EmojiSearchViewController.swift
@@ -51,7 +51,7 @@ class EmojiSearchContent : Redwood_treehouseTreehouseViewContent {
 }
 
 class EmojiSearchWidgetSystem : Redwood_treehouseTreehouseViewWidgetSystem {
-    func widgetFactory(app: Redwood_treehouseTreehouseApp<AnyObject>, json: Kotlinx_serialization_jsonJson, protocolMismatchHandler: Redwood_protocol_widgetProtocolMismatchHandler) -> Redwood_protocol_widgetDiffConsumingWidgetFactory {
+    func widgetFactory(app: Redwood_treehouseTreehouseApp<AnyObject>, json: Kotlinx_serialization_jsonJson, protocolMismatchHandler: Redwood_protocol_widgetProtocolMismatchHandler) -> Redwood_protocol_widgetDiffConsumingNodeFactory {
         return ExposedKt.diffConsumingEmojiSearchWidgetFactory(
             delegate: IosEmojiSearchWidgetFactory(treehouseApp: app, widgetSystem: self),
             json: json,


### PR DESCRIPTION
Move responsibilities up into a base type for the generated diff consuming node. Additionally, there is no reason for this generated node to actually implement `Widget` and so that is dropped.

This is, admittedly, a little sloppy. It's merely a step on a larger refactoring that I wanted to fire off before the long weekend.