### PR TITLE
Move the FrameClock into the host code

### DIFF
--- a/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/main/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.HostConfiguration
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
@@ -30,7 +31,7 @@ import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
-public fun <A : Any> TreehouseContent(
+public fun <A : AppService> TreehouseContent(
   treehouseApp: TreehouseApp<A>,
   widgetSystem: TreehouseView.WidgetSystem<A>,
   codeListener: CodeListener = CodeListener(),

--- a/redwood-treehouse-lazylayout-composeui/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeRedwoodLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-composeui/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeRedwoodLayoutWidgetFactory.kt
@@ -16,14 +16,15 @@
 package app.cash.redwood.treehouse.lazylayout.composeui
 
 import androidx.compose.runtime.Composable
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 
-public class ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory<W : Any>(
-  private val treehouseApp: TreehouseApp<W>,
-  private val widgetSystem: TreehouseView.WidgetSystem<W>,
+public class ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory<A : AppService>(
+  private val treehouseApp: TreehouseApp<A>,
+  private val widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : RedwoodTreehouseLazyLayoutWidgetFactory<@Composable () -> Unit> {
   override fun LazyColumn(): LazyColumn<@Composable () -> Unit> = ComposeUiLazyColumn(treehouseApp, widgetSystem)
 }

--- a/redwood-treehouse-lazylayout-composeui/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-composeui/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyColumn.kt
@@ -27,15 +27,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.composeui.TreehouseContent
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 
-internal class ComposeUiLazyColumn<W : Any>(
-  treehouseApp: TreehouseApp<W>,
-  widgetSystem: TreehouseView.WidgetSystem<W>,
+internal class ComposeUiLazyColumn<A : AppService>(
+  treehouseApp: TreehouseApp<A>,
+  widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : LazyColumn<@Composable () -> Unit> {
   private var intervals by mutableStateOf<List<LazyListIntervalContent>>(emptyList())
 

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.treehouse.lazylayout.uiview
 
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseUIKitView
 import app.cash.redwood.treehouse.TreehouseView
@@ -35,7 +36,7 @@ import platform.UIKit.section
 import platform.UIKit.setFrame
 import platform.darwin.NSInteger
 
-internal class UIViewLazyColumn<A : Any>(
+internal class UIViewLazyColumn<A : AppService>(
   treehouseApp: TreehouseApp<A>,
   widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : LazyColumn<UIView> {
@@ -54,7 +55,7 @@ internal class UIViewLazyColumn<A : Any>(
   override val value: UIView get() = root
 }
 
-private class TableViewDataSource<A : Any>(
+private class TableViewDataSource<A : AppService>(
   private val treehouseApp: TreehouseApp<A>,
   private val widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : UITableViewDiffableDataSource() {
@@ -76,7 +77,7 @@ private class TableViewDataSource<A : Any>(
   }
 }
 
-private class CellContent<A : Any>(
+private class CellContent<A : AppService>(
   private val itemProvider: LazyListIntervalContent.Item,
   private val index: Int,
 ) : TreehouseView.Content<A> {

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
@@ -15,13 +15,14 @@
  */
 package app.cash.redwood.treehouse.lazylayout.uiview
 
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 import platform.UIKit.UIView
 
-public class UIViewRedwoodTreehouseLazyLayoutWidgetFactory<A : Any>(
+public class UIViewRedwoodTreehouseLazyLayoutWidgetFactory<A : AppService>(
   private var treehouseApp: TreehouseApp<A>,
   private var widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : RedwoodTreehouseLazyLayoutWidgetFactory<UIView> {

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -27,6 +27,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseWidgetView
@@ -38,7 +39,7 @@ private data class LazyContentItem(
   val item: LazyListIntervalContent.Item,
 )
 
-internal class ViewLazyColumn<A : Any>(
+internal class ViewLazyColumn<A : AppService>(
   treehouseApp: TreehouseApp<A>,
   widgetSystem: TreehouseView.WidgetSystem<A>,
   override val value: RecyclerView,
@@ -73,7 +74,7 @@ internal class ViewLazyColumn<A : Any>(
     )
   }
 
-  private class LazyContentItemListAdapter<A : Any>(
+  private class LazyContentItemListAdapter<A : AppService>(
     private val treehouseApp: TreehouseApp<A>,
     private val widgetSystem: TreehouseView.WidgetSystem<A>,
     private val contentHeight: Int,
@@ -93,7 +94,7 @@ internal class ViewLazyColumn<A : Any>(
     }
   }
 
-  private class ViewHolder<A : Any>(
+  private class ViewHolder<A : AppService>(
     container: FrameLayout,
     treehouseApp: TreehouseApp<A>,
     widgetSystem: TreehouseView.WidgetSystem<A>,

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -18,12 +18,13 @@ package app.cash.redwood.treehouse.lazylayout.view
 import android.content.Context
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 
-public class ViewRedwoodTreehouseLazyLayoutWidgetFactory<A : Any>(
+public class ViewRedwoodTreehouseLazyLayoutWidgetFactory<A : AppService>(
   private val context: Context,
   private val treehouseApp: TreehouseApp<A>,
   private val widgetSystem: TreehouseView.WidgetSystem<A>,

--- a/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 @SuppressLint("ViewConstructor")
-public class TreehouseWidgetView<A : Any>(
+public class TreehouseWidgetView<A : AppService>(
   context: Context,
   override val widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : FrameLayout(context), TreehouseView<A> {

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppService.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2022 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.zipline.samples.emojisearch
+package app.cash.redwood.treehouse
 
-import app.cash.redwood.treehouse.AppService
-import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.zipline.ZiplineService
 
-interface EmojiSearchPresenter : AppService, ZiplineService {
-  fun launch(): ZiplineTreehouseUi
+/**
+ * Base interface for Treehouse applications. Each application should extend this interface to
+ * declare APIs that are declared by downloaded code and called from host code.
+ *
+ * Note that due to a Zipline limitation it's necessary for implementing classes to declare a direct
+ * dependency on [ZiplineService]. https://github.com/cashapp/zipline/issues/765
+ */
+public interface AppService : ZiplineService {
+  public val frameClockService: FrameClockService
+    get() = StandardFrameClockService
 }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/FrameClockService.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/FrameClockService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2022 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.zipline.samples.emojisearch
+package app.cash.redwood.treehouse
 
-import app.cash.redwood.treehouse.AppService
-import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.zipline.ZiplineService
 
-interface EmojiSearchPresenter : AppService, ZiplineService {
-  fun launch(): ZiplineTreehouseUi
+public interface FrameClockService : ZiplineService {
+  public fun sendFrame(timeNanos: Long)
 }
+
+public expect val StandardFrameClockService: FrameClockService

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/FrameClockServiceHost.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/FrameClockServiceHost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2022 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.zipline.samples.emojisearch
+package app.cash.redwood.treehouse
 
-import app.cash.redwood.treehouse.AppService
-import app.cash.redwood.treehouse.ZiplineTreehouseUi
-import app.cash.zipline.ZiplineService
-
-interface EmojiSearchPresenter : AppService, ZiplineService {
-  fun launch(): ZiplineTreehouseUi
+public actual val StandardFrameClockService: FrameClockService = object : FrameClockService {
+  override fun sendFrame(timeNanos: Long) {
+    error("unexpected call to sendFrame() on the host")
+  }
 }

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseLauncher.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseLauncher.kt
@@ -69,7 +69,7 @@ public class TreehouseLauncher internal constructor(
     )
   }
 
-  public fun <A : Any> launch(
+  public fun <A : AppService> launch(
     scope: CoroutineScope,
     spec: TreehouseApp.Spec<A>,
   ): TreehouseApp<A> {

--- a/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse/src/hostMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -21,7 +21,7 @@ import app.cash.redwood.widget.Widget
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 
-public interface TreehouseView<A : Any> {
+public interface TreehouseView<A : AppService> {
   /** This is the actual content, or null if not attached to the screen. */
   public val boundContent: Content<A>?
   public val children: Widget.Children<*>
@@ -33,18 +33,18 @@ public interface TreehouseView<A : Any> {
   /** Invoked when new code is loaded. This should at minimum clear all [children]. */
   public fun reset()
 
-  public fun interface OnStateChangeListener<A : Any> {
+  public fun interface OnStateChangeListener<A : AppService> {
     /**
      * Called when [TreehouseView.boundContent] has changed.
      */
     public fun onStateChanged(view: TreehouseView<A>)
   }
 
-  public fun interface Content<A : Any> {
+  public fun interface Content<A : AppService> {
     public fun get(app: A): ZiplineTreehouseUi
   }
 
-  public fun interface WidgetSystem<A : Any> {
+  public fun interface WidgetSystem<A : AppService> {
     /** Returns a widget factory for encoding and decoding changes to the contents of [view]. */
     public fun widgetFactory(
       app: TreehouseApp<A>,

--- a/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -33,7 +33,7 @@ import platform.UIKit.setFrame
 import platform.UIKit.subviews
 import platform.UIKit.superview
 
-public class TreehouseUIKitView<A : Any>(
+public class TreehouseUIKitView<A : AppService>(
   override val widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : TreehouseView<A> {
   @Deprecated(

--- a/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/FrameClockServiceJs.kt
+++ b/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/FrameClockServiceJs.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2022 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.zipline.samples.emojisearch
+package app.cash.redwood.treehouse
 
-import app.cash.redwood.treehouse.AppService
-import app.cash.redwood.treehouse.ZiplineTreehouseUi
-import app.cash.zipline.ZiplineService
+import androidx.compose.runtime.BroadcastFrameClock
 
-interface EmojiSearchPresenter : AppService, ZiplineService {
-  fun launch(): ZiplineTreehouseUi
+internal val StandardFrameClock = BroadcastFrameClock()
+
+public actual val StandardFrameClockService: FrameClockService = object : FrameClockService {
+  override fun sendFrame(timeNanos: Long) {
+    StandardFrameClock.sendFrame(timeNanos)
+  }
 }

--- a/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
+++ b/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.treehouse
 
-import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,8 +25,6 @@ import app.cash.redwood.protocol.compose.ProtocolRedwoodComposition
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 
 /**
@@ -56,7 +53,7 @@ private class RedwoodZiplineTreehouseUi(
     diffSinkToClose = diffSink
 
     val composition = ProtocolRedwoodComposition(
-      scope = scope + frameClock,
+      scope = scope + StandardFrameClock,
       factory = factory,
       widgetVersion = widgetVersion,
       diffSink = diffSink,
@@ -81,22 +78,3 @@ private class RedwoodZiplineTreehouseUi(
 
 @OptIn(DelicateCoroutinesApi::class)
 private val scope: CoroutineScope = GlobalScope
-private val frameClock: BroadcastFrameClock by lazy { newFrameClock(scope) }
-
-// TODO(jwilson): replace this with a native frame clock.
-private fun newFrameClock(
-  coroutineScope: CoroutineScope,
-  ticksPerSecond: Long = 60,
-): BroadcastFrameClock {
-  val result = BroadcastFrameClock()
-  coroutineScope.launch {
-    var now = 0L
-    val delayNanos = 1_000_000_000L / ticksPerSecond
-    while (true) {
-      result.sendFrame(now)
-      delay(delayNanos / 1_000_000)
-      now += delayNanos
-    }
-  }
-  return result
-}

--- a/redwood-treehouse/src/jvmMain/kotlin/app/cash/redwood/treehouse/FrameClockServiceJvm.kt
+++ b/redwood-treehouse/src/jvmMain/kotlin/app/cash/redwood/treehouse/FrameClockServiceJvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2022 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.zipline.samples.emojisearch
+package app.cash.redwood.treehouse
 
-import app.cash.redwood.treehouse.AppService
-import app.cash.redwood.treehouse.ZiplineTreehouseUi
-import app.cash.zipline.ZiplineService
-
-interface EmojiSearchPresenter : AppService, ZiplineService {
-  fun launch(): ZiplineTreehouseUi
+// TODO(jwilson): deduplicate with identical symbol in hostMain
+public actual val StandardFrameClockService: FrameClockService = object : FrameClockService {
+  override fun sendFrame(timeNanos: Long) {
+    error("unexpected call to sendFrame() on the host")
+  }
 }

--- a/samples/emoji-search/android-composeui/src/main/java/app/cash/zipline/samples/emojisearch/composeui/AndroidEmojiSearchWidgetFactory.kt
+++ b/samples/emoji-search/android-composeui/src/main/java/app/cash/zipline/samples/emojisearch/composeui/AndroidEmojiSearchWidgetFactory.kt
@@ -17,15 +17,16 @@ package app.cash.zipline.samples.emojisearch.composeui
 
 import androidx.compose.runtime.Composable
 import app.cash.redwood.layout.composeui.ComposeRedwoodLayoutWidgetFactory
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.lazylayout.composeui.ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 import example.schema.widget.EmojiSearchWidgetFactory
 
-class AndroidEmojiSearchWidgetFactory<W : Any>(
-  private val treehouseApp: TreehouseApp<W>,
-  widgetSystem: TreehouseView.WidgetSystem<W>,
+class AndroidEmojiSearchWidgetFactory<A : AppService>(
+  private val treehouseApp: TreehouseApp<A>,
+  widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : EmojiSearchWidgetFactory<@Composable () -> Unit> {
   override val RedwoodLayout = ComposeRedwoodLayoutWidgetFactory()
   override val RedwoodTreehouseLazyLayout = ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory(treehouseApp, widgetSystem)

--- a/samples/emoji-search/android-views/src/main/java/app/cash/zipline/samples/emojisearch/views/AndroidViewEmojiSearchWidgetFactory.kt
+++ b/samples/emoji-search/android-views/src/main/java/app/cash/zipline/samples/emojisearch/views/AndroidViewEmojiSearchWidgetFactory.kt
@@ -17,20 +17,19 @@ package app.cash.zipline.samples.emojisearch.views
 
 import android.content.Context
 import android.view.View
-import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.recyclerview.widget.RecyclerView
 import app.cash.redwood.layout.view.ViewRedwoodLayoutWidgetFactory
+import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.lazylayout.view.ViewRedwoodTreehouseLazyLayoutWidgetFactory
 import example.schema.widget.EmojiSearchWidgetFactory
 
-class AndroidViewEmojiSearchWidgetFactory<W : Any>(
+class AndroidViewEmojiSearchWidgetFactory<A : AppService>(
   private val context: Context,
-  private val treehouseApp: TreehouseApp<W>,
-  widgetSystem: TreehouseView.WidgetSystem<W>,
+  private val treehouseApp: TreehouseApp<A>,
+  widgetSystem: TreehouseView.WidgetSystem<A>,
 ) : EmojiSearchWidgetFactory<View> {
   override val RedwoodLayout = ViewRedwoodLayoutWidgetFactory(context)
   override val RedwoodTreehouseLazyLayout = ViewRedwoodTreehouseLazyLayoutWidgetFactory(context, treehouseApp, widgetSystem)

--- a/samples/emoji-search/ios/app/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios/app/EmojiSearchApp/EmojiSearchViewController.swift
@@ -45,14 +45,14 @@ class EmojiSearchViewController : UIViewController {
 }
 
 class EmojiSearchContent : Redwood_treehouseTreehouseViewContent {
-    func get(app: Any) -> Redwood_treehouseZiplineTreehouseUi {
+    func get(app: Redwood_treehouseAppService) -> Redwood_treehouseZiplineTreehouseUi {
         let treehouesUi = (app as! PresentersEmojiSearchPresenter)
         return treehouesUi.launch()
     }
 }
 
 class EmojiSearchWidgetSystem : Redwood_treehouseTreehouseViewWidgetSystem {
-    func widgetFactory(app: Redwood_treehouseTreehouseApp<AnyObject>, json: Kotlinx_serialization_jsonJson, protocolMismatchHandler: Redwood_protocol_widgetProtocolMismatchHandler) -> Redwood_protocol_widgetDiffConsumingNodeFactory {
+    func widgetFactory(app: Redwood_treehouseTreehouseApp<Redwood_treehouseAppService>, json: Kotlinx_serialization_jsonJson, protocolMismatchHandler: Redwood_protocol_widgetProtocolMismatchHandler) -> Redwood_protocol_widgetDiffConsumingNodeFactory {
         return ExposedKt.diffConsumingEmojiSearchWidgetFactory(
             delegate: IosEmojiSearchWidgetFactory(treehouseApp: app, widgetSystem: self),
             json: json,


### PR DESCRIPTION
This introduces a new type, AppService, that acts as the base type 'A' for the TreehouseApp type parameter. It is the bridge type that spans the host and downloaded code.

It also introduces an interface, FrameClockService, that receives frames in downloaded code.