### PR TITLE
Use ktlint_standard_filename for ktlint 0.48.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ allprojects {
     kotlin {
       target("src/*/kotlin/**/*.kt")
       ktlint('0.48.1').editorConfigOverride([
-        'ktlint_filename': 'disabled',
+        'ktlint_standard_filename': 'disabled',
       ])
       licenseHeaderFile(rootProject.file('gradle/license-header.txt'))
     }


### PR DESCRIPTION
Follow up #734.

https://github.com/pinterest/ktlint/releases/tag/0.48.0
https://pinterest.github.io/ktlint/faq/#why-is-editorconfig-property-disabled_rules-deprecated-and-how-do-i-resolve-this