### PR TITLE
Remove FlexItem.visible.

### DIFF
--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/FlexItem.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/FlexItem.kt
@@ -20,11 +20,6 @@ package app.cash.redwood.flexbox
  */
 public class FlexItem(
   /**
-   * True if this item is visible and should be laid out.
-   */
-  public val visible: Boolean = true,
-
-  /**
    * The baseline used for [AlignItems.Baseline] and [AlignSelf.Baseline].
    */
   public val baseline: Int = DefaultBaseline,

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/FlexLine.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/FlexLine.kt
@@ -38,11 +38,6 @@ internal class FlexLine {
   var itemCount = 0
 
   /**
-   * The number of items who are invisible (i.e. aren't included in measure or layout).
-   */
-  var invisibleItemCount = 0
-
-  /**
    * The sum of the flexGrow properties of the children included in this flex line.
    */
   var totalFlexGrow = 0.0
@@ -63,14 +58,9 @@ internal class FlexLine {
   var sumCrossSizeBefore = 0.0
 
   /**
-   * The index of the first child included in this flex line (inclusive).
+   * The index of the first item included in this flex line.
    */
   var firstIndex = 0
-
-  /**
-   * The index of the last child included in this flex line (inclusive).
-   */
-  var lastIndex = 0
 
   /**
    * True if any [FlexItem]s in this line have [FlexItem.flexGrow] attributes set

--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/utils.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/utils.kt
@@ -40,9 +40,17 @@ internal fun FlexItem.layout(left: Double, top: Double, right: Double, bottom: D
   this.bottom = bottom
 }
 
-/** The number of items who are not invisible in this flex line. */
-internal val FlexLine.itemCountVisible: Int
-  get() = itemCount - invisibleItemCount
+internal inline fun <T> List<T>.forEachIndices(block: (T) -> Unit) {
+  for (index in indices) block(get(index))
+}
+
+/** The index of the last child included in this flex line or -1 if the flex line is empty. */
+internal val FlexLine.lastIndex: Int
+  get() = if (itemCount > 0) firstIndex + itemCount - 1 else -1
+
+/** The range of item indices covered by this flex line. */
+internal inline val FlexLine.indices: IntRange
+  get() = firstIndex..lastIndex
 
 /** The largest main size of all flex lines. */
 internal fun List<FlexLine>.getLargestMainSize(): Double {


### PR DESCRIPTION
This isn't part of the flexbox spec and we aren't likely to use it given we remove items from the tree instead of hiding them.