### PR TITLE
Add placeholder support when targeting Android View host code

### DIFF
--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.StateFlow
 public class TreehouseWidgetView<A : AppService>(
   context: Context,
   override val widgetSystem: TreehouseView.WidgetSystem<A>,
+  override val codeListener: CodeListener = CodeListener(),
 ) : FrameLayout(context), TreehouseView<A> {
   @Deprecated(
     message = "TreehouseView no longer owns a TreehouseApp. Instead, call app.renderTo(view).",
@@ -48,7 +49,6 @@ public class TreehouseWidgetView<A : AppService>(
     widgetSystem: TreehouseView.WidgetSystem<A>,
   ) : this(context, widgetSystem)
 
-  public override var codeListener: CodeListener = CodeListener()
   public override var stateChangeListener: OnStateChangeListener<A>? = null
     set(value) {
       check(value != null) { "Views cannot be unbound from a listener at this time" }

--- a/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/properties.kt
+++ b/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/properties.kt
@@ -26,8 +26,13 @@ import kotlinx.serialization.modules.contextual
 @Serializable
 public class LazyListIntervalContent(
   @Contextual public val count: Int,
+  @Contextual public val placeholderProvider: Placeholder,
   @Contextual public val itemProvider: Item,
 ) {
+
+  public interface Placeholder : ZiplineService {
+    public fun get(): ZiplineTreehouseUi
+  }
 
   public interface Item : ZiplineService {
     public fun get(index: Int): ZiplineTreehouseUi
@@ -35,5 +40,6 @@ public class LazyListIntervalContent(
 }
 
 public val treehouseLazyLayoutSerializersModule: SerializersModule = SerializersModule {
+  contextual(ziplineServiceSerializer<LazyListIntervalContent.Placeholder>())
   contextual(ziplineServiceSerializer<LazyListIntervalContent.Item>())
 }

--- a/redwood-treehouse-lazylayout-paging/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/paging/LazyPagingItems.kt
+++ b/redwood-treehouse-lazylayout-paging/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/paging/LazyPagingItems.kt
@@ -31,10 +31,12 @@ import app.cash.redwood.treehouse.lazylayout.compose.LazyListScope
  */
 public fun <T : Any> LazyListScope.items(
   items: LazyPagingItems<T>,
+  placeholderContent: @Composable () -> Unit,
   itemContent: @Composable (value: T?) -> Unit,
 ) {
   items(
     count = items.itemCount,
+    placeholderContent = placeholderContent,
   ) { index ->
     itemContent(items[index])
   }
@@ -53,10 +55,12 @@ public fun <T : Any> LazyListScope.items(
  */
 public fun <T : Any> LazyListScope.itemsIndexed(
   items: LazyPagingItems<T>,
+  placeholderContent: @Composable () -> Unit,
   itemContent: @Composable (index: Int, value: T?) -> Unit,
 ) {
   items(
     count = items.itemCount,
+    placeholderContent = placeholderContent,
   ) { index ->
     itemContent(index, items[index])
   }

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -78,6 +78,7 @@ private object TruncatingColumnProvider : ColumnProvider {
   @Composable
   override fun <T> create(
     items: List<T>,
+    placeholderContent: @Composable () -> Unit,
     itemContent: @Composable (item: T) -> Unit,
   ) {
     Column {

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -56,6 +56,7 @@ interface ColumnProvider {
   @Composable
   fun <T> create(
     items: List<T>,
+    placeholderContent: @Composable () -> Unit,
     itemContent: @Composable (item: T) -> Unit,
   )
 }
@@ -102,7 +103,25 @@ fun EmojiSearch(
       hint = "Search",
       onChange = { searchTerm = it },
     )
-    columnProvider.create(filteredEmojis) { image ->
+    columnProvider.create(
+      filteredEmojis,
+      placeholderContent = {
+        val image = EmojiImage(
+          label = "loading…",
+          url = "https://github.githubassets.com/images/icons/emoji/unicode/231a.png?v8",
+        )
+        Row(
+          width = Constraint.Fill,
+          verticalAlignment = CrossAxisAlignment.Center,
+        ) {
+          Image(
+            url = image.url,
+            layoutModifier = LayoutModifier.padding(Padding(8)),
+          )
+          Text(text = image.label)
+        }
+      },
+    ) { image ->
       Row(
         width = Constraint.Fill,
         verticalAlignment = CrossAxisAlignment.Center,

--- a/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
+++ b/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
@@ -39,10 +39,11 @@ private class LazyColumnProvider(
   @Composable
   override fun <T> create(
     items: List<T>,
+    placeholderContent: @Composable () -> Unit,
     itemContent: @Composable (item: T) -> Unit,
   ) = with(bridge) {
     LazyColumn {
-      items(items, itemContent)
+      items(items, placeholderContent, itemContent)
     }
   }
 }


### PR DESCRIPTION
A lot of the logic here is just showing the placeholder when the item is loading. However, as the placeholder has to be retrieved asynchronously too, we need a placeholder (`blankView`) for the placeholder.

As the default `RecyclerView` item container has zero-height, `RecyclerView` attempts to load _all_ the available elements, including those that should be off screen (as an infinite number of zero-height items can fit in any `RecyclerView`). To avoid this, we add a `blankView` instead, which is an arbitrarily large, empty `FrameLayout`.

The `blankView` is swapped out with the placeholder once it's ready (i.e., the `onCodeLoaded` callback is invoked). The placeholder is then cached within the `ViewHolder`, so on re-use of the `ViewHolder`, the placeholder can be immediately retrieved and the `blankView` step can be skipped completely.

This will most likely need to be refactored if we want to go down [this route](https://github.com/cashapp/redwood/pull/772#discussion_r1091804731).