### PR TITLE
Consistently pass TreehouseApp to EventListeners

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ androidx-compose = "1.2.1"
 jbComposeCompiler = "1.3.2.1"
 jbComposeRuntime = "1.2.1"
 lint = "30.4.0-alpha09"
-zipline = "0.9.10"
+zipline = "0.9.11"
 coil = "2.2.2"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ androidx-compose = "1.2.1"
 jbComposeCompiler = "1.3.2.1"
 jbComposeRuntime = "1.2.1"
 lint = "30.4.0-alpha09"
-zipline = "0.9.11"
+zipline = "0.9.12"
 coil = "2.2.2"
 
 [libraries]

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
@@ -18,31 +18,62 @@ package app.cash.redwood.treehouse
 import app.cash.redwood.protocol.PropertyTag
 import app.cash.zipline.Call
 import app.cash.zipline.CallResult
+import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineService
 
 public abstract class EventListener {
+  /**
+   * Invoked each time a [TreehouseApp] is created. When this is triggered the app may not yet have
+   * any code loaded; but it will always attempt to load code.
+   */
   public open fun appCreated(
     app: TreehouseApp<*>,
   ) {
   }
 
+  /**
+   * Invoked with [TreehouseApp.cancel] when the application is shut down.
+   *
+   * This is different from [codeUnloaded] which occurs during hot reloads; this only occurs if the
+   * app itself is explicitly closed.
+   */
   public open fun appCanceled(
     app: TreehouseApp<*>,
   ) {
   }
 
+  /**
+   * Invoked for each attempt at loading code. This will be followed by a [codeLoadSuccess],
+   * [codeLoadFailed], or [codeLoadSkipped] if the code is unchanged.
+   *
+   * @return any object. This value will be passed back to one of the above functions. The base
+   *     function always returns null.
+   */
   public open fun codeLoadStart(
     app: TreehouseApp<*>,
     manifestUrl: String?,
   ): Any? = null
 
+  /**
+   * Invoked when code is successfully downloaded and initialized.
+   *
+   * @param startValue the value returned by [codeLoadStart] for the start of this call. This
+   *   is null unless [codeLoadStart] is overridden to return something else.
+   */
   public open fun codeLoadSuccess(
     app: TreehouseApp<*>,
     manifestUrl: String?,
+    zipline: Zipline,
     startValue: Any?,
   ) {
   }
 
+  /**
+   * Invoked when a code load is skipped because the code hasn't changed.
+   *
+   * @param startValue the value returned by [codeLoadStart] for the start of this call. This
+   *   is null unless [codeLoadStart] is overridden to return something else.
+   */
   public open fun codeLoadSkipped(
     app: TreehouseApp<*>,
     manifestUrl: String?,
@@ -50,6 +81,12 @@ public abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked when a code load fails.
+   *
+   * @param startValue the value returned by [codeLoadStart] for the start of this call. This
+   *   is null unless [codeLoadStart] is overridden to return something else.
+   */
   public open fun codeLoadFailed(
     app: TreehouseApp<*>,
     manifestUrl: String?,
@@ -58,18 +95,37 @@ public abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked when code is unloaded because it is no longer needed. Typically this occurs when a hot
+   * code update is applied.
+   */
+  public open fun codeUnloaded(
+    app: TreehouseApp<*>,
+    zipline: Zipline,
+  ) {
+  }
+
+  /**
+   * Invoked on a request to create an unknown widget [kind].
+   */
   public open fun onUnknownWidget(
     app: TreehouseApp<*>,
     kind: Int,
   ) {
   }
 
+  /**
+   * Invoked on a request to create an unknown layout modifier [tag].
+   */
   public open fun onUnknownLayoutModifier(
     app: TreehouseApp<*>,
     tag: Int,
   ) {
   }
 
+  /**
+   * Invoked on a request to manipulate unknown children [tag] for the specified widget [kind].
+   */
   public open fun onUnknownChildren(
     app: TreehouseApp<*>,
     kind: Int,
@@ -77,6 +133,9 @@ public abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked on a request to set an unknown property [tag] for the specified widget [kind].
+   */
   public open fun onUnknownProperty(
     app: TreehouseApp<*>,
     kind: Int,
@@ -84,11 +143,24 @@ public abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked when a network download starts. This will be followed by [downloadSuccess] or
+   * [downloadFailed].
+   *
+   * @return any object. This value will be passed back to one of the above functions. The base
+   *     function always returns null.
+   */
   public open fun downloadStart(
     app: TreehouseApp<*>,
     url: String,
   ): Any? = null
 
+  /**
+   * Invoked when a network download completes successfully.
+   *
+   * @param startValue the value returned by [downloadStart] for the start of this call. This
+   *   is null unless [downloadStart] is overridden to return something else.
+   */
   public open fun downloadSuccess(
     app: TreehouseApp<*>,
     url: String,
@@ -96,6 +168,12 @@ public abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked when a network download fails.
+   *
+   * @param startValue the value returned by [downloadStart] for the start of this call. This
+   *   is null unless [downloadStart] is overridden to return something else.
+   */
   public open fun downloadFailed(
     app: TreehouseApp<*>,
     url: String,
@@ -104,6 +182,10 @@ public abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked when the manifest couldn't be decoded as JSON. For example, this might occur if there's
+   * a captive portal on the network.
+   */
   public open fun manifestParseFailed(
     app: TreehouseApp<*>,
     url: String?,
@@ -111,30 +193,59 @@ public abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked when something calls [Zipline.bind], or a service is sent via an API.
+   */
   public open fun bindService(
+    app: TreehouseApp<*>,
     name: String,
     service: ZiplineService,
   ) {
   }
 
+  /**
+   * Invoked when something calls [Zipline.take], or a service is received via an API.
+   */
   public open fun takeService(
+    app: TreehouseApp<*>,
     name: String,
     service: ZiplineService,
   ) {
   }
 
+  /**
+   * Invoked when a service function is called. This may be invoked for either suspending or
+   * non-suspending functions.
+   *
+   * @return any object. This value will be passed back to [callEnd] when the call is completed. The
+   *   base function always returns null.
+   */
   public open fun callStart(
+    app: TreehouseApp<*>,
     call: Call,
   ): Any? = null
 
+  /**
+   * Invoked when a service function call completes.
+   *
+   * @param startValue the value returned by [callStart] for the start of this call. This is null
+   *   unless [callStart] is overridden to return something else.
+   */
   public open fun callEnd(
+    app: TreehouseApp<*>,
     call: Call,
     result: CallResult,
     startValue: Any?,
   ) {
   }
 
+  /**
+   * Invoked when a service is garbage collected without being closed.
+   *
+   * Note that this method may be invoked after [codeUnloaded].
+   */
   public open fun serviceLeaked(
+    app: TreehouseApp<*>,
     name: String,
   ) {
   }


### PR DESCRIPTION
This requires upgrading Zipline to 0.9.11.