### PR TITLE
Optimize generated Compose protocol serialize function

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
@@ -497,7 +497,7 @@ internal fun generateProtocolLayoutModifierSurrogates(
 
           if (property.defaultExpression != null) {
             serializerBody.beginControlFlow(
-              "if (shouldEncodeElementDefault(descriptor, %L) || value.%N != %L)",
+              "if (composite.shouldEncodeElementDefault(descriptor, %L) || value.%N != %L)",
               index,
               property.name,
               property.defaultExpression,
@@ -505,47 +505,47 @@ internal fun generateProtocolLayoutModifierSurrogates(
           }
           when (propertyType) {
             BOOLEAN -> serializerBody.addStatement(
-              "encodeBooleanElement(descriptor, %L, value.%N)",
+              "composite.encodeBooleanElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             BYTE -> serializerBody.addStatement(
-              "encodeByteElement(descriptor, %L, value.%N)",
+              "composite.encodeByteElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             CHAR -> serializerBody.addStatement(
-              "encodeCharElement(descriptor, %L, value.%N)",
+              "composite.encodeCharElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             SHORT -> serializerBody.addStatement(
-              "encodeShortElement(descriptor, %L, value.%N)",
+              "composite.encodeShortElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             INT -> serializerBody.addStatement(
-              "encodeIntElement(descriptor, %L, value.%N)",
+              "composite.encodeIntElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             LONG -> serializerBody.addStatement(
-              "encodeLongElement(descriptor, %L, value.%N)",
+              "composite.encodeLongElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             FLOAT -> serializerBody.addStatement(
-              "encodeFloatElement(descriptor, %L, value.%N)",
+              "composite.encodeFloatElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             DOUBLE -> serializerBody.addStatement(
-              "encodeDoubleElement(descriptor, %L, value.%N)",
+              "composite.encodeDoubleElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
             STRING -> serializerBody.addStatement(
-              "encodeStringElement(descriptor, %L, value.%N)",
+              "composite.encodeStringElement(descriptor, %L, value.%N)",
               index,
               property.name,
             )
@@ -554,7 +554,7 @@ internal fun generateProtocolLayoutModifierSurrogates(
                 nextSerializerId++
               }
               serializerBody.addStatement(
-                "encodeSerializableElement(descriptor, %L, serializer_%L, value.%N)",
+                "composite.encodeSerializableElement(descriptor, %L, serializer_%L, value.%N)",
                 index,
                 serializerId,
                 property.name,
@@ -616,9 +616,9 @@ internal fun generateProtocolLayoutModifierSurrogates(
                     )
                   }
                 }
-                .beginControlFlow("encoder.%M(descriptor)", KotlinxSerialization.encodeStructure)
+                .addStatement("val composite = encoder.beginStructure(descriptor)")
                 .addCode(serializerBody.build())
-                .endControlFlow()
+                .addStatement("composite.endStructure(descriptor)")
                 .build(),
             )
             .addFunction(

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -114,7 +114,6 @@ internal object KotlinxSerialization {
 
   val Decoder = ClassName("kotlinx.serialization.encoding", "Decoder")
   val Encoder = ClassName("kotlinx.serialization.encoding", "Encoder")
-  val encodeStructure = MemberName("kotlinx.serialization.encoding", "encodeStructure")
 
   val Json = ClassName("kotlinx.serialization.json", "Json")
   val JsonDefault = Json.nestedClass("Default")


### PR DESCRIPTION
Before Kotlin:

```kotlin
public override fun serialize(encoder: Encoder, `value`: VerticalAlignment): Unit {
  encoder.encodeStructure(descriptor) {
    encodeSerializableElement(descriptor, 0, serializer_0, value.alignment)
  }
}
```

Before JS:

```js
VerticalAlignmentSerializer.prototype.t43 = function (encoder, value) {
  // Inline function 'kotlinx.serialization.encoding.encodeStructure' call
  var tmp0_encodeStructure = this.h42_1;
  var composite = encoder.r2f(tmp0_encodeStructure);
  // Inline function 'com.example.redwood.emojisearch.compose.redwoodlayout.VerticalAlignmentSerializer.serialize.<anonymous>' call
  composite.f2h(VerticalAlignmentSerializer_getInstance().h42_1, 0, VerticalAlignmentSerializer_getInstance().i42_1, new CrossAxisAlignment(value.h2y()));
  composite.s2f(tmp0_encodeStructure);
};
```

Notice how in the JS it first calls `this.h42_1` to get the `descriptor` and this is then used for the `beginStructure` and `endStructure` calls produced by the `encodeStructure` inline function. However, between those calls, code in the inlined lambda which refer to the `descriptor` now trampoline through a function lookup of the instance `VerticalAlignmentSerializer_getInstance().h42_1` despite being availale as `this.h42_1`.

I filed this problem as https://youtrack.jetbrains.com/issue/KT-55807. For now we'll work around it because it's easy.

After Kotlin:

```kotlin
public override fun serialize(encoder: Encoder, `value`: VerticalAlignment): Unit {
  val composite = encoder.beginStructure(descriptor)
  composite.encodeSerializableElement(descriptor, 0, serializer_0, value.alignment)
  composite.endStructure(descriptor)
}
```

After JS:

```js
VerticalAlignmentSerializer.prototype.t43 = function (encoder, value) {
  var composite = encoder.r2f(this.h42_1);
  composite.f2h(this.h42_1, 0, this.i42_1, new CrossAxisAlignment(value.h2y()));
  composite.s2f(this.h42_1);
};
```

Before JS: 44221
After JS: 42627 (3.6% savings)

Before QuickJS bytecode: 23658
After QuickJS bytecode: 23544 (0.5% savings)

Did this on Friday but needed the other one to merge before rebase & PR.