### PR TITLE
Don't hardcode item height in LazyColumn

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ robolectric = { module = "org.robolectric:robolectric", version = "4.9.2" }
 okio = { module = "com.squareup.okio:okio", version = "3.3.0" }
 okHttp = { module = "com.squareup.okhttp3:okhttp", version = "4.10.0" }
 paging-compose-common = { module = "app.cash.paging:paging-compose-common", version = "3.2.0-alpha04-0.2.0" }
+androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version = "3.2.0-alpha04" }
 zipline = { module = "app.cash.zipline:zipline", version.ref = "zipline" }
 zipline-gradlePlugin = { module = "app.cash.zipline:zipline-gradle-plugin", version.ref = "zipline" }
 zipline-loader = { module = "app.cash.zipline:zipline-loader", version.ref = "zipline" }

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.flow.StateFlow
 public class TreehouseWidgetView(
   context: Context,
   override val widgetSystem: WidgetSystem,
-  private val alwaysReadyForContent: Boolean = false,
 ) : FrameLayout(context), TreehouseView {
   override var readyForContentChangeListener: ReadyForContentChangeListener? = null
     set(value) {
@@ -47,7 +46,6 @@ public class TreehouseWidgetView(
    * [onAttachedToWindow] returns and true until [onDetachedFromWindow] returns.
    */
   override var readyForContent: Boolean = false
-    get() = alwaysReadyForContent || field
     private set
 
   private val _children = ViewGroupChildren(this)

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.StateFlow
 public class TreehouseWidgetView(
   context: Context,
   override val widgetSystem: WidgetSystem,
+  private val alwaysReadyForContent: Boolean = false,
 ) : FrameLayout(context), TreehouseView {
   override var readyForContentChangeListener: ReadyForContentChangeListener? = null
     set(value) {
@@ -46,6 +47,7 @@ public class TreehouseWidgetView(
    * [onAttachedToWindow] returns and true until [onDetachedFromWindow] returns.
    */
   override var readyForContent: Boolean = false
+    get() = alwaysReadyForContent || field
     private set
 
   private val _children = ViewGroupChildren(this)

--- a/redwood-treehouse-lazylayout-view/build.gradle
+++ b/redwood-treehouse-lazylayout-view/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   api projects.redwoodTreehouseHost
   api projects.redwoodTreehouseLazylayoutWidget
   implementation libs.androidx.core
+  implementation libs.androidx.paging.runtime
   implementation libs.androidx.recyclerview
 }
 

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -118,7 +118,7 @@ internal class ViewLazyColumn<A : AppService>(
             interval.value.itemProvider.get(interval.index)
           }
           treehouseApp.createContent(itemContentSource).apply {
-            // TODO Pass in actual HostConfiguration
+            // TODO Create a public API that accepts an Android Context and returns the corresponding HostConfiguration
             preload(HostConfiguration(darkMode = true))
             awaitContent()
           }
@@ -131,8 +131,7 @@ internal class ViewLazyColumn<A : AppService>(
       return if (invalid) LoadResult.Invalid() else loadResult
     }
 
-    override fun getRefreshKey(state: PagingState<Int, Content>) =
-      state.anchorPosition?.let { maxOf(0, it - (state.config.initialLoadSize / 2)) }
+    override fun getRefreshKey(state: PagingState<Int, Content>) = state.anchorPosition
   }
 
   private class LazyContentItemListAdapter(

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -40,6 +40,7 @@ import app.cash.redwood.treehouse.TreehouseWidgetView
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -60,6 +61,16 @@ internal class ViewLazyColumn<A : AppService>(
       layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
     }
     value.adapter = adapter
+    value.addOnAttachStateChangeListener(
+      object : View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(view: View) {}
+
+        override fun onViewDetachedFromWindow(view: View) {
+          view.removeOnAttachStateChangeListener(this)
+          scope.cancel()
+        }
+      },
+    )
   }
 
   override fun intervals(intervals: List<LazyListIntervalContent>) {

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -146,11 +146,14 @@ internal class ViewLazyColumn<A : AppService>(
       },
     )
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-      getItem(position)!!.apply {
-        unbind()
-        bind(holder.treehouseWidgetView)
+    override fun onViewRecycled(holder: ViewHolder) {
+      if (holder.bindingAdapterPosition != RecyclerView.NO_POSITION) {
+        getItem(holder.bindingAdapterPosition)!!.unbind()
       }
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+      getItem(position)!!.bind(holder.treehouseWidgetView)
     }
   }
 


### PR DESCRIPTION
A third-alternative to not hardcoding the item height in `LazyColumn`. Interestingly, this doesn't have to resort to (a) [cloning views](https://github.com/cashapp/redwood/pull/772), or (b) having a [meta placeholder item](https://github.com/cashapp/redwood/pull/853). Weirdly, this doesn't even add support for placeholders, yet still gets around hardcoding the item height, as we're getting the items ready for the `RecyclerView` _before_ the `RecyclerView` is made aware of them.