### PR TITLE
Split impls from serialization code

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/diffConsumingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/diffConsumingGeneration.kt
@@ -337,17 +337,21 @@ internal fun generateDiffConsumingWidget(
     .build()
 }
 
-internal fun generateDiffConsumingLayoutModifiers(
+internal fun generateDiffConsumingLayoutModifierSerialization(
+  schema: ProtocolSchema,
+): FileSpec {
+  return FileSpec.builder(schema.widgetPackage(), "layoutModifierSerialization")
+    .addFunction(generateJsonArrayToLayoutModifier(schema))
+    .addFunction(generateJsonElementToLayoutModifier(schema))
+    .build()
+}
+
+internal fun generateDiffConsumingLayoutModifierImpls(
   schema: ProtocolSchema,
   host: ProtocolSchema = schema,
 ): FileSpec {
-  return FileSpec.builder(schema.widgetPackage(host), "layoutModifierSerialization")
+  return FileSpec.builder(schema.widgetPackage(host), "layoutModifierImpls")
     .apply {
-      if (schema === host) {
-        addFunction(generateJsonArrayToLayoutModifier(schema))
-        addFunction(generateJsonElementToLayoutModifier(schema))
-      }
-
       for (layoutModifier in schema.layoutModifiers) {
         val typeName = ClassName(schema.widgetPackage(host), layoutModifier.type.flatName + "Impl")
         val typeBuilder = if (layoutModifier.properties.isEmpty()) {
@@ -381,7 +385,7 @@ internal fun generateDiffConsumingLayoutModifiers(
         }
         addType(
           typeBuilder
-            .addModifiers(if (schema === host) PRIVATE else INTERNAL)
+            .addModifiers(INTERNAL)
             .addSuperinterface(schema.layoutModifierType(layoutModifier))
             .addFunction(layoutModifierEquals(schema, layoutModifier))
             .addFunction(layoutModifierHashCode(layoutModifier))

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
@@ -51,8 +51,9 @@ public fun ProtocolSchema.generate(type: ProtocolCodegenType, destination: Path)
     }
     Widget -> {
       generateDiffConsumingNodeFactory(this).writeTo(destination)
+      generateDiffConsumingLayoutModifierSerialization(this).writeTo(destination)
       for (dependency in allSchemas) {
-        generateDiffConsumingLayoutModifiers(dependency, host = this).writeTo(destination)
+        generateDiffConsumingLayoutModifierImpls(dependency, host = this).writeTo(destination)
         for (widget in dependency.widgets) {
           generateDiffConsumingWidget(dependency, widget, host = this).writeTo(destination)
         }

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/DiffConsumingGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/DiffConsumingGenerationTest.kt
@@ -59,7 +59,7 @@ class DiffConsumingGenerationTest {
   @Test fun `dependency layout modifiers are included in serialization`() {
     val schema = parseProtocolSchema(PrimarySchema::class)
 
-    val fileSpec = generateDiffConsumingLayoutModifiers(schema)
+    val fileSpec = generateDiffConsumingLayoutModifierSerialization(schema)
     assertThat(fileSpec.toString()).apply {
       contains("1 -> PrimaryModifierImpl.serializer()")
       contains("1000001 -> SecondaryModifierImpl.serializer()")


### PR DESCRIPTION
This is a no-op change in behavior but will simplify a forthcoming change to the schema model object.