### PR TITLE
Inject the whole coordinate triple into Gradle plugins

### DIFF
--- a/build-support/build.gradle
+++ b/build-support/build.gradle
@@ -43,5 +43,7 @@ buildConfig {
   }
 
   packageName('app.cash.redwood.buildsupport')
-  buildConfigField("String", "jbComposeCompiler", "\"${libs.versions.jbComposeCompiler.get()}\"")
+  buildConfigField("String", "composeCompilerGroupId", "\"${libs.jetbrains.compose.compiler.get().module.group}\"")
+  buildConfigField("String", "composeCompilerArtifactId", "\"${libs.jetbrains.compose.compiler.get().module.name}\"")
+  buildConfigField("String", "composeCompilerVersion", "\"${libs.jetbrains.compose.compiler.get().version}\"")
 }

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ComposePlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ComposePlugin.kt
@@ -34,9 +34,9 @@ class ComposePlugin : KotlinCompilerPluginSupportPlugin {
   override fun getCompilerPluginId() = "app.cash.redwood.tools.compose"
 
   override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
-    "org.jetbrains.compose.compiler",
-    "compiler",
-    jbComposeCompiler,
+    composeCompilerGroupId,
+    composeCompilerArtifactId,
+    composeCompilerVersion,
   )
 
   override fun applyToCompilation(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ kotlinx-serialization = "1.4.1"
 androidxComposeCompiler = "1.4.0"
 androidx-activity = "1.3.1"
 jbCompose = "1.3.0"
-jbComposeCompiler = "1.4.0"
 lint = "30.4.1"
 zipline = "0.9.16"
 coil = "2.2.2"
@@ -42,6 +41,7 @@ androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 
 google-material = { module = "com.google.android.material:material", version = "1.8.0" }
 
+jetbrains-compose-compiler = "org.jetbrains.compose.compiler:compiler:1.4.0"
 jetbrains-compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "jbCompose" }
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "jbCompose" }
 jetbrains-compose-material = { module = "org.jetbrains.compose.material:material", version.ref = "jbCompose" }

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -107,6 +107,8 @@ buildConfig {
   }
 
   packageName('app.cash.redwood.gradle')
-  buildConfigField("String", "jbComposeCompiler", "\"${libs.versions.jbComposeCompiler.get()}\"")
+  buildConfigField("String", "composeCompilerGroupId", "\"${libs.jetbrains.compose.compiler.get().module.group}\"")
+  buildConfigField("String", "composeCompilerArtifactId", "\"${libs.jetbrains.compose.compiler.get().module.name}\"")
+  buildConfigField("String", "composeCompilerVersion", "\"${libs.jetbrains.compose.compiler.get().version}\"")
   buildConfigField("String", "redwoodVersion", "\"${project.version}\"")
 }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodPlugin.kt
@@ -41,9 +41,9 @@ public class RedwoodPlugin : KotlinCompilerPluginSupportPlugin {
   override fun getCompilerPluginId(): String = "app.cash.redwood"
 
   override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
-    "org.jetbrains.compose.compiler",
-    "compiler",
-    jbComposeCompiler,
+    composeCompilerGroupId,
+    composeCompilerArtifactId,
+    composeCompilerVersion,
   )
 
   override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {


### PR DESCRIPTION
This will allow Renovate to update the version as well as make it easier to change back to AndroidX in the future.