### PR TITLE
Expose only a minimal bridge type for diff-producing codegen

### DIFF
--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidget.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidget.kt
@@ -23,6 +23,8 @@ import app.cash.redwood.widget.Widget
 /**
  * A [Widget] with no platform-specific representation which instead produces protocol diffs
  * based on its properties.
+ *
+ * @suppress For generated code use only.
  */
 public interface DiffProducingWidget : Widget<Nothing> {
   public val id: Id
@@ -32,9 +34,4 @@ public interface DiffProducingWidget : Widget<Nothing> {
     get() = throw AssertionError()
 
   public fun sendEvent(event: Event)
-
-  /** A [Widget.Provider] whose [Widget]s write to a [ProtocolBridge]. */
-  public interface Provider : Widget.Provider<Nothing> {
-    public val bridge: ProtocolBridge
-  }
 }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetChildren.kt
@@ -23,28 +23,28 @@ import app.cash.redwood.widget.Widget
 internal class DiffProducingWidgetChildren(
   private val id: Id,
   private val tag: ChildrenTag,
-  private val bridge: ProtocolBridge,
+  private val state: ProtocolState,
 ) : Widget.Children<Nothing> {
   private val ids = mutableListOf<Id>()
 
   override fun insert(index: Int, widget: Widget<Nothing>) {
     widget as DiffProducingWidget
     ids.add(index, widget.id)
-    bridge.addWidget(widget)
-    bridge.append(ChildrenDiff.Insert(id, tag, widget.id, widget.tag, index))
+    state.addWidget(widget)
+    state.append(ChildrenDiff.Insert(id, tag, widget.id, widget.tag, index))
   }
 
   override fun remove(index: Int, count: Int) {
     for (i in index until index + count) {
-      bridge.removeWidget(ids[i])
+      state.removeWidget(ids[i])
     }
     ids.remove(index, count)
-    bridge.append(ChildrenDiff.Remove(id, tag, index, count))
+    state.append(ChildrenDiff.Remove(id, tag, index, count))
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {
     ids.move(fromIndex, toIndex, count)
-    bridge.append(ChildrenDiff.Move(id, tag, fromIndex, toIndex, count))
+    state.append(ChildrenDiff.Move(id, tag, fromIndex, toIndex, count))
   }
 
   override fun onLayoutModifierUpdated(index: Int) {

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -22,9 +22,7 @@ import androidx.compose.runtime.currentComposer
 import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.compose.WidgetApplier
-import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.DiffSink
-import app.cash.redwood.protocol.Id
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -33,13 +31,11 @@ import kotlinx.coroutines.CoroutineScope
  */
 public fun ProtocolRedwoodComposition(
   scope: CoroutineScope,
-  provider: DiffProducingWidget.Provider,
+  bridge: ProtocolBridge,
   diffSink: DiffSink,
   widgetVersion: UInt,
 ): RedwoodComposition {
-  val bridge = provider.bridge
-  val root = DiffProducingWidgetChildren(Id.Root, ChildrenTag.Root, bridge)
-  val applier = WidgetApplier(provider, root) {
+  val applier = WidgetApplier(bridge.provider, bridge.root) {
     bridge.createDiffOrNull()?.let(diffSink::sendDiff)
   }
   val composition = RedwoodComposition(scope, applier)

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+import app.cash.redwood.protocol.ChildrenDiff
+import app.cash.redwood.protocol.ChildrenTag
+import app.cash.redwood.protocol.Diff
+import app.cash.redwood.protocol.Event
+import app.cash.redwood.protocol.Id
+import app.cash.redwood.protocol.LayoutModifiers
+import app.cash.redwood.protocol.PropertyDiff
+import app.cash.redwood.widget.Widget
+
+/** @suppress For generated code use only. */
+public class ProtocolState {
+  private var nextValue = Id.Root.value + 1L
+  private val nodes = mutableMapOf<Id, DiffProducingWidget>()
+
+  private var childrenDiffs = mutableListOf<ChildrenDiff>()
+  private var layoutModifiers = mutableListOf<LayoutModifiers>()
+  private var propertyDiffs = mutableListOf<PropertyDiff>()
+
+  public fun nextId(): Id {
+    val value = nextValue
+    nextValue = value + 1L
+    return Id(value)
+  }
+
+  public fun append(childrenDiff: ChildrenDiff) {
+    childrenDiffs += childrenDiff
+  }
+
+  public fun append(layoutModifiers: LayoutModifiers) {
+    this.layoutModifiers += layoutModifiers
+  }
+
+  public fun append(propertyDiff: PropertyDiff) {
+    propertyDiffs += propertyDiff
+  }
+
+  /**
+   * If there were any calls to [append] since the last call to this function return them as a
+   * [Diff] and reset the internal lists to be empty. This function returns null if there were
+   * no calls to [append] since the last invocation.
+   */
+  public fun createDiffOrNull(): Diff? {
+    val existingChildrenDiffs = childrenDiffs
+    val existingLayoutModifierDiffs = layoutModifiers
+    val existingPropertyDiffs = propertyDiffs
+    if (existingPropertyDiffs.isNotEmpty() || existingLayoutModifierDiffs.isNotEmpty() || existingChildrenDiffs.isNotEmpty()) {
+      childrenDiffs = mutableListOf()
+      layoutModifiers = mutableListOf()
+      propertyDiffs = mutableListOf()
+
+      return Diff(
+        childrenDiffs = existingChildrenDiffs,
+        layoutModifiers = existingLayoutModifierDiffs,
+        propertyDiffs = existingPropertyDiffs,
+      )
+    }
+    return null
+  }
+
+  public fun addWidget(widget: DiffProducingWidget) {
+    check(nodes.put(widget.id, widget) == null) {
+      "Attempted to add widget with ID ${widget.id.value} but one already exists"
+    }
+  }
+
+  public fun removeWidget(id: Id) {
+    nodes.remove(id)
+  }
+
+  public fun widgetChildren(id: Id, tag: ChildrenTag): Widget.Children<Nothing> {
+    return DiffProducingWidgetChildren(id, tag, this)
+  }
+
+  public fun sendEvent(event: Event) {
+    val node = checkNotNull(nodes[event.id]) {
+      // TODO how to handle race where an incoming event targets this removed node?
+      "Unknown node ${event.id} for event with tag ${event.tag}"
+    }
+    node.sendEvent(event)
+  }
+}

--- a/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetFactoryTest.kt
+++ b/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/DiffProducingWidgetFactoryTest.kt
@@ -25,7 +25,7 @@ import app.cash.redwood.protocol.LayoutModifierTag
 import app.cash.redwood.protocol.LayoutModifiers
 import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.protocol.PropertyTag
-import example.redwood.compose.ExampleSchemaDiffProducingWidgetFactories
+import example.redwood.compose.ExampleSchemaProtocolBridge
 import example.redwood.compose.TestScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -44,9 +44,8 @@ class DiffProducingWidgetFactoryTest {
         contextual(Duration::class, DurationIsoSerializer)
       }
     }
-    val bridge = ProtocolBridge()
-    val factory = ExampleSchemaDiffProducingWidgetFactories(bridge, json)
-    val textInput = factory.ExampleSchema.TextInput()
+    val bridge = ExampleSchemaProtocolBridge.create(json)
+    val textInput = bridge.provider.ExampleSchema.TextInput()
 
     textInput.customType(10.seconds)
 
@@ -64,9 +63,8 @@ class DiffProducingWidgetFactoryTest {
         contextual(Duration::class, DurationIsoSerializer)
       }
     }
-    val bridge = ProtocolBridge()
-    val factory = ExampleSchemaDiffProducingWidgetFactories(bridge, json)
-    val button = factory.ExampleSchema.Button()
+    val bridge = ExampleSchemaProtocolBridge.create(json)
+    val button = bridge.provider.ExampleSchema.Button()
 
     button.layoutModifiers = with(object : TestScope {}) {
       LayoutModifier.customType(10.seconds)
@@ -96,9 +94,8 @@ class DiffProducingWidgetFactoryTest {
         contextual(Duration::class, DurationIsoSerializer)
       }
     }
-    val bridge = ProtocolBridge()
-    val factory = ExampleSchemaDiffProducingWidgetFactories(bridge, json)
-    val button = factory.ExampleSchema.Button()
+    val bridge = ExampleSchemaProtocolBridge.create(json)
+    val button = bridge.provider.ExampleSchema.Button()
 
     button.layoutModifiers = with(object : TestScope {}) {
       LayoutModifier.customTypeWithDefault(10.seconds, "sup")
@@ -128,8 +125,8 @@ class DiffProducingWidgetFactoryTest {
         contextual(Duration::class, DurationIsoSerializer)
       }
     }
-    val factory = ExampleSchemaDiffProducingWidgetFactories(ProtocolBridge(), json)
-    val textInput = factory.ExampleSchema.TextInput()
+    val bridge = ExampleSchemaProtocolBridge.create(json)
+    val textInput = bridge.provider.ExampleSchema.TextInput()
 
     val diffProducingWidget = textInput as DiffProducingWidget
 
@@ -144,8 +141,8 @@ class DiffProducingWidgetFactoryTest {
   }
 
   @Test fun unknownEventThrowsDefault() {
-    val factory = ExampleSchemaDiffProducingWidgetFactories(ProtocolBridge())
-    val button = factory.ExampleSchema.Button() as DiffProducingWidget
+    val bridge = ExampleSchemaProtocolBridge.create()
+    val button = bridge.provider.ExampleSchema.Button() as DiffProducingWidget
 
     val event = Event(Id(1), EventTag(3456543))
     val t = assertFailsWith<IllegalArgumentException> {
@@ -157,8 +154,8 @@ class DiffProducingWidgetFactoryTest {
 
   @Test fun unknownEventCallsHandler() {
     val handler = RecordingProtocolMismatchHandler()
-    val factory = ExampleSchemaDiffProducingWidgetFactories(ProtocolBridge(), mismatchHandler = handler)
-    val button = factory.ExampleSchema.Button() as DiffProducingWidget
+    val bridge = ExampleSchemaProtocolBridge.create(mismatchHandler = handler)
+    val button = bridge.provider.ExampleSchema.Button() as DiffProducingWidget
 
     button.sendEvent(Event(Id(1), EventTag(3456543)))
 

--- a/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
+++ b/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
@@ -31,7 +31,7 @@ import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
 import example.redwood.compose.Button
-import example.redwood.compose.ExampleSchemaDiffProducingWidgetFactories
+import example.redwood.compose.ExampleSchemaProtocolBridge
 import example.redwood.compose.Row
 import example.redwood.compose.Text
 import kotlin.test.Test
@@ -49,7 +49,7 @@ class ProtocolTest {
     val clock = BroadcastFrameClock()
     val composition = ProtocolRedwoodComposition(
       scope = this + clock,
-      provider = ExampleSchemaDiffProducingWidgetFactories(ProtocolBridge()),
+      bridge = ExampleSchemaProtocolBridge.create(),
       diffSink = ::error,
       widgetVersion = 22U,
     )
@@ -68,7 +68,7 @@ class ProtocolTest {
     val diffs = ArrayDeque<Diff>()
     val composition = ProtocolRedwoodComposition(
       scope = this + clock,
-      provider = ExampleSchemaDiffProducingWidgetFactories(ProtocolBridge()),
+      bridge = ExampleSchemaProtocolBridge.create(),
       diffSink = { diff -> diffs += diff },
       widgetVersion = 1U,
     )
@@ -111,11 +111,11 @@ class ProtocolTest {
   @Test fun protocolSkipsLambdaChangeOfSamePresence() = runTest {
     val clock = BroadcastFrameClock()
     var state by mutableStateOf(0)
-    val bridge = ProtocolBridge()
+    val bridge = ExampleSchemaProtocolBridge.create()
     val diffs = ArrayDeque<Diff>()
     val composition = ProtocolRedwoodComposition(
       scope = this + clock,
-      provider = ExampleSchemaDiffProducingWidgetFactories(bridge),
+      bridge = bridge,
       diffSink = { diff -> diffs += diff },
       widgetVersion = 1U,
     )

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
@@ -28,7 +28,7 @@ public enum class ProtocolCodegenType {
 public fun ProtocolSchema.generate(type: ProtocolCodegenType, destination: Path) {
   when (type) {
     Compose -> {
-      generateDiffProducingWidgetFactories(this).writeTo(destination)
+      generateProtocolBridge(this).writeTo(destination)
       for (dependency in allSchemas) {
         generateDiffProducingWidgetFactory(dependency, host = this).writeTo(destination)
         generateDiffProducingLayoutModifiers(dependency, host = this).writeTo(destination)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -64,12 +64,12 @@ internal fun Schema.composePackage(host: Schema = this): String {
   }
 }
 
-internal fun Schema.diffProducingWidgetFactoriesType(): ClassName {
-  return ClassName(composePackage(), "${name}DiffProducingWidgetFactories")
+internal fun Schema.protocolBridgeType(): ClassName {
+  return ClassName(composePackage(), "${name}ProtocolBridge")
 }
 
 internal fun Schema.diffProducingWidgetFactoryType(host: Schema): ClassName {
-  return ClassName(composePackage(host), "${name}DiffProducingWidgetFactory")
+  return ClassName(composePackage(host), "DiffProducing${name}WidgetFactory")
 }
 
 internal fun Schema.diffProducingWidgetType(widget: Widget, host: Schema): ClassName {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -27,6 +27,7 @@ import com.squareup.kotlinpoet.UNIT
 
 internal object Protocol {
   val ChildrenTag = ClassName("app.cash.redwood.protocol", "ChildrenTag")
+  val Diff = ClassName("app.cash.redwood.protocol", "Diff")
   val Event = ClassName("app.cash.redwood.protocol", "Event")
   val EventTag = ClassName("app.cash.redwood.protocol", "EventTag")
   val EventSink = ClassName("app.cash.redwood.protocol", "EventSink")
@@ -41,8 +42,9 @@ internal object Protocol {
 
 internal object ComposeProtocol {
   val DiffProducingWidget = ClassName("app.cash.redwood.protocol.compose", "DiffProducingWidget")
-  val DiffProducingWidgetProvider = DiffProducingWidget.nestedClass("Provider")
   val ProtocolBridge = ClassName("app.cash.redwood.protocol.compose", "ProtocolBridge")
+  val ProtocolBridgeFactory = ProtocolBridge.nestedClass("Factory")
+  val ProtocolState = ClassName("app.cash.redwood.protocol.compose", "ProtocolState")
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.compose", "ProtocolMismatchHandler")
 }

--- a/redwood-treehouse-lazylayout-compose/src/jsMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-compose/src/jsMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
@@ -17,14 +17,14 @@ package app.cash.redwood.treehouse.lazylayout.compose
 
 import androidx.compose.runtime.Composable
 import app.cash.redwood.LayoutScopeMarker
-import app.cash.redwood.protocol.compose.DiffProducingWidget
+import app.cash.redwood.protocol.compose.ProtocolBridge
 import app.cash.redwood.treehouse.TreehouseUi
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.redwood.treehouse.asZiplineTreehouseUi
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 
 @Composable
-public fun DiffProducingWidget.Provider.LazyColumn(content: LazyListScope.() -> Unit) {
+public fun ProtocolBridge.LazyColumn(content: LazyListScope.() -> Unit) {
   val scope = TreehouseLazyListScope(this)
   content(scope)
   LazyColumn(scope.intervals)
@@ -47,11 +47,11 @@ public inline fun <T> LazyListScope.items(
   }
 }
 
-private class TreehouseLazyListScope(private val provider: DiffProducingWidget.Provider) : LazyListScope {
+private class TreehouseLazyListScope(private val provider: ProtocolBridge) : LazyListScope {
   val intervals = mutableListOf<LazyListIntervalContent>()
 
   private class Item(
-    private val provider: DiffProducingWidget.Provider,
+    private val provider: ProtocolBridge,
     private val content: @Composable (index: Int) -> Unit,
   ) : LazyListIntervalContent.Item {
 

--- a/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
+++ b/redwood-treehouse/src/jsMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.protocol.EventSink
-import app.cash.redwood.protocol.compose.DiffProducingWidget
+import app.cash.redwood.protocol.compose.ProtocolBridge
 import app.cash.redwood.protocol.compose.ProtocolRedwoodComposition
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -31,17 +31,17 @@ import kotlinx.coroutines.plus
  * The Kotlin/JS side of a treehouse UI.
  */
 public fun TreehouseUi.asZiplineTreehouseUi(
-  provider: DiffProducingWidget.Provider,
+  bridge: ProtocolBridge,
   widgetVersion: UInt,
 ): ZiplineTreehouseUi {
-  return RedwoodZiplineTreehouseUi(provider, widgetVersion, this)
+  return RedwoodZiplineTreehouseUi(bridge, widgetVersion, this)
 }
 
 private class RedwoodZiplineTreehouseUi(
-  private val provider: DiffProducingWidget.Provider,
+  private val bridge: ProtocolBridge,
   private val widgetVersion: UInt,
   private val treehouseUi: TreehouseUi,
-) : ZiplineTreehouseUi, EventSink by provider.bridge {
+) : ZiplineTreehouseUi, EventSink by bridge {
   private lateinit var diffSinkToClose: DiffSinkService
   private lateinit var composition: RedwoodComposition
 
@@ -54,7 +54,7 @@ private class RedwoodZiplineTreehouseUi(
 
     val composition = ProtocolRedwoodComposition(
       scope = scope + StandardFrameClock,
-      provider = provider,
+      bridge = bridge,
       widgetVersion = widgetVersion,
       diffSink = diffSink,
     )

--- a/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearch.kt
+++ b/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/EmojiSearch.kt
@@ -24,12 +24,11 @@ import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.Padding
 import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.layout.compose.Row
-import app.cash.redwood.protocol.compose.DiffProducingWidget
+import app.cash.redwood.protocol.compose.ProtocolBridge
 import app.cash.redwood.treehouse.TreehouseUi
 import app.cash.redwood.treehouse.lazylayout.compose.LazyColumn
 import app.cash.redwood.treehouse.lazylayout.compose.items
 import app.cash.zipline.samples.emojisearch.EmojiSearchEvent.SearchTermEvent
-import example.schema.compose.EmojiSearchDiffProducingWidgetFactories
 import example.schema.compose.Image
 import example.schema.compose.Text
 import example.schema.compose.TextInput
@@ -39,8 +38,8 @@ class EmojiSearchTreehouseUi(
   private val initialViewModel: EmojiSearchViewModel,
   private val viewModels: Flow<EmojiSearchViewModel>,
   private val onEvent: (EmojiSearchEvent) -> Unit,
-  private val factories: EmojiSearchDiffProducingWidgetFactories,
-) : TreehouseUi, DiffProducingWidget.Provider by factories {
+  private val bridge: ProtocolBridge,
+) : TreehouseUi, ProtocolBridge by bridge {
 
   @Composable
   override fun Show() {

--- a/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/RealEmojiSearchPresenter.kt
+++ b/samples/emoji-search/presenters/src/jsMain/kotlin/app/cash/zipline/samples/emojisearch/RealEmojiSearchPresenter.kt
@@ -15,11 +15,10 @@
  */
 package app.cash.zipline.samples.emojisearch
 
-import app.cash.redwood.protocol.compose.ProtocolBridge
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.redwood.treehouse.asZiplineTreehouseUi
 import app.cash.zipline.samples.emojisearch.EmojiSearchEvent.SearchTermEvent
-import example.schema.compose.EmojiSearchDiffProducingWidgetFactories
+import example.schema.compose.EmojiSearchProtocolBridge
 import example.values.TextFieldState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -43,15 +42,15 @@ class RealEmojiSearchPresenter(
 
   override fun launch(): ZiplineTreehouseUi {
     val events = MutableSharedFlow<EmojiSearchEvent>(extraBufferCapacity = Int.MAX_VALUE)
-    val factories = EmojiSearchDiffProducingWidgetFactories(ProtocolBridge(), json)
+    val bridge = EmojiSearchProtocolBridge.create(json)
     val treehouseUi = EmojiSearchTreehouseUi(
       initialViewModel = initialViewModel,
       viewModels = produceModels(events),
       onEvent = events::tryEmit,
-      factories = factories,
+      bridge = bridge,
     )
     return treehouseUi.asZiplineTreehouseUi(
-      provider = factories,
+      bridge = bridge,
       widgetVersion = 0U,
     )
   }


### PR DESCRIPTION
This reduces the generated API surface to something that hides 100% of the factory and widget types. Instead, a `ProtocolBridge` subtype is exposed with its companion acting as a factory.