### PR TITLE
Move Gradle wrapper validator action to own workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'
@@ -43,7 +42,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
-      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'
@@ -56,7 +54,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'
@@ -86,7 +83,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'

--- a/.github/workflows/gradle-wrapper.yaml
+++ b/.github/workflows/gradle-wrapper.yaml
@@ -1,0 +1,15 @@
+name: gradle-wrapper
+
+on:
+  pull_request:
+    paths:
+    - 'gradlew'
+    - 'gradlew.bat'
+    - 'gradle/wrapper/'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'

--- a/.github/workflows/todo.yaml
+++ b/.github/workflows/todo.yaml
@@ -11,7 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      # Note: Intentionally omitting the git submodule checkout
 
       - uses: alstr/todo-to-issue-action@v4.9
         id: todo


### PR DESCRIPTION
It fails too much and the wrapper almost never changes. New rule: Renovate is the only one who is allowed to bump Gradle (because we generally trust it) and this action will only run on those PRs.