### PR TITLE
Fix first crash in Emoji Search on Android Views

### DIFF
--- a/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/ViewTextInput.kt
+++ b/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/ViewTextInput.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.EditText
 import android.widget.FrameLayout
 import androidx.core.widget.addTextChangedListener
 import app.cash.redwood.LayoutModifier
@@ -41,7 +42,7 @@ internal class ViewTextInput(
   private val textInputEditText = object : TextInputEditText(textInputLayout.context) {
     override fun onSelectionChanged(selStart: Int, selEnd: Int) {
       super.onSelectionChanged(selStart, selEnd)
-      stateChanged()
+      stateChanged(this)
     }
   }
 
@@ -54,7 +55,7 @@ internal class ViewTextInput(
 
     textInputEditText.addTextChangedListener(
       onTextChanged = { _, _, _, _ ->
-        stateChanged()
+        stateChanged(textInputEditText)
       }
     )
     textInputEditText.maxLines = 2
@@ -92,11 +93,10 @@ internal class ViewTextInput(
    * new [TextFieldState.userEditCount]. That way we can ignore updates that are based on stale
    * data.
    */
-  private fun stateChanged() {
+  private fun stateChanged(editText: EditText) {
     // Ignore this update if it isn't a user edit.
     if (updating) return
 
-    val editText = textInputEditText
     val newState = state.userEdit(
       text = editText.text?.toString().orEmpty(),
       selectionStart = editText.selectionStart,


### PR DESCRIPTION
Partially reverts https://github.com/cashapp/redwood/pull/682.

There are actually two crashes back-to-back before this crash. The second crash that is hit is the same as the one that's hit on Emoji Search Android Compose (https://github.com/cashapp/redwood/pull/715#issuecomment-1380514574). This PR doesn't fix that second crash.

<details>
  <summary>Stacktrace</summary>

```
 E  FATAL EXCEPTION: main
    Process: com.example.redwood.emojisearch.android.views, PID: 28613
    java.lang.NullPointerException: Attempt to invoke virtual method 'android.text.Editable com.example.redwood.emojisearch.android.views.ViewTextInput$textInputEditText$1.getText()' on a null object reference
    	at com.example.redwood.emojisearch.android.views.ViewTextInput.stateChanged(ViewTextInput.kt:101)
    	at com.example.redwood.emojisearch.android.views.ViewTextInput.access$stateChanged(ViewTextInput.kt:32)
    	at com.example.redwood.emojisearch.android.views.ViewTextInput$textInputEditText$1.onSelectionChanged(ViewTextInput.kt:44)
    	at android.widget.TextView.spanChange(TextView.java:10963)
    	at android.widget.TextView$ChangeWatcher.onSpanAdded(TextView.java:13839)
    	at android.text.SpannableStringBuilder.sendSpanAdded(SpannableStringBuilder.java:1288)
    	at android.text.SpannableStringBuilder.setSpan(SpannableStringBuilder.java:778)
    	at android.text.SpannableStringBuilder.setSpan(SpannableStringBuilder.java:677)
    	at android.text.Selection.setSelection(Selection.java:96)
    	at android.text.Selection.setSelection(Selection.java:78)
    	at android.text.Selection.setSelection(Selection.java:153)
    	at android.text.method.ArrowKeyMovementMethod.initialize(ArrowKeyMovementMethod.java:312)
    	at android.widget.TextView.setText(TextView.java:6386)
    	at android.widget.TextView.setText(TextView.java:6227)
    	at android.widget.EditText.setText(EditText.java:121)
    	at android.widget.TextView.<init>(TextView.java:1694)
    	at android.widget.EditText.<init>(EditText.java:87)
    	at android.widget.EditText.<init>(EditText.java:83)
    	at androidx.appcompat.widget.AppCompatEditText.<init>(AppCompatEditText.java:100)
    	at com.google.android.material.textfield.TextInputEditText.<init>(TextInputEditText.java:64)
    	at com.google.android.material.textfield.TextInputEditText.<init>(TextInputEditText.java:59)
    	at com.google.android.material.textfield.TextInputEditText.<init>(TextInputEditText.java:55)
    	at com.example.redwood.emojisearch.android.views.ViewTextInput$textInputEditText$1.<init>(ViewTextInput.kt:41)
    	at com.example.redwood.emojisearch.android.views.ViewTextInput.<init>(ViewTextInput.kt:41)
    	at com.example.redwood.emojisearch.android.views.AndroidEmojiSearchWidgetFactory.TextInput(AndroidEmojiSearchWidgetFactory.kt:33)
    	at com.example.redwood.emojisearch.widget.EmojiSearchDiffConsumingNodeFactory.create-AxfZ-o8(EmojiSearchDiffConsumingNodeFactory.kt:24)
    	at app.cash.redwood.protocol.widget.ProtocolBridge.sendDiff(ProtocolBridge.kt:53)
    	at app.cash.redwood.treehouse.TreehouseApp$RealBinding$sendDiff$1.invokeSuspend(TreehouseApp.kt:278)
    	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    	at android.os.Handler.handleCallback(Handler.java:938)
    	at android.os.Handler.dispatchMessage(Handler.java:99)
    	at android.os.Looper.loopOnce(Looper.java:201)
    	at android.os.Looper.loop(Looper.java:288)
    	at android.app.ActivityThread.main(ActivityThread.java:7842)
    	at java.lang.reflect.Method.invoke(Native Method)
    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
    	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@40cbf86, Dispatchers.Main]
```

</details>