### PR TITLE
Start testing `TreehouseWidgetView` behavior

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,5 +67,6 @@ paparazzi-gradlePlugin = { module = "app.cash.paparazzi:paparazzi-gradle-plugin"
 jimfs = "com.google.jimfs:jimfs:1.2"
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil-core = { module = "io.coil-kt:coil", version.ref = "coil" }
+turbine = "app.cash.turbine:turbine:0.12.1"
 
 lint-core = { module = "com.android.tools.lint:lint", version.ref = "lint" }

--- a/redwood-treehouse/build.gradle
+++ b/redwood-treehouse/build.gradle
@@ -53,6 +53,7 @@ kotlin {
       dependencies {
         implementation libs.kotlin.test
         implementation libs.kotlinx.coroutines.test
+        implementation libs.turbine
       }
     }
     nativeTest {
@@ -60,6 +61,9 @@ kotlin {
     }
     androidTest {
       dependsOn(hostTest)
+      dependencies {
+        implementation libs.robolectric
+      }
     }
   }
 }

--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_MASK
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import app.cash.redwood.treehouse.TreehouseView.CodeListener
@@ -66,7 +67,7 @@ public class TreehouseWidgetView<A : Any>(
     }
 
   private val _children = ViewGroupChildren(this)
-  override val children: Widget.Children<*> = _children
+  override val children: Widget.Children<View> get() = _children
 
   private val mutableHostConfiguration =
     MutableStateFlow(computeHostConfiguration(context.resources.configuration))

--- a/redwood-treehouse/src/androidTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
+++ b/redwood-treehouse/src/androidTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import android.app.Activity
+import android.content.res.Configuration
+import android.content.res.Configuration.UI_MODE_NIGHT_MASK
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.view.View
+import android.view.ViewGroup
+import app.cash.redwood.LayoutModifier
+import app.cash.redwood.widget.ViewGroupChildren
+import app.cash.redwood.widget.Widget
+import app.cash.turbine.test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class TreehouseWidgetViewTest {
+  private val context = RuntimeEnvironment.getApplication()!!
+
+  @Test fun widgetsAddChildViews() {
+    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+
+    val view = View(context)
+    layout.children.insert(0, viewWidget(view))
+    assertEquals(1, layout.childCount)
+    assertSame(view, layout.getChildAt(0))
+  }
+
+  @Test fun attachAndDetachSendsStateChange() {
+    val activity = Robolectric.buildActivity(Activity::class.java).resume().visible().get()
+    val parent = activity.findViewById<ViewGroup>(android.R.id.content)
+    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    val listener = CountingStateChangeListener()
+
+    layout.stateChangeListener = listener
+    assertEquals(0, listener.count)
+
+    parent.addView(layout)
+    assertEquals(1, listener.count)
+
+    parent.removeView(layout)
+    assertEquals(2, listener.count)
+  }
+
+  @Test fun contentSendsStateChange() {
+    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    val listener = CountingStateChangeListener()
+    layout.stateChangeListener = listener
+    assertEquals(0, listener.count)
+
+    layout.setContent { throw UnsupportedOperationException() }
+    assertEquals(1, listener.count)
+  }
+
+  @Test fun resetClearsUntrackedChildren() {
+    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+
+    layout.addView(View(context))
+    assertEquals(1, layout.childCount)
+
+    layout.reset()
+    assertEquals(0, layout.childCount)
+  }
+
+  @Test fun resetClearsTrackedWidgets() {
+    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+
+    // Needed to access internal state which cannot be reasonably observed through the public API.
+    val children = layout.children as ViewGroupChildren
+
+    children.insert(0, viewWidget(View(context)))
+    assertEquals(1, children.widgets.size)
+
+    layout.reset()
+    assertEquals(0, children.widgets.size)
+  }
+
+  @Test
+  @Config(sdk = [26])
+  fun hostConfigurationReflectsInitialUiMode() {
+    val newConfig = Configuration(context.resources.configuration)
+    newConfig.uiMode = (newConfig.uiMode and UI_MODE_NIGHT_MASK.inv()) or UI_MODE_NIGHT_YES
+    val newContext = context.createConfigurationContext(newConfig) // Needs API 26.
+    val layout = TreehouseWidgetView(newContext, throwingWidgetSystem)
+    assertEquals(HostConfiguration(darkMode = true), layout.hostConfiguration.value)
+  }
+
+  @Test fun hostConfigurationEmitsUiModeChanges() = runTest {
+    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    layout.hostConfiguration.test {
+      assertEquals(HostConfiguration(darkMode = false), awaitItem())
+
+      val newConfig = Configuration(context.resources.configuration)
+      newConfig.uiMode = (newConfig.uiMode and UI_MODE_NIGHT_MASK.inv()) or UI_MODE_NIGHT_YES
+
+      layout.dispatchConfigurationChanged(newConfig)
+      assertEquals(HostConfiguration(darkMode = true), awaitItem())
+    }
+  }
+
+  private fun viewWidget(view: View) = object : Widget<View> {
+    override val value: View get() = view
+    override var layoutModifiers: LayoutModifier = LayoutModifier
+  }
+
+  private val throwingWidgetSystem =
+    TreehouseView.WidgetSystem<Nothing> { _, _, _ -> throw UnsupportedOperationException() }
+}

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -44,7 +44,7 @@ public interface TreehouseView<A : Any> {
     public fun get(app: A): ZiplineTreehouseUi
   }
 
-  public interface WidgetSystem<A : Any> {
+  public fun interface WidgetSystem<A : Any> {
     /** Returns a widget factory for encoding and decoding changes to the contents of [view]. */
     public fun widgetFactory(
       app: TreehouseApp<A>,

--- a/redwood-treehouse/src/hostTest/kotlin/app/cash/redwood/treehouse/CountingStateChangeListener.kt
+++ b/redwood-treehouse/src/hostTest/kotlin/app/cash/redwood/treehouse/CountingStateChangeListener.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+class CountingStateChangeListener : TreehouseView.OnStateChangeListener<Nothing> {
+  var count = 0
+
+  override fun onStateChanged(view: TreehouseView<Nothing>) {
+    count++
+  }
+}

--- a/redwood-widget/src/test/kotlin/app/cash/redwood/widget/ViewGroupChildrenTest.kt
+++ b/redwood-widget/src/test/kotlin/app/cash/redwood/widget/ViewGroupChildrenTest.kt
@@ -23,11 +23,11 @@ import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class ViewGroupChildrenTest : AbstractWidgetChildrenTest<View>() {
-  private val parent = FrameLayout(RuntimeEnvironment.application)
+  private val parent = FrameLayout(RuntimeEnvironment.getApplication())
   override val children = ViewGroupChildren(parent)
 
   override fun widget(name: String): View {
-    return View(RuntimeEnvironment.application).apply {
+    return View(RuntimeEnvironment.getApplication()).apply {
       tag = name
     }
   }


### PR DESCRIPTION
Not testing `boundContent` or `widgetSystem` since I plan to break those out of the interface and into the app's new binding type.

Refs #541. Really happy with how easy this was after #579. iOS next!