### PR TITLE
Remove Compose target marker generation

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/GenerateCommand.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/GenerateCommand.kt
@@ -70,7 +70,6 @@ internal class GenerateCommand : CliktCommand(name = "generate") {
 
     when (type) {
       Compose -> {
-        generateComposableTargetMarker(schema).writeTo(out)
         for (dependency in schema.allSchemas) {
           generateLayoutModifierImpls(dependency)?.writeTo(out)
           for (scope in dependency.scopes) {

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/composeGeneration.kt
@@ -40,42 +40,6 @@ import com.squareup.kotlinpoet.joinToCode
 import kotlin.reflect.KClass
 
 /*
-@Retention(AnnotationRetention.BINARY)
-@ComposableTargetMarker(description = "Example Composable")
-@Target(
-  AnnotationTarget.FUNCTION,
-  AnnotationTarget.PROPERTY_GETTER,
-  AnnotationTarget.TYPE,
-  AnnotationTarget.TYPE_PARAMETER,
-)
-public annotation class SunspotComposable
-*/
-internal fun generateComposableTargetMarker(schema: Schema): FileSpec {
-  val name = schema.composeTargetMarker
-  return FileSpec.builder(schema.composePackage(), name.simpleName)
-    .addType(
-      TypeSpec.annotationBuilder(name)
-        .addAnnotation(
-          AnnotationSpec.builder(Retention::class)
-            .addMember("%T.BINARY", AnnotationRetention::class)
-            .build(),
-        )
-        .addAnnotation(
-          AnnotationSpec.builder(ComposeRuntime.ComposableTargetMarker)
-            .addMember("description = %S", schema.name + " Composable")
-            .build(),
-        )
-        .addAnnotation(
-          AnnotationSpec.builder(Target::class)
-            .addMember("%1T.FUNCTION, %1T.PROPERTY_GETTER, %1T.TYPE, %1T.TYPE_PARAMETER", AnnotationTarget::class)
-            .build(),
-        )
-        .build(),
-    )
-    .build()
-}
-
-/*
 @Composable
 @SunspotComposable
 @OptIn(RedwoodCodegenApi::class)
@@ -107,14 +71,12 @@ internal fun generateComposable(
 ): FileSpec {
   val widgetType = schema.widgetType(widget).parameterizedBy(STAR)
   val widgetFactoryType = host.getWidgetFactoryType().parameterizedBy(STAR)
-  val composeTargetMarker = host.composeTargetMarker
   val flatName = widget.type.flatName
   return FileSpec.builder(schema.composePackage(), flatName)
     .addFunction(
       FunSpec.builder(flatName)
         .addModifiers(PUBLIC)
         .addAnnotation(ComposeRuntime.Composable)
-        .addAnnotation(composeTargetMarker)
         .addAnnotation(
           AnnotationSpec.builder(Stdlib.OptIn)
             .addMember("%T::class", Redwood.RedwoodCodegenApi)
@@ -154,7 +116,7 @@ internal fun generateComposable(
                 }
                 is Children -> {
                   val scope = trait.scope?.let { ClassName(schema.composePackage(), it.simpleName!!) }
-                  ParameterSpec.builder(trait.name, composableLambda(scope, composeTargetMarker))
+                  ParameterSpec.builder(trait.name, composableLambda(scope))
                     .apply {
                       trait.defaultExpression?.let { defaultValue(it) }
                     }

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/sharedHelpers.kt
@@ -64,8 +64,6 @@ internal fun Schema.composePackage(host: Schema = this): String {
   }
 }
 
-internal val Schema.composeTargetMarker get() = ClassName(composePackage(this), "${name}Composable")
-
 internal fun Schema.diffProducingWidgetFactoryType(host: Schema): ClassName {
   return ClassName(composePackage(host), "DiffProducing${name}WidgetFactory")
 }

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/generator/types.kt
@@ -74,13 +74,11 @@ internal object RedwoodCompose {
 
 internal object ComposeRuntime {
   val Composable = ClassName("androidx.compose.runtime", "Composable")
-  val ComposableTargetMarker = ClassName("androidx.compose.runtime", "ComposableTargetMarker")
   val Stable = ClassName("androidx.compose.runtime", "Stable")
 }
 
 internal fun composableLambda(
   receiver: TypeName?,
-  composeTargetMarker: ClassName,
 ): TypeName {
   return LambdaTypeName.get(
     returnType = UNIT,
@@ -88,7 +86,6 @@ internal fun composableLambda(
   ).copy(
     annotations = listOf(
       AnnotationSpec.builder(ComposeRuntime.Composable).build(),
-      AnnotationSpec.builder(composeTargetMarker).build(),
     ),
   )
 }

--- a/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/generator/ComposeGenerationTest.kt
@@ -40,27 +40,13 @@ class ComposeGenerationTest {
     @Children(2) val unscoped: () -> Unit,
   )
 
-  @Test fun `function target marker`() {
-    val schema = parseSchema(ScopedAndUnscopedSchema::class)
-
-    val fileSpec = generateComposable(schema, schema.widgets.single())
-    assertThat(fileSpec.toString()).contains(
-      """
-      |@Composable
-      |@ScopedAndUnscopedSchemaComposable
-      |@OptIn(RedwoodCodegenApi::class)
-      |public fun
-      """.trimMargin(),
-    )
-  }
-
-  @Test fun `scoped and unscoped children with target marker`() {
+  @Test fun `scoped and unscoped children`() {
     val schema = parseSchema(ScopedAndUnscopedSchema::class)
 
     val fileSpec = generateComposable(schema, schema.widgets.single())
     assertThat(fileSpec.toString()).apply {
-      contains("scoped: @Composable @ScopedAndUnscopedSchemaComposable RowScope.() -> Unit")
-      contains("unscoped: @Composable @ScopedAndUnscopedSchemaComposable () -> Unit")
+      contains("scoped: @Composable RowScope.() -> Unit")
+      contains("unscoped: @Composable () -> Unit")
     }
   }
 
@@ -100,7 +86,7 @@ class ComposeGenerationTest {
     assertThat(fileSpec.toString()).apply {
       contains("trait: String = \"test\"")
       contains("onEvent: (() -> Unit)? = { error(\"test\") }")
-      contains("block: @Composable @DefaultSchemaComposable () -> Unit = {}")
+      contains("block: @Composable () -> Unit = {}")
     }
   }
 
@@ -124,8 +110,8 @@ class ComposeGenerationTest {
     assertThat(fileSpec.toString()).contains(
       """
       |  layoutModifier: LayoutModifier = LayoutModifier,
-      |  top: @Composable @MultipleChildSchemaComposable () -> Unit,
-      |  bottom: @Composable @MultipleChildSchemaComposable () -> Unit,
+      |  top: @Composable () -> Unit,
+      |  bottom: @Composable () -> Unit,
       """.trimMargin(),
     )
   }


### PR DESCRIPTION
With the forthcoming switch to schemas generating their own composables these no longer make sense. In theory the lint check may still work as these were always optional, but who knows.