### PR TITLE
Make Widget IDs backed by an `Int`

### DIFF
--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
@@ -25,7 +25,7 @@ import app.cash.redwood.widget.Widget
 
 /** @suppress For generated code use only. */
 public class ProtocolState {
-  private var nextValue = Id.Root.value + 1L
+  private var nextValue = Id.Root.value + 1
   private val widgets = mutableMapOf<Id, ProtocolWidget>()
 
   private var childrenDiffs = mutableListOf<ChildrenDiff>()
@@ -34,7 +34,7 @@ public class ProtocolState {
 
   public fun nextId(): Id {
     val value = nextValue
-    nextValue = value + 1L
+    nextValue = value + 1
     return Id(value)
   }
 

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/values.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/values.kt
@@ -21,9 +21,9 @@ import kotlinx.serialization.Serializable
 /** Identifies a widget instance. */
 @JvmInline
 @Serializable
-public value class Id(public val value: Long) {
+public value class Id(public val value: Int) {
   public companion object {
-    public val Root: Id = Id(0L)
+    public val Root: Id = Id(0)
   }
 }
 


### PR DESCRIPTION
This is wildly more efficient in JS. I started looking at expect/actual-ing this storage type to be `Double` on JS and `Long` on other platforms but an `Int` means we can create 1000 widgets per second for 49 days straight without overflow. Seems fine.