### PR TITLE
Use platform-specific collections inside Compose protocol

### DIFF
--- a/redwood-protocol-compose/build.gradle
+++ b/redwood-protocol-compose/build.gradle
@@ -25,6 +25,18 @@ kotlin {
         implementation projects.testSchema.compose.protocol
       }
     }
+    nonJsMain {
+      dependsOn(commonMain)
+    }
+    androidMain {
+      dependsOn(nonJsMain)
+    }
+    jvmMain {
+      dependsOn(nonJsMain)
+    }
+    nativeMain {
+      dependsOn(nonJsMain)
+    }
   }
 }
 

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/PlatformList.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/PlatformList.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+internal expect class PlatformList<E>() {
+  fun add(element: E)
+}
+
+internal expect fun <E> PlatformList<E>.asList(): List<E>

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/PlatformMap.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/PlatformMap.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+internal expect class PlatformMap<K, V>() {
+  operator fun get(key: K): V?
+  operator fun set(key: K, value: V)
+  operator fun contains(key: K): Boolean
+  fun remove(key: K)
+}

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolState.kt
@@ -26,11 +26,11 @@ import app.cash.redwood.widget.Widget
 /** @suppress For generated code use only. */
 public class ProtocolState {
   private var nextValue = Id.Root.value + 1
-  private val widgets = mutableMapOf<Id, ProtocolWidget>()
+  private val widgets = PlatformMap<Int, ProtocolWidget>()
 
-  private var childrenDiffs = mutableListOf<ChildrenDiff>()
-  private var layoutModifiers = mutableListOf<LayoutModifiers>()
-  private var propertyDiffs = mutableListOf<PropertyDiff>()
+  private var childrenDiffs = PlatformList<ChildrenDiff>()
+  private var layoutModifiers = PlatformList<LayoutModifiers>()
+  private var propertyDiffs = PlatformList<PropertyDiff>()
   private var hasDiffs = false
 
   public fun nextId(): Id {
@@ -40,17 +40,17 @@ public class ProtocolState {
   }
 
   public fun append(childrenDiff: ChildrenDiff) {
-    childrenDiffs += childrenDiff
+    childrenDiffs.add(childrenDiff)
     hasDiffs = true
   }
 
   public fun append(layoutModifiers: LayoutModifiers) {
-    this.layoutModifiers += layoutModifiers
+    this.layoutModifiers.add(layoutModifiers)
     hasDiffs = true
   }
 
   public fun append(propertyDiff: PropertyDiff) {
-    propertyDiffs += propertyDiff
+    propertyDiffs.add(propertyDiff)
     hasDiffs = true
   }
 
@@ -63,29 +63,31 @@ public class ProtocolState {
     if (!hasDiffs) return null
 
     val diff = Diff(
-      childrenDiffs = childrenDiffs,
-      layoutModifiers = layoutModifiers,
-      propertyDiffs = propertyDiffs,
+      childrenDiffs = childrenDiffs.asList(),
+      layoutModifiers = layoutModifiers.asList(),
+      propertyDiffs = propertyDiffs.asList(),
     )
 
-    childrenDiffs = mutableListOf()
-    layoutModifiers = mutableListOf()
-    propertyDiffs = mutableListOf()
+    childrenDiffs = PlatformList()
+    layoutModifiers = PlatformList()
+    propertyDiffs = PlatformList()
 
     return diff
   }
 
   public fun addWidget(widget: ProtocolWidget) {
-    check(widgets.put(widget.id, widget) == null) {
-      "Attempted to add widget with ID ${widget.id.value} but one already exists"
+    val idValue = widget.id.value
+    check(idValue !in widgets) {
+      "Attempted to add widget with ID $idValue but one already exists"
     }
+    widgets[idValue] = widget
   }
 
   public fun removeWidget(id: Id) {
-    widgets.remove(id)
+    widgets.remove(id.value)
   }
 
-  public fun getWidget(id: Id): ProtocolWidget? = widgets[id]
+  public fun getWidget(id: Id): ProtocolWidget? = widgets[id.value]
 
   public fun widgetChildren(id: Id, tag: ChildrenTag): Widget.Children<Nothing> {
     return ProtocolWidgetChildren(id, tag, this)

--- a/redwood-protocol-compose/src/jsMain/kotlin/app/cash/redwood/protocol/compose/PlatformList.kt
+++ b/redwood-protocol-compose/src/jsMain/kotlin/app/cash/redwood/protocol/compose/PlatformList.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+@JsName("Array")
+internal external class JsArray<E> {
+  val length: Int
+
+  @JsName("push")
+  fun add(element: E)
+}
+
+internal actual typealias PlatformList<E> = JsArray<E>
+
+internal actual inline fun <E> PlatformList<E>.asList(): List<E> {
+  return JsArrayList(this)
+}
+
+internal class JsArrayList<E>(
+  private val storage: JsArray<E>,
+) : AbstractList<E>(), RandomAccess {
+  override val size: Int get() = storage.length
+
+  override fun get(index: Int): E {
+    return storage.asDynamic()[index].unsafeCast<E>()
+  }
+}

--- a/redwood-protocol-compose/src/jsMain/kotlin/app/cash/redwood/protocol/compose/PlatformMap.kt
+++ b/redwood-protocol-compose/src/jsMain/kotlin/app/cash/redwood/protocol/compose/PlatformMap.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+@JsName("Map")
+internal external class JsMap<K, V> {
+  operator fun get(key: K): V?
+  operator fun set(key: K, value: V)
+
+  @JsName("has")
+  operator fun contains(key: K): Boolean
+
+  @JsName("delete")
+  fun remove(key: K)
+}
+
+internal actual typealias PlatformMap<K, V> = JsMap<K, V>

--- a/redwood-protocol-compose/src/nonJsMain/kotlin/app/cash/redwood/protocol/compose/PlatformList.kt
+++ b/redwood-protocol-compose/src/nonJsMain/kotlin/app/cash/redwood/protocol/compose/PlatformList.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+@Suppress(
+  "ACTUAL_TYPE_ALIAS_NOT_TO_CLASS", // ArrayList itself aliases to j.u.ArrayList on JVM.
+  "ACTUAL_WITHOUT_EXPECT", // https://youtrack.jetbrains.com/issue/KT-37316
+)
+internal actual typealias PlatformList<E> = ArrayList<E>
+
+@Suppress(
+  "NOTHING_TO_INLINE", // Explicitly trying to be zero-overhead.
+  "KotlinRedundantDiagnosticSuppress", // Inline warning only happens on JVM source set.
+)
+internal actual inline fun <E> PlatformList<E>.asList(): List<E> {
+  return this
+}

--- a/redwood-protocol-compose/src/nonJsMain/kotlin/app/cash/redwood/protocol/compose/PlatformMap.kt
+++ b/redwood-protocol-compose/src/nonJsMain/kotlin/app/cash/redwood/protocol/compose/PlatformMap.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.compose
+
+@Suppress(
+  "ACTUAL_TYPE_ALIAS_NOT_TO_CLASS", // LinkedHashMap itself aliases to j.u.LinkedHashMap on JVM.
+  "ACTUAL_WITHOUT_EXPECT", // https://youtrack.jetbrains.com/issue/KT-37316
+)
+internal actual typealias PlatformMap<K, V> = LinkedHashMap<K, V>


### PR DESCRIPTION
These collections are implementation details and are used at some of the lowest layers of the app. They should be as efficient as possible.

Before JS:
```js
function ProtocolState() {
  this.a3h_1 = _Id___get_value__impl__b6l2oq(Companion_getInstance().r3d_1) + 1 | 0;
  this.b3h_1 = LinkedHashMap_init_$Create$();
  this.c3h_1 = ArrayList_init_$Create$();
  this.d3h_1 = ArrayList_init_$Create$();
  this.e3h_1 = ArrayList_init_$Create$();
  this.f3h_1 = false;
  this.g3h_1 = 8;
}

ProtocolState.prototype.i3h = function (childrenDiff) {
  this.c3h_1.a(childrenDiff);
  this.f3h_1 = true;
};

ProtocolState.prototype.u3g = function () {
  if (!this.f3h_1)
    return null;
  var diff = new Diff(this.c3h_1, this.d3h_1, this.e3h_1);
  this.c3h_1 = ArrayList_init_$Create$();
  this.d3h_1 = ArrayList_init_$Create$();
  this.e3h_1 = ArrayList_init_$Create$();
  return diff;
};

ProtocolState.prototype.o3h = function (id) {
  return this.b3h_1.t2(new Id(id));
};
```

After JS:
```js
function ProtocolState() {
  this.a3h_1 = _Id___get_value__impl__b6l2oq(Companion_getInstance().r3d_1) + 1 | 0;
  this.b3h_1 = new Map();
  this.c3h_1 = new Array();
  this.d3h_1 = new Array();
  this.e3h_1 = new Array();
  this.f3h_1 = false;
  this.g3h_1 = 8;
}

ProtocolState.prototype.i3h = function (childrenDiff) {
  this.c3h_1.push(childrenDiff);
  this.f3h_1 = true;
};

ProtocolState.prototype.u3g = function () {
  if (!this.f3h_1)
    return null;
  var tmp = new JsArrayList(this.c3h_1);
  var tmp_0 = new JsArrayList(this.d3h_1);
  var tmp$ret$2 = new JsArrayList(this.e3h_1);
  var diff = new Diff(tmp, tmp_0, tmp$ret$2);
  this.c3h_1 = new Array();
  this.d3h_1 = new Array();
  this.e3h_1 = new Array();
  return diff;
};

ProtocolState.prototype.o3h = function (id) {
  return this.b3h_1.get(_Id___get_value__impl__b6l2oq(id));
};
```

In terms of code size it's a lateral move at best, but by using the raw underlying collections we are not subject to layers of wrappers and indirection for emulating the JVM collection semantics that Kotlin's collection have unfortunately inherited. Additionally, we explicitly unbox `Id` before it goes into our map to avoid an actual boxing operation that is not needed in JS. On the JVM the Int will still box, but that's fine since it always boxed `Id` before. When Babel ultimately runs over this code functions like `_Id___get_value__impl__b6l2oq` will disappear completely as it is an identity function.