### PR TITLE
New Content interface and implementation

### DIFF
--- a/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.DisposableEffectResult
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -62,8 +61,8 @@ public fun <A : AppService> TreehouseContent(
   }
   DisposableEffect(treehouseView, contentSource) {
     val closeable = contentSource.bindWhenReady(treehouseView, treehouseApp)
-    return@DisposableEffect object : DisposableEffectResult {
-      override fun dispose() = closeable.close()
+    onDispose {
+      closeable.close()
     }
   }
 

--- a/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -18,6 +18,8 @@ package app.cash.redwood.treehouse.composeui
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.DisposableEffectResult
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -27,7 +29,8 @@ import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseView.CodeListener
-import app.cash.redwood.treehouse.TreehouseView.OnStateChangeListener
+import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
+import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -43,26 +46,25 @@ public fun <A : AppService> TreehouseContent(
   )
 
   val rememberedCodeListener = rememberUpdatedState(codeListener)
-  val rememberedContent = rememberUpdatedState(contentSource)
   val treehouseView = remember(widgetSystem) {
     object : TreehouseView<A> {
       override val codeListener get() = rememberedCodeListener.value
-      override var stateChangeListener: OnStateChangeListener<A>? = null
-      override val boundContentSource: TreehouseContentSource<A> get() = rememberedContent.value
       override val children = ComposeWidgetChildren()
       override val hostConfiguration = MutableStateFlow(hostConfiguration)
       override val widgetSystem = widgetSystem
+      override val readyForContent = true
+      override var readyForContentChangeListener: ReadyForContentChangeListener<A>? = null
       override fun reset() = children.remove(0, children.widgets.size)
     }
   }
   LaunchedEffect(treehouseView, hostConfiguration) {
     treehouseView.hostConfiguration.value = hostConfiguration
   }
-  LaunchedEffect(treehouseApp, treehouseView) {
-    treehouseApp.renderTo(treehouseView)
-  }
-  LaunchedEffect(treehouseView, contentSource) {
-    treehouseView.stateChangeListener?.onStateChanged(treehouseView)
+  DisposableEffect(treehouseView, contentSource) {
+    val closeable = contentSource.bindWhenReady(treehouseView, treehouseApp)
+    return@DisposableEffect object : DisposableEffectResult {
+      override fun dispose() = closeable.close()
+    }
   }
 
   Box {

--- a/redwood-treehouse-host/src/androidInstrumentedTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
+++ b/redwood-treehouse-host/src/androidInstrumentedTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
@@ -54,9 +54,9 @@ class TreehouseWidgetViewTest {
     val activity = Robolectric.buildActivity(Activity::class.java).resume().visible().get()
     val parent = activity.findViewById<ViewGroup>(android.R.id.content)
     val layout = TreehouseWidgetView(context, throwingWidgetSystem)
-    val listener = CountingStateChangeListener()
+    val listener = CountingReadyForContentChangeListener()
 
-    layout.stateChangeListener = listener
+    layout.readyForContentChangeListener = listener
     assertEquals(0, listener.count)
 
     parent.addView(layout)
@@ -64,16 +64,6 @@ class TreehouseWidgetViewTest {
 
     parent.removeView(layout)
     assertEquals(2, listener.count)
-  }
-
-  @Test fun contentSendsStateChange() {
-    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
-    val listener = CountingStateChangeListener()
-    layout.stateChangeListener = listener
-    assertEquals(0, listener.count)
-
-    layout.setContentSource { throw UnsupportedOperationException() }
-    assertEquals(1, listener.count)
   }
 
   @Test fun resetClearsUntrackedChildren() {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/Content.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/Content.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+/**
+ * A UI built as an interactive widget tree, that may or may not be actively running, or bound to an
+ * on-screen display.
+ *
+ * This content may be bound and unbound multiple times. For example, if its target view is
+ * obscured, or removed it may be unbound, only to be rebound later to the same view or another
+ * view. Whether state of the content is retained between bind and unbind cycles is an
+ * implementation detail. In practice this will work similarly to refreshing a webpage: changes
+ * applied using the content are retained but widget state like scroll positions and selection
+ * bounds are lost.
+ *
+ * Calling [bind] may not immediately yield a ready widget tree; the content source may require
+ * work to prepare its UI such as downloading code or asynchronous calls to a worker thread.
+ *
+ * Content must be unbound after use.
+ */
+public interface Content<A : AppService> {
+  /**
+   * It is an error to bind multiple views simultaneously.
+   *
+   * This function may only be invoked on [TreehouseDispatchers.ui].
+   */
+  public fun bind(view: TreehouseView<A>)
+
+  /**
+   * Calling [unbind] without a bound view is safe.
+   *
+   * This function may only be invoked on [TreehouseDispatchers.ui].
+   */
+  public fun unbind()
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ContentBinding.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ContentBinding.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
+import okio.Closeable
+
+/**
+ * Binds this content to [view] whenever the view is
+ * [ready for content][TreehouseView.readyForContent]. The content will bind and unbind as this view
+ * is attached and detached from the UI.
+ *
+ * Returns a closeable that unbinds from the content and stops tracking the ready state.
+ */
+public fun <A : AppService> Content<A>.bindWhenReady(view: TreehouseView<A>): Closeable {
+  val listener = ReadyForContentChangeListener<A> {
+    if (view.readyForContent) {
+      bind(view)
+    } else {
+      unbind()
+    }
+  }
+
+  view.readyForContentChangeListener = listener
+  listener.onReadyForContentChanged(view)
+
+  return object : Closeable {
+    override fun close() {
+      unbind()
+      view.readyForContentChangeListener = null
+    }
+  }
+}
+
+public fun <A : AppService> TreehouseContentSource<A>.bindWhenReady(
+  view: TreehouseView<A>,
+  app: TreehouseApp<A>,
+): Closeable {
+  val content = app.createContent(this)
+  return content.bindWhenReady(view)
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseContent.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+internal class TreehouseContent<A : AppService>(
+  private val treehouseApp: TreehouseApp<A>,
+  private val source: TreehouseContentSource<A>,
+) : Content<A> {
+  private val dispatchers = treehouseApp.dispatchers
+
+  private var view: TreehouseView<A>? = null
+  private var binding: Binding? = null
+
+  override fun bind(view: TreehouseView<A>) {
+    treehouseApp.dispatchers.checkUi()
+
+    // Binding the bound view does nothing. This is necessary so that listeners don't need to
+    // independently track the bound/unbound state.
+    if (this.view == view) return
+
+    require(this.view == null)
+    this.view = view
+
+    treehouseApp.boundContents += this
+    receiveZiplineSession(treehouseApp.ziplineSession, false)
+  }
+
+  override fun unbind() {
+    treehouseApp.dispatchers.checkUi()
+
+    if (view == null) return // unbind() is idempotent.
+
+    treehouseApp.boundContents.remove(this)
+    binding?.cancel()
+    view = null
+    binding = null
+  }
+
+  /** This function may only be invoked on [TreehouseDispatchers.ui]. */
+  internal fun receiveZiplineSession(
+    ziplineSession: ZiplineSession<A>?,
+    codeChanged: Boolean,
+  ) {
+    dispatchers.checkUi()
+
+    // Make sure we're tracking this view, so we can update it when the code changes.
+    val view = this.view!!
+    val previous = binding
+    if (!codeChanged && previous is RealBinding<*>) {
+      return // Nothing has changed.
+    }
+
+    val next = when {
+      // We have content and code. Launch the treehouse UI.
+      ziplineSession != null -> {
+        RealBinding(
+          app = treehouseApp,
+          appScope = treehouseApp.appScope,
+          eventPublisher = treehouseApp.eventPublisher,
+          contentSource = source,
+          session = ziplineSession,
+          view = view,
+        ).apply {
+          start(ziplineSession, view)
+        }
+      }
+
+      // We have content but no code. Keep track of it for later.
+      else -> {
+        LoadingBinding.also {
+          if (previous == null) {
+            view.codeListener.onInitialCodeLoading()
+          }
+        }
+      }
+    }
+
+    // Replace the previous binding, if any.
+    binding = next
+
+    previous?.cancel()
+  }
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -22,22 +22,19 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 
 public interface TreehouseView<A : AppService> {
-  /** This is the actual content, or null if not attached to the screen. */
-  public val boundContentSource: TreehouseContentSource<A>?
   public val children: Widget.Children<*>
   public val hostConfiguration: StateFlow<HostConfiguration>
   public val widgetSystem: WidgetSystem<A>
   public val codeListener: CodeListener
-  public var stateChangeListener: OnStateChangeListener<A>?
+  public val readyForContent: Boolean
+  public var readyForContentChangeListener: ReadyForContentChangeListener<A>?
 
   /** Invoked when new code is loaded. This should at minimum clear all [children]. */
   public fun reset()
 
-  public fun interface OnStateChangeListener<A : AppService> {
-    /**
-     * Called when [TreehouseView.boundContentSource] has changed.
-     */
-    public fun onStateChanged(view: TreehouseView<A>)
+  public fun interface ReadyForContentChangeListener<A : AppService> {
+    /** Called when [TreehouseView.readyForContent] has changed. */
+    public fun onReadyForContentChanged(view: TreehouseView<A>)
   }
 
   public fun interface WidgetSystem<A : AppService> {

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CountingReadyForContentChangeListener.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CountingReadyForContentChangeListener.kt
@@ -15,10 +15,12 @@
  */
 package app.cash.redwood.treehouse
 
-class CountingStateChangeListener : TreehouseView.OnStateChangeListener<Nothing> {
+import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
+
+class CountingReadyForContentChangeListener : ReadyForContentChangeListener<Nothing> {
   var count = 0
 
-  override fun onStateChanged(view: TreehouseView<Nothing>) {
+  override fun onReadyForContentChanged(view: TreehouseView<Nothing>) {
     count++
   }
 }

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -16,7 +16,7 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.treehouse.TreehouseView.CodeListener
-import app.cash.redwood.treehouse.TreehouseView.OnStateChangeListener
+import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
 import app.cash.redwood.widget.UIViewChildren
 import app.cash.redwood.widget.Widget
 import kotlin.DeprecationLevel.ERROR
@@ -46,22 +46,15 @@ public class TreehouseUIKitView<A : AppService>(
 
   public val view: UIView = RootUiView(this)
   public override var codeListener: CodeListener = CodeListener()
-  public override var stateChangeListener: OnStateChangeListener<A>? = null
+
+  override var readyForContentChangeListener: ReadyForContentChangeListener<A>? = null
     set(value) {
-      check(value != null) { "Views cannot be unbound from a listener at this time" }
-      check(field == null) { "View already bound to a listener" }
+      check(value == null || field == null) { "View already bound to a listener" }
       field = value
     }
 
-  private var contentSource: TreehouseContentSource<A>? = null
-
-  override val boundContentSource: TreehouseContentSource<A>?
-    get() {
-      return when {
-        view.superview != null -> contentSource
-        else -> null
-      }
-    }
+  override val readyForContent: Boolean
+    get() = view.superview != null
 
   private val _children = UIViewChildren(view)
   override val children: Widget.Children<UIView> get() = _children
@@ -80,13 +73,8 @@ public class TreehouseUIKitView<A : AppService>(
     (view.subviews as List<UIView>).forEach(UIView::removeFromSuperview)
   }
 
-  public fun setContent(contentSource: TreehouseContentSource<A>) {
-    this.contentSource = contentSource
-    stateChangeListener?.onStateChanged(this)
-  }
-
   internal fun superviewChanged() {
-    stateChangeListener?.onStateChanged(this)
+    readyForContentChangeListener?.onReadyForContentChanged(this)
   }
 
   internal fun updateHostConfiguration() {

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
@@ -50,9 +50,9 @@ class TreehouseUIKitViewTest {
   @Test fun attachAndDetachSendsStateChange() {
     val parent = UIView()
     val layout = TreehouseUIKitView(throwingWidgetSystem)
-    val listener = CountingStateChangeListener()
+    val listener = CountingReadyForContentChangeListener()
 
-    layout.stateChangeListener = listener
+    layout.readyForContentChangeListener = listener
     assertEquals(0, listener.count)
 
     parent.addSubview(layout.view)
@@ -60,16 +60,6 @@ class TreehouseUIKitViewTest {
 
     layout.view.removeFromSuperview()
     assertEquals(2, listener.count)
-  }
-
-  @Test fun contentSendsStateChange() {
-    val layout = TreehouseUIKitView(throwingWidgetSystem)
-    val listener = CountingStateChangeListener()
-    layout.stateChangeListener = listener
-    assertEquals(0, listener.count)
-
-    layout.setContent { throw UnsupportedOperationException() }
-    assertEquals(1, listener.count)
   }
 
   @Test fun resetClearsUntrackedChildren() {

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
@@ -22,6 +22,7 @@ import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseUIKitView
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
+import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import platform.Foundation.NSIndexPath
@@ -72,13 +73,11 @@ private class TableViewDataSource<A : AppService>(
 
   override fun tableView(tableView: UITableView, cellForRowAtIndexPath: NSIndexPath): UITableViewCell {
     val treehouseView = TreehouseUIKitView(widgetSystem)
-    treehouseApp.renderTo(treehouseView)
-    treehouseView.setContent(
-      CellContentSource(
-        intervals[cellForRowAtIndexPath.section.toInt()].itemProvider,
-        cellForRowAtIndexPath.row.toInt(),
-      ),
+    val cellContentSource = CellContentSource<A>(
+      intervals[cellForRowAtIndexPath.section.toInt()].itemProvider,
+      cellForRowAtIndexPath.row.toInt(),
     )
+    cellContentSource.bindWhenReady(treehouseView, treehouseApp)
     return TableViewCell(treehouseView.view)
   }
 }

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -31,8 +31,10 @@ import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseWidgetView
+import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
+import okio.Closeable
 
 private data class LazyContentItem(
   val index: Int,
@@ -83,26 +85,25 @@ internal class ViewLazyColumn<A : AppService>(
       val container = FrameLayout(parent.context).apply {
         layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, contentHeight)
       }
-      return ViewHolder(container, treehouseApp, widgetSystem)
+      return ViewHolder(container, widgetSystem)
     }
 
     override fun onBindViewHolder(holder: ViewHolder<A>, position: Int) {
       val itemContent = currentList[position]
-      holder.treehouseWidgetView.setContentSource {
+      holder.widgetContentBinding?.close()
+      holder.widgetContentBinding = {
         itemContent.item.get(itemContent.index)
-      }
+      }.bindWhenReady(holder.treehouseWidgetView, treehouseApp)
     }
   }
 
   private class ViewHolder<A : AppService>(
     container: FrameLayout,
-    treehouseApp: TreehouseApp<A>,
     widgetSystem: TreehouseView.WidgetSystem<A>,
   ) : RecyclerView.ViewHolder(container) {
+    var widgetContentBinding: Closeable? = null
     val treehouseWidgetView = TreehouseWidgetView(container.context, widgetSystem)
       .apply {
-        treehouseApp.renderTo(this)
-
         layoutParams = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
           gravity = Gravity.CENTER_HORIZONTAL
         }

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -29,6 +29,7 @@ import androidx.recyclerview.widget.RecyclerView
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
+import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseWidgetView
 import app.cash.redwood.treehouse.bindWhenReady
@@ -90,10 +91,15 @@ internal class ViewLazyColumn<A : AppService>(
 
     override fun onBindViewHolder(holder: ViewHolder<A>, position: Int) {
       val itemContent = currentList[position]
-      holder.widgetContentBinding?.close()
-      holder.widgetContentBinding = {
+      val itemContentSource = TreehouseContentSource<A> {
         itemContent.item.get(itemContent.index)
-      }.bindWhenReady(holder.treehouseWidgetView, treehouseApp)
+      }
+
+      holder.widgetContentBinding?.close()
+      holder.widgetContentBinding = itemContentSource.bindWhenReady(
+        view = holder.treehouseWidgetView,
+        app = treehouseApp,
+      )
     }
   }
 

--- a/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -25,6 +25,7 @@ import app.cash.redwood.treehouse.TreehouseAppFactory
 import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseWidgetView
+import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.view.ViewRedwoodTreehouseLazyLayoutWidgetFactory
 import app.cash.zipline.loader.ManifestVerifier
 import app.cash.zipline.loader.asZiplineHttpClient
@@ -70,8 +71,7 @@ class EmojiSearchActivity : ComponentActivity() {
 
     setContentView(
       TreehouseWidgetView(this, widgetSystem).apply {
-        treehouseApp.renderTo(this)
-        setContentSource(treehouseContentSource)
+        treehouseContentSource.bindWhenReady(this, treehouseApp)
       },
     )
   }

--- a/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
+++ b/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
@@ -19,14 +19,18 @@ package com.example.redwood.emojisearch.ios
 
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
+import app.cash.redwood.treehouse.AppService
+import app.cash.redwood.treehouse.Content
 import app.cash.redwood.treehouse.TreehouseUIKitView
 import app.cash.redwood.treehouse.TreehouseView
+import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.uiview.UIViewRedwoodTreehouseLazyLayoutWidgetFactory
 import com.example.redwood.emojisearch.widget.EmojiSearchDiffConsumingNodeFactory
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactory
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
+import okio.Closeable
 import platform.Foundation.NSData
 
 // Used to export types to Objective-C / Swift.
@@ -46,3 +50,8 @@ fun exposedTypes(
 fun byteStringOf(data: NSData): ByteString = data.toByteString()
 
 fun layoutModifier(): LayoutModifier = LayoutModifier
+
+fun <A : AppService> bindWhenReady(
+  content: Content<A>,
+  view: TreehouseView<A>,
+): Closeable = content.bindWhenReady(view)

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -37,9 +37,8 @@ class EmojiSearchViewController : UIViewController {
         let treehouseApp = emojiSearchLauncher.createTreehouseApp()
         let widgetSystem = EmojiSearchWidgetSystem()
         let treehouseView = Redwood_treehouse_hostTreehouseUIKitView<Presenter_treehouseEmojiSearchPresenter>(widgetSystem: widgetSystem)
-        treehouseApp.renderTo(view: treehouseView)
-        treehouseView.setContent(contentSource: EmojiSearchContent())
-
+        let content = treehouseApp.createContent(source: EmojiSearchContent())
+        ExposedKt.bindWhenReady(content: content, view: treehouseView)
         view = treehouseView.view
     }
 }


### PR DESCRIPTION
This is a major step towards breaking the dependency from TreehouseView onto Zipline etc.

With this change TreehouseView no longer knows about TreehouseApp, and no longer needs a renderTo() call.

I'm not particularly happy with the 'readyForContent' variable name or the ReadyForContentChangeListener interface name. I want something that represents attached state on both platforms.

There's a possible follow-up to this change to simplify the RealBinding and LoadingBinding types. These are still necessary, but the new structure reduces how much stuff they need to own.

https://github.com/cashapp/redwood/issues/541