### PR TITLE
Expose treehouseLazyLayoutSerializersModule publicly for inclusion

### DIFF
--- a/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/properties.kt
+++ b/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/properties.kt
@@ -17,8 +17,11 @@ package app.cash.redwood.treehouse.lazylayout.api
 
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.zipline.ZiplineService
+import app.cash.zipline.ziplineServiceSerializer
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 
 @Serializable
 public class LazyListIntervalContent(
@@ -29,4 +32,8 @@ public class LazyListIntervalContent(
   public interface Item : ZiplineService {
     public fun get(index: Int): ZiplineTreehouseUi
   }
+}
+
+public val treehouseLazyLayoutSerializersModule: SerializersModule = SerializersModule {
+  contextual(ziplineServiceSerializer<LazyListIntervalContent.Item>())
 }

--- a/samples/emoji-search/presenter-treehouse/src/commonMain/kotlin/com/example/redwood/emojisearch/treehouse/serializers.kt
+++ b/samples/emoji-search/presenter-treehouse/src/commonMain/kotlin/com/example/redwood/emojisearch/treehouse/serializers.kt
@@ -15,11 +15,9 @@
  */
 package com.example.redwood.emojisearch.treehouse
 
-import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
-import app.cash.zipline.ziplineServiceSerializer
+import app.cash.redwood.treehouse.lazylayout.api.treehouseLazyLayoutSerializersModule
 import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.contextual
 
 val treehouseSerializersModule = SerializersModule {
-  contextual(ziplineServiceSerializer<LazyListIntervalContent.Item>())
+  include(treehouseLazyLayoutSerializersModule)
 }


### PR DESCRIPTION
Consumers of lazy layout should be shielded from the serialization internals as much as possible.