### PR TITLE
Update release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - '**'
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
 jobs:
   publish:
@@ -29,7 +29,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew build publish
+        run: ./gradlew publish dokkaHtmlMultiModule --parallel
 
       - name: Extract release notes
         id: release_notes
@@ -41,9 +41,6 @@ jobs:
           body: ${{ steps.release_notes.outputs.release_notes }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate docs
-        run: ./gradlew dokkaHtml
 
       - name: Deploy docs to website
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ kotlin.mpp.enableCInteropCommonization=true
 app.cash.redwood.internal=true
 
 GROUP=app.cash.redwood
+# HEY! If you change major version update release.yaml doc folder.
 VERSION_NAME=0.1.0-SNAPSHOT
 
 POM_DESCRIPTION=Multiplatform tree management


### PR DESCRIPTION
- Do not do a full build. Just publish and trust things are good.
- Run in parallel. Latest publish plugin uses a build service to prevent parallelism on upload tasks and also creates an explicit staging repo to prevent Sonatype repo split.
- Fix Dokka task, and also run that in parallel.
- Match RAM provisioning of regular build.