### PR TITLE
Allow TreehouseUi to be closed

### DIFF
--- a/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/TreehouseUi.kt
+++ b/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/TreehouseUi.kt
@@ -20,4 +20,7 @@ import androidx.compose.runtime.Composable
 public interface TreehouseUi {
   @Composable
   public fun Show()
+
+  public fun close() {
+  }
 }

--- a/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
+++ b/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
@@ -75,6 +75,7 @@ private class RedwoodZiplineTreehouseUi(
   override fun close() {
     composition.cancel()
     diffSinkToClose.close()
+    treehouseUi.close()
   }
 }
 


### PR DESCRIPTION
If the class has instance members that hold resources (like other ZiplineServices), this is a hook to release those.