### PR TITLE
Allow reset to clear out-of-band views

### DIFF
--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -45,7 +45,8 @@ public class TreehouseWidgetView<A : Any>(
       }
     }
 
-  override val children: Widget.Children<*> = ViewGroupChildren(this)
+  private val _children = ViewGroupChildren(this)
+  override val children: Widget.Children<*> = _children
 
   private val mutableHostConfiguration =
     MutableStateFlow(computeHostConfiguration(context.resources.configuration))
@@ -54,7 +55,10 @@ public class TreehouseWidgetView<A : Any>(
     get() = mutableHostConfiguration
 
   override fun reset() {
-    children.remove(0, childCount)
+    _children.remove(0, _children.widgets.size)
+
+    // Ensure any out-of-band views are also removed.
+    removeAllViews()
   }
 
   public fun setContent(content: TreehouseView.Content<A>) {

--- a/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -26,6 +26,7 @@ import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UITraitCollection
 import platform.UIKit.UIUserInterfaceStyle.UIUserInterfaceStyleDark
 import platform.UIKit.UIView
+import platform.UIKit.removeFromSuperview
 import platform.UIKit.setFrame
 import platform.UIKit.subviews
 import platform.UIKit.superview
@@ -46,7 +47,8 @@ public class TreehouseUIKitView<A : Any>(
       }
     }
 
-  override val children: Widget.Children<*> = UIViewChildren(view)
+  private val _children = UIViewChildren(view)
+  override val children: Widget.Children<*> = _children
 
   private val mutableHostConfiguration = MutableStateFlow(HostConfiguration())
 
@@ -54,7 +56,11 @@ public class TreehouseUIKitView<A : Any>(
     get() = mutableHostConfiguration
 
   override fun reset() {
-    children.remove(0, view.subviews.size)
+    _children.remove(0, _children.widgets.size)
+
+    // Ensure any out-of-band views are also removed.
+    @Suppress("UNCHECKED_CAST") // Correct generic lost by cinterop.
+    (view.subviews as List<UIView>).forEach(UIView::removeFromSuperview)
   }
 
   public fun setContent(content: TreehouseView.Content<A>) {


### PR DESCRIPTION
Child views such as progress indicators may be used with Treehouse and are not tracked by the normal children mechanism.

This isn't the most satisfying solution, but I think some forthcoming refactors will actually make this better. We cannot simply throw away the `Widget.Children` instance because it's captured before the call to `reset()`.