### PR TITLE
Unwrap URL in emoji-search README

### DIFF
--- a/samples/emoji-search/README.md
+++ b/samples/emoji-search/README.md
@@ -28,7 +28,7 @@ Run this:
 ./gradlew :samples:emoji-search:presenter-treehouse:serveDevelopmentZipline --info --continuous
 ```
 
-This will compile Kotlin/JS and serve it at [[http://localhost:8080/presenter-treehouse.js]]. The server will
+This will compile Kotlin/JS and serve it at http://localhost:8080/presenter-treehouse.js. The server will
 run until you CTRL+C the process.
 
 


### PR DESCRIPTION
Applying the same change that @JakeWharton made to the other URLs in the READMEs. GitHub's text parser is smart enough not to link-ify the period that follows the URL.