### PR TITLE
Add width and height params to layouts.

### DIFF
--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexContainer.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/FlexContainer.kt
@@ -27,6 +27,16 @@ import kotlin.math.roundToInt
  */
 public class FlexContainer {
   /**
+   * If true, the container will fill the available width passed to it in [measure].
+   */
+  public var fillWidth: Boolean = false
+
+  /**
+   * If true, the container will fill the available height passed to it in [measure].
+   */
+  public var fillHeight: Boolean = false
+
+  /**
    * The flex direction attribute of the container.
    */
   public var flexDirection: FlexDirection = FlexDirection.Row
@@ -887,20 +897,16 @@ public class FlexContainer {
    * Expand the item vertically to the size of the [crossSize] (considering [item]'s margins).
    */
   private fun stretchViewVertically(item: FlexItem, crossSize: Double) {
-    val newHeight = (crossSize - item.margin.top - item.margin.bottom)
+    item.measuredHeight = (crossSize - item.margin.top - item.margin.bottom)
       .coerceIn(item.measurable.minHeight, item.measurable.maxHeight)
-    item.measuredWidth = item.measuredWidth
-    item.measuredHeight = newHeight
   }
 
   /**
    * Expand the item horizontally to the size of the crossSize (considering [item]'s margins).
    */
   private fun stretchViewHorizontally(item: FlexItem, crossSize: Double) {
-    val newWidth = (crossSize - item.margin.start - item.margin.end)
+    item.measuredWidth = (crossSize - item.margin.start - item.margin.end)
       .coerceIn(item.measurable.minWidth, item.measurable.maxWidth)
-    item.measuredWidth = newWidth
-    item.measuredHeight = item.measuredHeight
   }
 
   /**
@@ -1045,10 +1051,21 @@ public class FlexContainer {
    * @param heightSpec vertical space requirements as imposed by the parent.
    */
   public fun measure(widthSpec: MeasureSpec, heightSpec: MeasureSpec): MeasureResult {
-    if (flexDirection.isHorizontal) {
-      return measureHorizontal(widthSpec, heightSpec)
+    val width = if (fillWidth && widthSpec.mode != MeasureSpecMode.Exactly && widthSpec.size > 0) {
+      MeasureSpec.from(widthSpec.size, MeasureSpecMode.Exactly)
     } else {
-      return measureVertical(widthSpec, heightSpec)
+      widthSpec
+    }
+    val height = if (fillHeight && heightSpec.mode != MeasureSpecMode.Exactly && heightSpec.size > 0) {
+      MeasureSpec.from(heightSpec.size, MeasureSpecMode.Exactly)
+    } else {
+      heightSpec
+    }
+
+    if (flexDirection.isHorizontal) {
+      return measureHorizontal(width, height)
+    } else {
+      return measureVertical(width, height)
     }
   }
 

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/properties.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexcontainer/properties.kt
@@ -260,7 +260,7 @@ public value class MeasureSpecMode internal constructor(internal val ordinal: In
 }
 
 /**
- * Describes the padding/margin to apply to a node/flexbox.
+ * Describes the padding/margin to apply to an item/container.
  */
 public data class Spacing(
   val start: Double = 0.0,

--- a/redwood-layout-api/src/commonMain/kotlin/app/cash/redwood/layout/api/properties.kt
+++ b/redwood-layout-api/src/commonMain/kotlin/app/cash/redwood/layout/api/properties.kt
@@ -25,6 +25,23 @@ import kotlinx.serialization.Serializable
 // TODO make value classes have private ctors and private vals.
 //  Blocked by https://issuetracker.google.com/issues/251430194.
 
+/** Controls how the container should determine its width/height. */
+@JvmInline
+@Serializable
+public value class Constraint internal constructor(internal val ordinal: Int) {
+
+  override fun toString(): String = when (ordinal) {
+    0 -> "Wrap"
+    1 -> "Fill"
+    else -> throw AssertionError()
+  }
+
+  public companion object {
+    public val Wrap: Constraint = Constraint(0)
+    public val Fill: Constraint = Constraint(1)
+  }
+}
+
 /** Equivalent to `justify-content`. */
 @JvmInline
 @Serializable

--- a/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeColumn.kt
+++ b/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeColumn.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.layout.composeui
 import androidx.compose.runtime.Composable
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.flexcontainer.FlexDirection
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
@@ -33,6 +34,14 @@ internal class ComposeColumn : Column<@Composable () -> Unit> {
   override val value: @Composable () -> Unit get() = container.composable
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
+
+  override fun width(width: Constraint) {
+    container.width(width)
+  }
+
+  override fun height(height: Constraint) {
+    container.height(height)
+  }
 
   override fun padding(padding: Padding) {
     container.padding(padding)

--- a/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeFlexContainer.kt
+++ b/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeFlexContainer.kt
@@ -60,12 +60,12 @@ internal class ComposeFlexContainer(private val direction: FlexDirection) {
 
   fun width(width: Constraint) {
     container.fillWidth = width == Constraint.Fill
-    recomposeTick++
+    invalidate()
   }
 
   fun height(height: Constraint) {
     container.fillHeight = height == Constraint.Fill
-    recomposeTick++
+    invalidate()
   }
 
   fun padding(padding: Padding) {

--- a/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeFlexContainer.kt
+++ b/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeFlexContainer.kt
@@ -35,6 +35,7 @@ import app.cash.redwood.flexcontainer.FlexContainer
 import app.cash.redwood.flexcontainer.FlexDirection
 import app.cash.redwood.flexcontainer.JustifyContent
 import app.cash.redwood.flexcontainer.isHorizontal
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.widget.Widget
@@ -56,6 +57,16 @@ internal class ComposeFlexContainer(private val direction: FlexDirection) {
   private var padding = Padding.Zero
 
   var modifier: Modifier by mutableStateOf(Modifier)
+
+  fun width(width: Constraint) {
+    container.fillWidth = width == Constraint.Fill
+    recomposeTick++
+  }
+
+  fun height(height: Constraint) {
+    container.fillHeight = height == Constraint.Fill
+    recomposeTick++
+  }
 
   fun padding(padding: Padding) {
     this.padding = padding

--- a/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeRow.kt
+++ b/redwood-layout-composeui/src/main/kotlin/app/cash/redwood/layout/composeui/ComposeRow.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.layout.composeui
 import androidx.compose.runtime.Composable
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.flexcontainer.FlexDirection
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
@@ -33,6 +34,14 @@ internal class ComposeRow : Row<@Composable () -> Unit> {
   override val value: @Composable () -> Unit get() = container.composable
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
+
+  override fun width(width: Constraint) {
+    container.width(width)
+  }
+
+  override fun height(height: Constraint) {
+    container.height(height)
+  }
 
   override fun padding(padding: Padding) {
     container.padding(padding)

--- a/redwood-layout-composeui/src/test/kotlin/app/cash/redwood/layout/composeui/ComposeFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/test/kotlin/app/cash/redwood/layout/composeui/ComposeFlexContainerTest.kt
@@ -30,6 +30,7 @@ import app.cash.redwood.flexcontainer.FlexDirection
 import app.cash.redwood.flexcontainer.JustifyContent
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.widget.Widget
 import org.junit.Rule
@@ -69,6 +70,14 @@ class ComposeFlexContainerTest : AbstractFlexContainerTest<@Composable () -> Uni
     private var childCount = 0
 
     override val value get() = delegate.composable
+
+    override fun width(constraint: Constraint) {
+      delegate.width(constraint)
+    }
+
+    override fun height(constraint: Constraint) {
+      delegate.width(constraint)
+    }
 
     override fun alignItems(alignItems: AlignItems) {
       delegate.alignItems(alignItems)

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeFlexContainerTest_columnWithJustifyContentCenter.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeFlexContainerTest_columnWithJustifyContentCenter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f0d5568b298259db005ebfe33a3817f4b4bc5d54311906a2b9b76b7425c54be
+size 58208

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeFlexContainerTest_columnWithJustifyContentSpaceAround.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeFlexContainerTest_columnWithJustifyContentSpaceAround.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66409be678b4724d7fc2d97cf9373cc351d176f191c3c04ef7253ab02165f829
+size 58637

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeFlexContainerTest_columnWithJustifyContentSpaceBetween.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeFlexContainerTest_columnWithJustifyContentSpaceBetween.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25772f9965122b14513716a1eb7d856f147544d69cabf2c59e95e4d84f9f47d3
+size 58553

--- a/redwood-layout-schema/src/main/kotlin/app/cash/redwood/layout/widgets.kt
+++ b/redwood-layout-schema/src/main/kotlin/app/cash/redwood/layout/widgets.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.layout
 
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
@@ -26,13 +27,17 @@ import app.cash.redwood.schema.Widget
 
 @Widget(1)
 public data class Row(
-  @Property(1) @Default("Padding.Zero")
+  @Property(1) @Default("Constraint.Wrap")
+  val width: Constraint,
+  @Property(2) @Default("Constraint.Wrap")
+  val height: Constraint,
+  @Property(3) @Default("Padding.Zero")
   val padding: Padding,
-  @Property(2) @Default("Overflow.Clip")
+  @Property(4) @Default("Overflow.Clip")
   val overflow: Overflow,
-  @Property(3) @Default("MainAxisAlignment.Start")
+  @Property(5) @Default("MainAxisAlignment.Start")
   val horizontalAlignment: MainAxisAlignment,
-  @Property(4) @Default("CrossAxisAlignment.Start")
+  @Property(6) @Default("CrossAxisAlignment.Start")
   val verticalAlignment: CrossAxisAlignment,
   @Children(1) val children: RowScope.() -> Unit,
 )
@@ -41,13 +46,17 @@ public object RowScope
 
 @Widget(2)
 public data class Column(
-  @Property(1) @Default("Padding.Zero")
+  @Property(1) @Default("Constraint.Wrap")
+  val width: Constraint,
+  @Property(2) @Default("Constraint.Wrap")
+  val height: Constraint,
+  @Property(3) @Default("Padding.Zero")
   val padding: Padding,
-  @Property(2) @Default("Overflow.Clip")
+  @Property(4) @Default("Overflow.Clip")
   val overflow: Overflow,
-  @Property(3) @Default("CrossAxisAlignment.Start")
+  @Property(5) @Default("CrossAxisAlignment.Start")
   val horizontalAlignment: CrossAxisAlignment,
-  @Property(4) @Default("MainAxisAlignment.Start")
+  @Property(6) @Default("MainAxisAlignment.Start")
   val verticalAlignment: MainAxisAlignment,
   @Children(1) val children: ColumnScope.() -> Unit,
 )

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -19,6 +19,7 @@ import app.cash.redwood.LayoutModifier
 import app.cash.redwood.flexcontainer.AlignItems
 import app.cash.redwood.flexcontainer.FlexDirection
 import app.cash.redwood.flexcontainer.JustifyContent
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.widget.Widget
@@ -75,10 +76,45 @@ abstract class AbstractFlexContainerTest<T : Any> {
     }
     verifySnapshot(container)
   }
+
+  @Test fun columnWithJustifyContentCenter() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.justifyContent(JustifyContent.Center)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container)
+  }
+
+  @Test fun columnWithJustifyContentSpaceBetween() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.justifyContent(JustifyContent.SpaceBetween)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container)
+  }
+
+  @Test fun columnWithJustifyContentSpaceAround() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.justifyContent(JustifyContent.SpaceAround)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container)
+  }
 }
 
 interface TestFlexContainer<T : Any> {
   val value: T
+  fun width(constraint: Constraint)
+  fun height(constraint: Constraint)
   fun alignItems(alignItems: AlignItems)
   fun justifyContent(justifyContent: JustifyContent)
   fun padding(padding: Padding)

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewColumn.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewColumn.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.layout.uiview
 
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.flexcontainer.FlexDirection
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
@@ -33,6 +34,14 @@ internal class UIViewColumn(viewFactory: RedwoodUIScrollViewFactory) : Column<UI
   override val value: UIView get() = container.view
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
+
+  override fun width(width: Constraint) {
+    container.width(width)
+  }
+
+  override fun height(height: Constraint) {
+    container.height(height)
+  }
 
   override fun padding(padding: Padding) {
     container.padding(padding)

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.flexcontainer.FlexContainer
 import app.cash.redwood.flexcontainer.FlexDirection
 import app.cash.redwood.flexcontainer.JustifyContent
 import app.cash.redwood.flexcontainer.MeasureResult
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.widget.UIViewChildren
@@ -48,6 +49,16 @@ internal class UIViewFlexContainer(
 
   private val _children: UIViewChildren = UIViewChildren(_view)
   val children: Widget.Children<UIView> get() = _children
+
+  fun width(width: Constraint) {
+    container.fillWidth = width == Constraint.Fill
+    invalidate()
+  }
+
+  fun height(height: Constraint) {
+    container.fillHeight = height == Constraint.Fill
+    invalidate()
+  }
 
   fun padding(padding: Padding) {
     container.padding = padding.toSpacing()

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewRow.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewRow.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.layout.uiview
 
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.flexcontainer.FlexDirection
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
@@ -33,6 +34,14 @@ internal class UIViewRow(viewFactory: RedwoodUIScrollViewFactory) : Row<UIView> 
   override val value: UIView get() = container.view
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
+
+  override fun width(width: Constraint) {
+    container.width(width)
+  }
+
+  override fun height(height: Constraint) {
+    container.height(height)
+  }
 
   override fun padding(padding: Padding) {
     container.padding(padding)

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewColumn.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewColumn.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.view.View
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.flexcontainer.FlexDirection
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
@@ -34,6 +35,14 @@ internal class ViewColumn(context: Context) : Column<View> {
   override val value: View get() = container.view
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
+
+  override fun width(width: Constraint) {
+    container.width(width)
+  }
+
+  override fun height(height: Constraint) {
+    container.height(height)
+  }
 
   override fun padding(padding: Padding) {
     container.padding(padding)

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
@@ -29,6 +29,7 @@ import app.cash.redwood.flexcontainer.MeasureResult
 import app.cash.redwood.flexcontainer.MeasureSpec as RedwoodMeasureSpec
 import app.cash.redwood.flexcontainer.Size
 import app.cash.redwood.flexcontainer.isHorizontal
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.widget.ViewGroupChildren
@@ -63,6 +64,16 @@ internal class ViewFlexContainer(
 
   private val _children = ViewGroupChildren(hostView)
   val children: Widget.Children<View> get() = _children
+
+  fun width(width: Constraint) {
+    container.fillWidth = width == Constraint.Fill
+    invalidate()
+  }
+
+  fun height(height: Constraint) {
+    container.fillHeight = height == Constraint.Fill
+    invalidate()
+  }
 
   fun padding(padding: Padding) {
     container.padding = padding.toSpacing(context)

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewRow.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewRow.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.view.View
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.flexcontainer.FlexDirection
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
@@ -34,6 +35,14 @@ internal class ViewRow(context: Context) : Row<View> {
   override val value: View get() = container.view
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
+
+  override fun width(width: Constraint) {
+    container.width(width)
+  }
+
+  override fun height(height: Constraint) {
+    container.height(height)
+  }
 
   override fun padding(padding: Padding) {
     container.padding(padding)

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -28,6 +28,7 @@ import app.cash.redwood.flexcontainer.FlexDirection
 import app.cash.redwood.flexcontainer.JustifyContent
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.widget.Widget
 import org.junit.Rule
@@ -64,6 +65,14 @@ class ViewFlexContainerTest : AbstractFlexContainerTest<View>() {
     private var childCount = 0
 
     override val value get() = delegate.view
+
+    override fun width(constraint: Constraint) {
+      delegate.width(constraint)
+    }
+
+    override fun height(constraint: Constraint) {
+      delegate.width(constraint)
+    }
 
     override fun alignItems(alignItems: AlignItems) {
       delegate.alignItems(alignItems)

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContentCenter.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContentCenter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f0d5568b298259db005ebfe33a3817f4b4bc5d54311906a2b9b76b7425c54be
+size 58208

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContentSpaceAround.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContentSpaceAround.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66409be678b4724d7fc2d97cf9373cc351d176f191c3c04ef7253ab02165f829
+size 58637

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContentSpaceBetween.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContentSpaceBetween.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25772f9965122b14513716a1eb7d856f147544d69cabf2c59e95e4d84f9f47d3
+size 58553

--- a/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearch.kt
+++ b/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearch.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.layout.compose.Column
@@ -43,7 +44,9 @@ class EmojiSearchTreehouseUi(
     val viewModel by viewModels.collectAsState(initialViewModel)
 
     Column(
+      width = Constraint.Fill,
       horizontalAlignment = CrossAxisAlignment.Stretch,
+      padding = Padding(horizontal = 40),
     ) {
       TextInput(
         state = viewModel.searchTerm,
@@ -55,6 +58,7 @@ class EmojiSearchTreehouseUi(
       LazyColumn {
         items(viewModel.images) { image ->
           Row(
+            width = Constraint.Fill,
             verticalAlignment = CrossAxisAlignment.Center,
           ) {
             Image(

--- a/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearch.kt
+++ b/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearch.kt
@@ -46,7 +46,7 @@ class EmojiSearchTreehouseUi(
     Column(
       width = Constraint.Fill,
       horizontalAlignment = CrossAxisAlignment.Stretch,
-      padding = Padding(horizontal = 40),
+      padding = Padding(horizontal = 24),
     ) {
       TextInput(
         state = viewModel.searchTerm,


### PR DESCRIPTION
`Row` and `Column` currently wrap their size based on the sum of their children. This lets us tell the flex container to occupy either the full width/height. This is especially important for root layouts where we almost always want them to be a column that occupies the full width - no matter the size of its children.

The `overflow` parameters is still important. If the children overflow the available size, the container will begin to scroll or wrap depending on its `Overflow`.

The API is:

```kotlin
Column(width = Constraint.Fill) {
    // children
}
```