### PR TITLE
Use a singleton lambda to set layout modifiers

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
@@ -50,7 +50,7 @@ fun Row(
   _RedwoodComposeNode<SunspotWidgetFactoryProvider<*>, Row<*>>(
     factory = { it.RedwoodLayout.Row() },
     update = {
-      set(layoutModifier) { layoutModifiers = it }
+      set(layoutModifier, Widget.SetLayoutModifiers)
       set(padding, Row<*>::padding)
       set(overflow, Row<*>::overflow)
     },
@@ -121,7 +121,7 @@ internal fun generateComposable(
           }
 
           val updateLambda = CodeBlock.builder()
-            .add("set(layoutModifier) { layoutModifiers = it }\n")
+            .add("set(layoutModifier, %T.SetLayoutModifiers)\n", RedwoodWidget.Widget)
 
           val childrenLambda = CodeBlock.builder()
           for (trait in widget.traits) {

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.widget
 
 import app.cash.redwood.LayoutModifier
+import app.cash.redwood.RedwoodCodegenApi
 
 public interface Widget<W : Any> {
   /**
@@ -28,6 +29,12 @@ public interface Widget<W : Any> {
    * A collection of elements that change how a widget is laid out.
    */
   public var layoutModifiers: LayoutModifier
+
+  public companion object {
+    /** @suppress Optimization for generated code to avoid generating/allocating many lambdas. */
+    @RedwoodCodegenApi
+    public val SetLayoutModifiers: Widget<*>.(LayoutModifier) -> Unit = { layoutModifiers = it }
+  }
 
   /** Marker interface for types whose properties expose factories of [Widget]s. */
   @Suppress("unused") // This type parameter used to match against other types like Children.


### PR DESCRIPTION
This avoids needing to create and allocate a lambda for every widget.

Before Kotlin:

```kotlin
RedwoodComposeNode<ExampleSchemaWidgetFactoryProvider<*>, Button<*>>(
  factory = { it.ExampleSchema.Button() },
  update = {
    set(layoutModifier) { layoutModifiers = it }
```

After Kotlin:

```kotlin
RedwoodComposeNode<ExampleSchemaWidgetFactoryProvider<*>, Button<*>>(
  factory = { it.ExampleSchema.Button() },
  update = {
    set(layoutModifier, Widget.SetLayoutModifiers)
```

Before JS:

```js
function Button$composable$lambda_0($this$set, it) {
  $this$set.p39(it);
  return Unit_getInstance();
}
// and for Text, TextInput, etc.

var tmp_1 = layoutModifier_0._v;
Updater__set_impl_v7kwss(tmp2__anonymous__z9zvc9, tmp_1, Button$composable$lambda_0);
```

After JS:

```js
function Widget$Companion$SetLayoutModifiers$lambda($this$null, it) {
  $this$null.x37(it);
  return Unit_getInstance();
}

Updater__set_impl_v7kwss(tmp2__anonymous__z9zvc9, layoutModifier_0._v, Companion_getInstance_0().y37_1);
```