### PR TITLE
Allow duplicate widgets across dependencies

### DIFF
--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
@@ -162,7 +162,7 @@ public fun parseProtocolSchema(schemaType: KClass<*>, tag: Int = 0): ProtocolSch
       schema
     }
 
-  val schema = ParsedProtocolSchema(
+  return ParsedProtocolSchema(
     schemaType.simpleName!!,
     schemaType.java.packageName,
     scopes.toList(),
@@ -170,25 +170,6 @@ public fun parseProtocolSchema(schemaType: KClass<*>, tag: Int = 0): ProtocolSch
     layoutModifiers,
     dependencies,
   )
-
-  val duplicatedWidgets = (listOf(schema) + dependencies)
-    .flatMap { it.widgets.map { widget -> widget to it } }
-    .groupBy { it.first.type }
-    .filterValues { it.size > 1 }
-    .mapValues { it.value.map(Pair<*, Schema>::second) }
-  if (duplicatedWidgets.isNotEmpty()) {
-    throw IllegalArgumentException(
-      buildString {
-        appendLine("Schema dependency tree contains duplicated widgets")
-        for ((widget, schemas) in duplicatedWidgets) {
-          append("\n- ${widget.qualifiedName}: ")
-          schemas.joinTo(this) { "${it.`package`}.${it.name}" }
-        }
-      },
-    )
-  }
-
-  return schema
 }
 
 private fun parseWidget(

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -719,58 +719,6 @@ class SchemaParserTest {
   }
 
   @Schema(
-    members = [],
-    dependencies = [
-      Dependency(1, SchemaWidgetDuplicateAcrossDependenciesA::class),
-      Dependency(2, SchemaWidgetDuplicateAcrossDependenciesB::class),
-    ],
-  )
-  object SchemaWidgetDuplicateAcrossDependencies
-
-  @Widget(1)
-  object WidgetDuplicateAcrossDependencies
-
-  @Schema([WidgetDuplicateAcrossDependencies::class])
-  object SchemaWidgetDuplicateAcrossDependenciesA
-
-  @Schema([WidgetDuplicateAcrossDependencies::class])
-  object SchemaWidgetDuplicateAcrossDependenciesB
-
-  @Test fun schemaWidgetDuplicateAcrossDependenciesThrows() {
-    assertThrows<IllegalArgumentException> {
-      parseProtocolSchema(SchemaWidgetDuplicateAcrossDependencies::class)
-    }.hasMessageThat().isEqualTo(
-      """
-      |Schema dependency tree contains duplicated widgets
-      |
-      |- app.cash.redwood.tooling.schema.SchemaParserTest.WidgetDuplicateAcrossDependencies: app.cash.redwood.tooling.schema.SchemaWidgetDuplicateAcrossDependenciesA, app.cash.redwood.tooling.schema.SchemaWidgetDuplicateAcrossDependenciesB
-      """.trimMargin(),
-    )
-  }
-
-  @Schema(
-    members = [
-      WidgetDuplicateAcrossDependencies::class,
-    ],
-    dependencies = [
-      Dependency(1, SchemaWidgetDuplicateAcrossDependenciesA::class),
-    ],
-  )
-  object SchemaWidgetDuplicateInDependency
-
-  @Test fun schemaWidgetDuplicateInDependencyThrows() {
-    assertThrows<IllegalArgumentException> {
-      parseProtocolSchema(SchemaWidgetDuplicateInDependency::class)
-    }.hasMessageThat().isEqualTo(
-      """
-      |Schema dependency tree contains duplicated widgets
-      |
-      |- app.cash.redwood.tooling.schema.SchemaParserTest.WidgetDuplicateAcrossDependencies: app.cash.redwood.tooling.schema.SchemaWidgetDuplicateInDependency, app.cash.redwood.tooling.schema.SchemaWidgetDuplicateAcrossDependenciesA
-      """.trimMargin(),
-    )
-  }
-
-  @Schema(
     members = [
       UnscopedLayoutModifier::class,
     ],


### PR DESCRIPTION
This is weird, but there isn't any technical reason to prevent this. In the future we won't be able to prevent it, so drop it now.