### PR TITLE
Rollback action upgrade

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3.7.0
+      - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: 19
@@ -45,7 +45,7 @@ jobs:
         with:
           lfs: true
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3.7.0
+      - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: 19
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3.7.0
+      - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: 19
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3.7.0
+      - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: 19
@@ -121,7 +121,7 @@ jobs:
           name: site
           path: site
 
-      - uses: actions/setup-java@v3.7.0
+      - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: 19


### PR DESCRIPTION
The 3.7.0 release was deleted, because that's a thing you can do.

💀 https://github.com/actions/setup-java/issues/422