### PR TITLE
Ensure git index is clean after builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,9 @@ jobs:
           path: build/dokka/htmlMultiModule/
           if-no-files-found: error
 
-      - run: echo "// test" >> build.gradle
+      # Run the npm install on the full project. Without this, the partial build above updates the
+      # lock file with a subset of the full project's needs (thus making the git index dirty).
+      - run: ./gradlew kotlinNpmInstall
 
       - name: Ensure git index is clean
         run: test -z "$(git status --porcelain | tee /dev/fd/2)"
@@ -50,8 +52,6 @@ jobs:
       - uses: gradle/gradle-build-action@v2
 
       - run: ./gradlew verifyPaparazziDebug
-
-      - run: echo "test" > sup.txt
 
       - name: Ensure git index is clean
         run: test -z "$(git status --porcelain | tee /dev/fd/2)"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,11 @@ jobs:
           path: build/dokka/htmlMultiModule/
           if-no-files-found: error
 
+      - run: echo "// test" >> build.gradle
+
+      - name: Ensure git index is clean
+        run: test -z "$(git status --porcelain | tee /dev/fd/2)"
+
   paparazzi:
     runs-on: ubuntu-latest
     steps:
@@ -45,6 +50,11 @@ jobs:
       - uses: gradle/gradle-build-action@v2
 
       - run: ./gradlew verifyPaparazziDebug
+
+      - run: echo "test" > sup.txt
+
+      - name: Ensure git index is clean
+        run: test -z "$(git status --porcelain | tee /dev/fd/2)"
 
   sample-counter:
     runs-on: macos-latest
@@ -70,6 +80,9 @@ jobs:
           pod install
           xcodebuild -workspace CounterApp.xcworkspace -scheme CounterApp -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest'
 
+      - name: Ensure git index is clean
+        run: test -z "$(git status --porcelain | tee /dev/fd/2)"
+
   sample-emoji:
     runs-on: macos-latest
     steps:
@@ -88,6 +101,9 @@ jobs:
           cd samples/emoji-search/ios/app
           pod install
           xcodebuild -workspace EmojiSearchApp.xcworkspace -scheme EmojiSearchApp -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest'
+
+      - name: Ensure git index is clean
+        run: test -z "$(git status --porcelain | tee /dev/fd/2)"
 
   # This worker only serves to fan-in success on the parallel workers. It is used to guard merges
   # on GitHub by always running whereas 'publish' below only runs on our 'trunk'.


### PR DESCRIPTION
Closes #546.

First commit has two failing shards to demonstrate behavior: one with a modified tracked file and one with an untracked file. Second commit removes those from being generated and will pass.