### PR TITLE
Revert "Make treehouse-lazylayout-schema publishable (#553)"

### DIFF
--- a/redwood-treehouse-lazylayout-schema/build.gradle
+++ b/redwood-treehouse-lazylayout-schema/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'com.vanniktech.maven.publish'
-apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 dependencies {
   api projects.redwoodSchemaAnnotations

--- a/redwood-treehouse-lazylayout-schema/widget/build.gradle
+++ b/redwood-treehouse-lazylayout-schema/widget/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.widget'
-apply plugin: 'com.vanniktech.maven.publish'
-apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"


### PR DESCRIPTION
Reverts 54720fea2853c478b705e9a2dccde96e2cd931e1 to fix `trunk`. `build / sample-emoji (pull_request)` automatically merges `trunk` when building so that job will fail for all PRs.