### PR TITLE
Fix the build after partial revert

### DIFF
--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintTask.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintTask.kt
@@ -25,6 +25,8 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.ABSOLUTE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import org.gradle.workers.WorkAction
@@ -39,6 +41,7 @@ internal abstract class RedwoodLintTask @Inject constructor(
   abstract val toolClasspath: ConfigurableFileCollection
 
   @get:InputDirectory
+  @get:PathSensitive(ABSOLUTE)
   abstract val projectDirectory: RegularFileProperty
 
   @get:Input


### PR DESCRIPTION
This annotation is apparently required with `@InputDirectory`.