### PR TITLE
Split schema types into protocol and non-protocol

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.generator
 
 import app.cash.redwood.schema.parser.LayoutModifier
+import app.cash.redwood.schema.parser.ProtocolWidget.ProtocolTrait
 import app.cash.redwood.schema.parser.Schema
 import app.cash.redwood.schema.parser.Widget
 import app.cash.redwood.schema.parser.Widget.Children
@@ -159,6 +160,7 @@ internal fun generateComposable(
                     }
                     .build()
                 }
+                is ProtocolTrait -> throw AssertionError()
               },
             )
             index++
@@ -194,6 +196,7 @@ internal fun generateComposable(
                   add("}\n")
                 }
               }
+              is ProtocolTrait -> throw AssertionError()
             }
           }
 

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
@@ -16,6 +16,8 @@
 package app.cash.redwood.generator
 
 import app.cash.redwood.schema.parser.LayoutModifier
+import app.cash.redwood.schema.parser.ProtocolLayoutModifier
+import app.cash.redwood.schema.parser.ProtocolSchema
 import app.cash.redwood.schema.parser.Schema
 import app.cash.redwood.schema.parser.Widget
 import app.cash.redwood.schema.parser.Widget.Event
@@ -114,7 +116,7 @@ internal val Schema.toLayoutModifier: MemberName get() =
 internal val Schema.toProtocol: MemberName get() =
   MemberName(composePackage(this), "toProtocol")
 
-internal fun Schema.allLayoutModifiers(): List<Pair<Schema, LayoutModifier>> {
+internal fun ProtocolSchema.allLayoutModifiers(): List<Pair<ProtocolSchema, ProtocolLayoutModifier>> {
   return (listOf(this) + dependencies).flatMap { schema ->
     schema.layoutModifiers.map { schema to it }
   }

--- a/redwood-schema/src/main/kotlin/app/cash/redwood/schema/parser/schemaClasses.kt
+++ b/redwood-schema/src/main/kotlin/app/cash/redwood/schema/parser/schemaClasses.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.schema.parser
+
+import app.cash.redwood.schema.parser.LayoutModifier.Property
+import app.cash.redwood.schema.parser.ProtocolWidget.ProtocolChildren
+import app.cash.redwood.schema.parser.ProtocolWidget.ProtocolEvent
+import app.cash.redwood.schema.parser.ProtocolWidget.ProtocolProperty
+import app.cash.redwood.schema.parser.ProtocolWidget.ProtocolTrait
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+internal data class ParsedProtocolSchema(
+  override val name: String,
+  override val `package`: String,
+  override val scopes: List<KClass<*>>,
+  override val widgets: List<ProtocolWidget>,
+  override val layoutModifiers: List<ProtocolLayoutModifier>,
+  override val dependencies: List<ProtocolSchema>,
+) : ProtocolSchema
+
+internal data class ParsedProtocolWidget(
+  override val tag: Int,
+  override val type: KClass<*>,
+  override val traits: List<ProtocolTrait>,
+) : ProtocolWidget
+
+internal data class ParsedProtocolProperty(
+  override val tag: Int,
+  override val name: String,
+  override val type: KType,
+  override val defaultExpression: String?,
+) : ProtocolProperty
+
+internal data class ParsedProtocolEvent(
+  override val tag: Int,
+  override val name: String,
+  override val defaultExpression: String?,
+  override val parameterType: KType?,
+) : ProtocolEvent
+
+internal data class ParsedProtocolChildren(
+  override val tag: Int,
+  override val name: String,
+  override val defaultExpression: String?,
+  override val scope: KClass<*>?,
+) : ProtocolChildren
+
+internal data class ParsedProtocolLayoutModifier(
+  override val tag: Int,
+  override val scopes: List<KClass<*>>,
+  override val type: KClass<*>,
+  override val properties: List<Property>,
+) : ProtocolLayoutModifier


### PR DESCRIPTION
This will eventually allow you to have a schema without any protocol annotations for using Redwood without the protocol/Treehouse.

Refs #221 