### PR TITLE
Eliminate 'DiffProducing' prefix

### DIFF
--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -39,10 +39,10 @@ public fun ProtocolRedwoodComposition(
     bridge.createDiffOrNull()?.let(diffSink::sendDiff)
   }
   val composition = RedwoodComposition(scope, applier)
-  return DiffProducingRedwoodComposition(composition, widgetVersion)
+  return ProtocolRedwoodComposition(composition, widgetVersion)
 }
 
-private class DiffProducingRedwoodComposition(
+private class ProtocolRedwoodComposition(
   private val composition: RedwoodComposition,
   private val widgetVersion: UInt,
 ) : RedwoodComposition by composition {

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
@@ -26,7 +26,7 @@ import app.cash.redwood.widget.Widget
 /** @suppress For generated code use only. */
 public class ProtocolState {
   private var nextValue = Id.Root.value + 1L
-  private val nodes = mutableMapOf<Id, DiffProducingWidget>()
+  private val widgets = mutableMapOf<Id, ProtocolWidget>()
 
   private var childrenDiffs = mutableListOf<ChildrenDiff>()
   private var layoutModifiers = mutableListOf<LayoutModifiers>()
@@ -73,19 +73,19 @@ public class ProtocolState {
     return null
   }
 
-  public fun addWidget(widget: DiffProducingWidget) {
-    check(nodes.put(widget.id, widget) == null) {
+  public fun addWidget(widget: ProtocolWidget) {
+    check(widgets.put(widget.id, widget) == null) {
       "Attempted to add widget with ID ${widget.id.value} but one already exists"
     }
   }
 
   public fun removeWidget(id: Id) {
-    nodes.remove(id)
+    widgets.remove(id)
   }
 
-  public fun getWidget(id: Id): DiffProducingWidget? = nodes[id]
+  public fun getWidget(id: Id): ProtocolWidget? = widgets[id]
 
   public fun widgetChildren(id: Id, tag: ChildrenTag): Widget.Children<Nothing> {
-    return DiffProducingWidgetChildren(id, tag, this)
+    return ProtocolWidgetChildren(id, tag, this)
   }
 }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidget.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidget.kt
@@ -26,7 +26,7 @@ import app.cash.redwood.widget.Widget
  *
  * @suppress For generated code use only.
  */
-public interface DiffProducingWidget : Widget<Nothing> {
+public interface ProtocolWidget : Widget<Nothing> {
   public val id: Id
   public val tag: WidgetTag
 

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidgetChildren.kt
@@ -20,7 +20,7 @@ import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.widget.Widget
 
-internal class DiffProducingWidgetChildren(
+internal class ProtocolWidgetChildren(
   private val id: Id,
   private val tag: ChildrenTag,
   private val state: ProtocolState,
@@ -28,7 +28,7 @@ internal class DiffProducingWidgetChildren(
   private val ids = mutableListOf<Id>()
 
   override fun insert(index: Int, widget: Widget<Nothing>) {
-    widget as DiffProducingWidget
+    widget as ProtocolWidget
     ids.add(index, widget.id)
     state.addWidget(widget)
     state.append(ChildrenDiff.Insert(id, tag, widget.id, widget.tag, index))

--- a/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/GeneratedProtocolBridgeTest.kt
+++ b/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/GeneratedProtocolBridgeTest.kt
@@ -128,21 +128,21 @@ class GeneratedProtocolBridgeTest {
     val bridge = ExampleSchemaProtocolBridge.create(json)
     val textInput = bridge.provider.ExampleSchema.TextInput()
 
-    val diffProducingWidget = textInput as DiffProducingWidget
+    val protocolWidget = textInput as ProtocolWidget
 
     var argument: Duration? = null
     textInput.onChangeCustomType {
       argument = it
     }
 
-    diffProducingWidget.sendEvent(Event(Id(1), EventTag(4), JsonPrimitive("PT10S")))
+    protocolWidget.sendEvent(Event(Id(1), EventTag(4), JsonPrimitive("PT10S")))
 
     assertEquals(10.seconds, argument)
   }
 
   @Test fun unknownEventThrowsDefault() {
     val bridge = ExampleSchemaProtocolBridge.create()
-    val button = bridge.provider.ExampleSchema.Button() as DiffProducingWidget
+    val button = bridge.provider.ExampleSchema.Button() as ProtocolWidget
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.sendEvent(Event(Id(1), EventTag(3456543)))
@@ -154,7 +154,7 @@ class GeneratedProtocolBridgeTest {
   @Test fun unknownEventCallsHandler() {
     val handler = RecordingProtocolMismatchHandler()
     val bridge = ExampleSchemaProtocolBridge.create(mismatchHandler = handler)
-    val button = bridge.provider.ExampleSchema.Button() as DiffProducingWidget
+    val button = bridge.provider.ExampleSchema.Button() as ProtocolWidget
 
     button.sendEvent(Event(Id(1), EventTag(3456543)))
 

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
@@ -29,11 +29,12 @@ public fun ProtocolSchema.generate(type: ProtocolCodegenType, destination: Path)
   when (type) {
     Compose -> {
       generateProtocolBridge(this).writeTo(destination)
+      generateProtocolLayoutModifierSerialization(this).writeTo(destination)
       for (dependency in allSchemas) {
-        generateDiffProducingWidgetFactory(dependency, host = this).writeTo(destination)
-        generateDiffProducingLayoutModifiers(dependency, host = this).writeTo(destination)
+        generateProtocolWidgetFactory(dependency, host = this).writeTo(destination)
+        generateProtocolLayoutModifierSurrogates(dependency, host = this).writeTo(destination)
         for (widget in dependency.widgets) {
-          generateDiffProducingWidget(dependency, widget, host = this).writeTo(destination)
+          generateProtocolWidget(dependency, widget, host = this).writeTo(destination)
         }
       }
     }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -56,8 +56,8 @@ internal val Event.lambdaType: TypeName
 
 private val noArgumentEventLambda = LambdaTypeName.get(returnType = UNIT).copy(nullable = true)
 
-internal fun Schema.composePackage(host: Schema = this): String {
-  return if (this === host) {
+internal fun Schema.composePackage(host: Schema? = null): String {
+  return if (host == null) {
     "$`package`.compose"
   } else {
     "${host.`package`}.compose.${name.lowercase()}"
@@ -68,12 +68,12 @@ internal fun Schema.protocolBridgeType(): ClassName {
   return ClassName(composePackage(), "${name}ProtocolBridge")
 }
 
-internal fun Schema.diffProducingWidgetFactoryType(host: Schema): ClassName {
-  return ClassName(composePackage(host), "DiffProducing${name}WidgetFactory")
+internal fun Schema.protocolWidgetFactoryType(host: Schema): ClassName {
+  return ClassName(composePackage(host), "Protocol${name}WidgetFactory")
 }
 
-internal fun Schema.diffProducingWidgetType(widget: Widget, host: Schema): ClassName {
-  return ClassName(composePackage(host), "DiffProducing${widget.type.flatName}")
+internal fun Schema.protocolWidgetType(widget: Widget, host: Schema): ClassName {
+  return ClassName(composePackage(host), "Protocol${widget.type.flatName}")
 }
 
 internal fun Schema.diffConsumingNodeFactoryType(): ClassName {
@@ -123,8 +123,8 @@ internal fun Schema.layoutModifierImpl(layoutModifier: LayoutModifier): ClassNam
 internal val Schema.toLayoutModifier: MemberName get() =
   MemberName(widgetPackage(this), "toLayoutModifier")
 
-internal val Schema.toProtocol: MemberName get() =
-  MemberName(composePackage(this), "toProtocol")
+internal val Schema.layoutModifierToProtocol: MemberName get() =
+  MemberName(composePackage(), "toProtocol")
 
 internal fun ProtocolSchema.allLayoutModifiers(): List<Pair<ProtocolSchema, ProtocolLayoutModifier>> {
   return (listOf(this) + dependencies).flatMap { schema ->

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -41,12 +41,12 @@ internal object Protocol {
 }
 
 internal object ComposeProtocol {
-  val DiffProducingWidget = ClassName("app.cash.redwood.protocol.compose", "DiffProducingWidget")
   val ProtocolBridge = ClassName("app.cash.redwood.protocol.compose", "ProtocolBridge")
   val ProtocolBridgeFactory = ProtocolBridge.nestedClass("Factory")
   val ProtocolState = ClassName("app.cash.redwood.protocol.compose", "ProtocolState")
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.compose", "ProtocolMismatchHandler")
+  val ProtocolWidget = ClassName("app.cash.redwood.protocol.compose", "ProtocolWidget")
 }
 
 internal object WidgetProtocol {

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
@@ -22,7 +22,7 @@ import app.cash.redwood.tooling.schema.parseProtocolSchema
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-class DiffProducingGenerationTest {
+class ComposeProtocolGenerationTest {
   @Schema(
     [
       IdPropertyNameCollisionNode::class,
@@ -39,13 +39,11 @@ class DiffProducingGenerationTest {
   @Test fun `id property does not collide`() {
     val schema = parseProtocolSchema(IdPropertyNameCollisionSchema::class)
 
-    val fileSpec = generateDiffProducingWidget(schema, schema.widgets.single())
+    val fileSpec = generateProtocolWidget(schema, schema.widgets.single())
     assertThat(fileSpec.toString()).contains(
       """
       |  public override fun id(id: String): Unit {
-      |    bridge.append(PropertyDiff(this.id, PropertyTag(2), json.encodeToJsonElement(serializer_0, id)))
-      |  }
-      |
+      |    this.state.append(PropertyDiff(this.id,
       """.trimMargin(),
     )
   }
@@ -53,7 +51,7 @@ class DiffProducingGenerationTest {
   @Test fun `dependency layout modifiers are included in serialization`() {
     val schema = parseProtocolSchema(PrimarySchema::class)
 
-    val fileSpec = generateDiffProducingLayoutModifiers(schema)
+    val fileSpec = generateProtocolLayoutModifierSerialization(schema)
     assertThat(fileSpec.toString()).apply {
       contains("is PrimaryModifier -> PrimaryModifierSurrogate.encode(json, this)")
       contains("is SecondaryModifier -> SecondaryModifierSurrogate.encode(json, this)")


### PR DESCRIPTION
We now only have 'Protocol' which exists as Widgets (this change) or Nodes (future change to eliminate 'Diff Consuming').

Also cleaned up some leftover 'Sunspot' references and incorrect local names.