### PR TITLE
Redo widget binding lifecycles

### DIFF
--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -227,11 +227,11 @@ public class TreehouseApp<A : Any> internal constructor(
     }
 
     fun cancel() {
-      dispatchers.checkUi()
-
       content.close()
-      viewOrNull = null
-      bridgeOrNull = null
+      scope.launch(dispatchers.ui) {
+        viewOrNull = null
+        bridgeOrNull = null
+      }
     }
   }
 


### PR DESCRIPTION
Goals of this change:

 * Do more stuff on the UI thread, and own more state on the UI thread. We used to own binding state on the Zipline thread, but that was clumsy 'cause widgets change more frequently than Zipline instances.
 * Stop holding references to widget views as quickly as possible
