### PR TITLE
Fix site source folder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: site
+          FOLDER: build/dokka/htmlMultiModule/
           TARGET_FOLDER: docs/0.x/
           CLEAN: true


### PR DESCRIPTION
The source folder is 'site/' for 'trunk' builds because we run Dokka on one shard and then download the HTML into 'site/'. When deploying from the build shard we need to use original folder.