### PR TITLE
Do not add a blank line between copyright and package

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,7 +1,7 @@
 <component name="CopyrightManager">
   <settings default="Square">
-    <module2copyright>
-      <element module="Project Files" copyright="Square" />
-    </module2copyright>
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="addBlankAfter" value="false" />
+    </LanguageOptions>
   </settings>
 </component>


### PR DESCRIPTION
This was not an option back when we set this up. It is now.