### PR TITLE
Break the `TreehouseView` dependency on `TreehouseApp`

### DIFF
--- a/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -25,6 +25,7 @@ import app.cash.redwood.treehouse.HostConfiguration
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseView.CodeListener
+import app.cash.redwood.treehouse.TreehouseView.OnStateChangeListener
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -44,6 +45,7 @@ public fun <A : Any> TreehouseContent(
   val treehouseView = remember(widgetSystem) {
     object : TreehouseView<A> {
       override val codeListener get() = rememberedCodeListener.value
+      override var stateChangeListener: OnStateChangeListener<A>? = null
       override val boundContent: TreehouseView.Content<A> get() = rememberedContent.value
       override val children = ComposeWidgetChildren()
       override val hostConfiguration = MutableStateFlow(hostConfiguration)
@@ -51,12 +53,14 @@ public fun <A : Any> TreehouseContent(
       override fun reset() = children.remove(0, children.widgets.size)
     }
   }
-
   LaunchedEffect(treehouseView, hostConfiguration) {
     treehouseView.hostConfiguration.value = hostConfiguration
   }
-  LaunchedEffect(treehouseApp, treehouseView, content) {
-    treehouseApp.onContentChanged(treehouseView)
+  LaunchedEffect(treehouseApp, treehouseView) {
+    treehouseApp.renderTo(treehouseView)
+  }
+  LaunchedEffect(treehouseView, content) {
+    treehouseView.stateChangeListener?.onStateChanged(treehouseView)
   }
 
   Box {

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
@@ -69,7 +69,8 @@ private class TableViewDataSource<A : Any>(
   }
 
   override fun tableView(tableView: UITableView, cellForRowAtIndexPath: NSIndexPath): UITableViewCell {
-    val treehouseView = TreehouseUIKitView(treehouseApp, widgetSystem)
+    val treehouseView = TreehouseUIKitView(widgetSystem)
+    treehouseApp.renderTo(treehouseView)
     treehouseView.setContent(CellContent(intervals[cellForRowAtIndexPath.section.toInt()].itemProvider, cellForRowAtIndexPath.row.toInt()))
     return TableViewCell(treehouseView.view)
   }

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -98,8 +98,10 @@ internal class ViewLazyColumn<A : Any>(
     treehouseApp: TreehouseApp<A>,
     widgetSystem: TreehouseView.WidgetSystem<A>,
   ) : RecyclerView.ViewHolder(container) {
-    val treehouseWidgetView = TreehouseWidgetView(container.context, treehouseApp, widgetSystem)
+    val treehouseWidgetView = TreehouseWidgetView(container.context, widgetSystem)
       .apply {
+        treehouseApp.renderTo(this)
+
         layoutParams = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
           gravity = Gravity.CENTER_HORIZONTAL
         }

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -65,9 +65,13 @@ public class TreehouseApp<A : Any> internal constructor(
   public val zipline: Zipline?
     get() = ziplineSession?.zipline
 
-  /** This function may only be invoked on [TreehouseDispatchers.ui]. */
-  public fun onContentChanged(view: TreehouseView<A>) {
+  private val stateChangeListener = TreehouseView.OnStateChangeListener { view ->
     bind(view, ziplineSession, codeChanged = false)
+  }
+
+  public fun renderTo(view: TreehouseView<A>) {
+    view.stateChangeListener = stateChangeListener
+    stateChangeListener.onStateChanged(view)
   }
 
   /**

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -28,9 +28,17 @@ public interface TreehouseView<A : Any> {
   public val hostConfiguration: StateFlow<HostConfiguration>
   public val widgetSystem: WidgetSystem<A>
   public val codeListener: CodeListener
+  public var stateChangeListener: OnStateChangeListener<A>?
 
   /** Invoked when new code is loaded. This should at minimum clear all [children]. */
   public fun reset()
+
+  public fun interface OnStateChangeListener<A : Any> {
+    /**
+     * Called when [TreehouseView.boundContent] has changed.
+     */
+    public fun onStateChanged(view: TreehouseView<A>)
+  }
 
   public fun interface Content<A : Any> {
     public fun get(app: A): ZiplineTreehouseUi

--- a/samples/emoji-search/android-views/src/main/java/app/cash/zipline/samples/emojisearch/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/java/app/cash/zipline/samples/emojisearch/views/EmojiSearchActivity.kt
@@ -61,7 +61,8 @@ class EmojiSearchActivity : ComponentActivity() {
     }
 
     setContentView(
-      TreehouseWidgetView(this, treehouseApp, widgetSystem).apply {
+      TreehouseWidgetView(this, widgetSystem).apply {
+        treehouseApp.renderTo(this)
         setContent(treehouseContent)
       },
     )

--- a/samples/emoji-search/ios/app/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios/app/EmojiSearchApp/EmojiSearchViewController.swift
@@ -36,7 +36,8 @@ class EmojiSearchViewController : UIViewController {
         let emojiSearchLauncher = EmojiSearchLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
         let treehouseApp = emojiSearchLauncher.createTreehouseApp()
         let widgetSystem = EmojiSearchWidgetSystem()
-        let treehouseView = Redwood_treehouseTreehouseUIKitView<PresentersEmojiSearchPresenter>(treehouseApp: treehouseApp, widgetSystem: widgetSystem)
+        let treehouseView = Redwood_treehouseTreehouseUIKitView<PresentersEmojiSearchPresenter>(widgetSystem: widgetSystem)
+        treehouseApp.renderTo(view: treehouseView)
         treehouseView.setContent(content: EmojiSearchContent())
 
         view = treehouseView.view


### PR DESCRIPTION
This makes no attempt to clean up the `TreehouseView` API but instead contains the minimal changes to facilitate `TreehouseView`s being testable in isolation.

Refs #541 