### PR TITLE
Make TreehouseUi implement AppService.

### DIFF
--- a/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/TreehouseUi.kt
+++ b/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/TreehouseUi.kt
@@ -17,10 +17,7 @@ package app.cash.redwood.treehouse
 
 import androidx.compose.runtime.Composable
 
-public interface TreehouseUi {
+public interface TreehouseUi : AppService {
   @Composable
   public fun Show()
-
-  public fun close() {
-  }
 }


### PR DESCRIPTION
We're currently running into this exception in any screen that uses `TreehouseUi`. Tested locally and I believe this fixes the crash though I also ran into some unrelated local dev issues while confirming.

```
FATAL EXCEPTION: Treehouse
app.cash.zipline.ZiplineApiMismatchException: no such method (incompatible API versions?)
	called function:
		val frameClockService: app.cash.redwood.treehouse.FrameClockService
	available functions:
		fun getScreen(kotlin.String, com.squareup.cash.treehouse.navigation.Navigator): app.cash.redwood.treehouse.ZiplineTreehouseUi
		fun close(): kotlin.Unit
	at captureStack (../../../../../runtime/coreRuntime.kt:86)
	at ZiplineApiMismatchException (../../../../../ZiplineApiMismatchException.kt:257)
	at <anonymous> (../../../../../calls.kt)
	at <anonymous> (../../../../../InboundService.kt:730)
	at <anonymous> (../../../../../Endpoint.kt:88)
	at <anonymous> (zipline-root-zipline.js)
	at <anonymous> (../../../../../GlobalBridge.kt)
	at <anonymous> (zipline-root-zipline.js)
	at com.squareup.cash.treehouse.ui.ZiplineTreehouse$Companion$Adapter$GeneratedOutboundService.getFrameClockService(ZiplineTreehouse.kt:14)
	at app.cash.redwood.treehouse.TreehouseApp$onCodeChanged$1.invokeSuspend(TreehouseApp.kt:93)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at java.lang.Thread.run(Thread.java:1012)
	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@3d1f239, java.util.concurrent.Executors$FinalizableDelegatedExecutorService@947b07e]
```