### PR TITLE
Reduce listener callbacks to one

### DIFF
--- a/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 public fun <A : Any> TreehouseContent(
   treehouseApp: TreehouseApp<A>,
   widgetSystem: TreehouseView.WidgetSystem<A>,
+  onCodeLoaded: (initial: Boolean) -> Unit = {},
   content: TreehouseView.Content<A>,
 ) {
   val hostConfiguration = HostConfiguration(
@@ -38,9 +39,9 @@ public fun <A : Any> TreehouseContent(
   )
 
   val rememberedContent = rememberUpdatedState(content)
-  val treehouseView = remember {
+  val treehouseView = remember(onCodeLoaded, widgetSystem) {
     object : TreehouseView<A> {
-      override var codeListener = TreehouseView.CodeListener()
+      override var codeListener = TreehouseView.CodeListener(onCodeLoaded)
       override val boundContent: TreehouseView.Content<A> get() = rememberedContent.value
       override val children = ComposeWidgetChildren()
       override val hostConfiguration = MutableStateFlow(hostConfiguration)
@@ -49,7 +50,7 @@ public fun <A : Any> TreehouseContent(
     }
   }
 
-  LaunchedEffect(hostConfiguration) {
+  LaunchedEffect(treehouseView, hostConfiguration) {
     treehouseView.hostConfiguration.value = hostConfiguration
   }
   LaunchedEffect(content) {

--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -34,7 +34,7 @@ public class TreehouseWidgetView<A : Any>(
   private val treehouseApp: TreehouseApp<A>,
   override val widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : FrameLayout(context), TreehouseView<A> {
-  public override var codeListener: CodeListener = CodeListener()
+  public override var codeListener: CodeListener = CodeListener {}
   private var content: TreehouseView.Content<A>? = null
 
   override val boundContent: TreehouseView.Content<A>?

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -45,14 +45,11 @@ public interface TreehouseView<A : Any> {
     ): DiffConsumingNode.Factory<*>
   }
 
-  public open class CodeListener {
-    /** Show a spinner when a view is waiting for the code to load. */
-    public open fun codeLoading(view: TreehouseView<*>) {}
-
-    /** Clear the loading indicator when the first code is loaded. */
-    public open fun beforeInitialCode(view: TreehouseView<*>) {}
-
-    /** Clear the previous UI and show a quick animation for subsequent code updates. */
-    public open fun beforeUpdatedCode(view: TreehouseView<*>) {}
+  public fun interface CodeListener {
+    /**
+     * Invoked each time new code is loaded. This is called after the view's old children have
+     * been cleared but before the children of the new code have been added.
+     */
+    public fun onCodeLoaded(initial: Boolean)
   }
 }

--- a/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -35,7 +35,7 @@ public class TreehouseUIKitView<A : Any>(
   override val widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : TreehouseView<A> {
   public val view: UIView = RootUiView(this)
-  public override var codeListener: CodeListener = CodeListener()
+  public override var codeListener: CodeListener = CodeListener {}
   private var content: TreehouseView.Content<A>? = null
 
   override val boundContent: TreehouseView.Content<A>?

--- a/samples/emoji-search/android-composeui/src/main/java/app/cash/zipline/samples/emojisearch/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/java/app/cash/zipline/samples/emojisearch/composeui/EmojiSearchActivity.kt
@@ -60,7 +60,7 @@ class EmojiSearchActivity : ComponentActivity() {
     val view = ComposeView(this)
     view.setContent {
       EmojiSearchTheme {
-        TreehouseContent(treehouseApp, widgetSystem, treehouseContent)
+        TreehouseContent(treehouseApp, widgetSystem, content = treehouseContent)
       }
     }
     setContentView(view)


### PR DESCRIPTION
This listener is was used for loading indicators and displaying animations on reloads. For loading indicators, display them upon initial creation of the TreehouseView subtype or when one is reused (such as in a data binding list view). For animating, the provided boolean differentiates first load from subsequent loads and it runs at the same time as before.

The view subtype parameter is not needed since you can capture the actual TreehouseView subtype when creating the lambda.

Start of #541 