### PR TITLE
Make `MeasureSpec` a value type

### DIFF
--- a/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/properties.kt
+++ b/redwood-flex-container/src/commonMain/kotlin/app/cash/redwood/flexbox/properties.kt
@@ -186,33 +186,25 @@ public value class JustifyContent private constructor(private val ordinal: Int) 
  * Each MeasureSpec represents a requirement for either the width or the height.
  * A MeasureSpec is composed of a size and a mode.
  */
-// TODO: Convert MeasureSpec into an inline class.
-public class MeasureSpec private constructor(
-  public val size: Double,
-  public val mode: MeasureSpecMode,
-) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    return other is MeasureSpec &&
-      size == other.size &&
-      mode == other.mode
-  }
+@JvmInline
+public value class MeasureSpec private constructor(private val value: Double) {
+  public val size: Double
+    get() = Double.fromBits(value.toRawBits() and SizeBits)
 
-  override fun hashCode(): Int {
-    var result = size.hashCode()
-    result = 31 * result + mode.hashCode()
-    return result
-  }
+  public val mode: MeasureSpecMode
+    get() = MeasureSpecMode((value.toRawBits() and ModeBits).toInt())
 
-  override fun toString(): String {
-    return "MeasureSpec(size=$size, mode=$mode)"
-  }
+  override fun toString(): String = "MeasureSpec(size=$size, mode=$mode)"
 
   public companion object {
+    private const val ModeBits = 0b11L
+    private const val SizeBits = ModeBits.inv()
+
     public fun from(size: Double, mode: MeasureSpecMode): MeasureSpec {
       require(size >= 0) { "invalid size: $size" }
-      // Use the top 2 bits for the mode and use the bottom 30 bits for the size.
-      return MeasureSpec(size, mode)
+      // The mode is stored in the least significant 2 bits of the fractional part.
+      val value = Double.fromBits((size.toRawBits() and SizeBits) or mode.ordinal.toLong())
+      return MeasureSpec(value)
     }
 
     /** A convenience function to constrain [size] inside a given [measureSpec]. */


### PR DESCRIPTION
This value is forced to be non-negative which does give us one free bit to manipulate, but there are no other easy bits to steal from a floating-point representation. Instead, use the two least-significant bits from the fractional part. This will slightly alter values, but at precisions which are imperceptible to users.

You can play with the algorithm at https://pl.kotl.in/MjyOdx8-A