### PR TITLE
Make remaining Lazy Layout artifacts publishable

### DIFF
--- a/redwood-treehouse-lazylayout-compose/build.gradle
+++ b/redwood-treehouse-lazylayout-compose/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.compose'
+apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"

--- a/redwood-treehouse-lazylayout-schema/build.gradle
+++ b/redwood-treehouse-lazylayout-schema/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 dependencies {
   api projects.redwoodSchema

--- a/redwood-treehouse-lazylayout-widget/build.gradle
+++ b/redwood-treehouse-lazylayout-widget/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.widget'
+apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
   apply from: "${rootDir}/addAllTargets.gradle"


### PR DESCRIPTION
@colinrtwhite I think we can [make these publishable again](https://github.com/cashapp/redwood/pull/559) after [Jake's change](https://github.com/cashapp/redwood/pull/631), since the module structure has changed