### PR TITLE
Move WidgetSystem from TreehouseView to Content

### DIFF
--- a/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -29,7 +29,7 @@ import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseView.CodeListener
 import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,12 +46,11 @@ public fun <A : AppService> TreehouseContent(
   )
 
   val rememberedCodeListener = rememberUpdatedState(codeListener)
-  val treehouseView = remember(widgetSystem) {
+  val treehouseView = remember {
     object : TreehouseView {
       override val codeListener get() = rememberedCodeListener.value
       override val children = ComposeWidgetChildren()
       override val hostConfiguration = MutableStateFlow(hostConfiguration)
-      override val widgetSystem = widgetSystem
       override val readyForContent = true
       override var readyForContentChangeListener: ReadyForContentChangeListener? = null
       override fun reset() = children.remove(0, children.widgets.size)
@@ -60,8 +59,8 @@ public fun <A : AppService> TreehouseContent(
   LaunchedEffect(treehouseView, hostConfiguration) {
     treehouseView.hostConfiguration.value = hostConfiguration
   }
-  DisposableEffect(treehouseView, contentSource) {
-    val closeable = contentSource.bindWhenReady(treehouseView, treehouseApp)
+  DisposableEffect(contentSource, treehouseView, treehouseApp, widgetSystem) {
+    val closeable = contentSource.bindWhenReady(treehouseView, treehouseApp, widgetSystem)
     onDispose {
       closeable.close()
     }

--- a/redwood-treehouse-host/src/androidInstrumentedTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
+++ b/redwood-treehouse-host/src/androidInstrumentedTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
@@ -22,7 +22,6 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.view.View
 import android.view.ViewGroup
 import app.cash.redwood.LayoutModifier
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.widget.ViewGroupChildren
 import app.cash.redwood.widget.Widget
 import app.cash.turbine.test
@@ -43,7 +42,7 @@ class TreehouseWidgetViewTest {
   private val context = RuntimeEnvironment.getApplication()!!
 
   @Test fun widgetsAddChildViews() {
-    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    val layout = TreehouseWidgetView(context)
 
     val view = View(context)
     layout.children.insert(0, viewWidget(view))
@@ -54,7 +53,7 @@ class TreehouseWidgetViewTest {
   @Test fun attachAndDetachSendsStateChange() {
     val activity = Robolectric.buildActivity(Activity::class.java).resume().visible().get()
     val parent = activity.findViewById<ViewGroup>(android.R.id.content)
-    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    val layout = TreehouseWidgetView(context)
     val listener = CountingReadyForContentChangeListener()
 
     layout.readyForContentChangeListener = listener
@@ -68,7 +67,7 @@ class TreehouseWidgetViewTest {
   }
 
   @Test fun resetClearsUntrackedChildren() {
-    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    val layout = TreehouseWidgetView(context)
 
     layout.addView(View(context))
     assertEquals(1, layout.childCount)
@@ -78,7 +77,7 @@ class TreehouseWidgetViewTest {
   }
 
   @Test fun resetClearsTrackedWidgets() {
-    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    val layout = TreehouseWidgetView(context)
 
     // Needed to access internal state which cannot be reasonably observed through the public API.
     val children = layout.children as ViewGroupChildren
@@ -96,12 +95,12 @@ class TreehouseWidgetViewTest {
     val newConfig = Configuration(context.resources.configuration)
     newConfig.uiMode = (newConfig.uiMode and UI_MODE_NIGHT_MASK.inv()) or UI_MODE_NIGHT_YES
     val newContext = context.createConfigurationContext(newConfig) // Needs API 26.
-    val layout = TreehouseWidgetView(newContext, throwingWidgetSystem)
+    val layout = TreehouseWidgetView(newContext)
     assertEquals(HostConfiguration(darkMode = true), layout.hostConfiguration.value)
   }
 
   @Test fun hostConfigurationEmitsUiModeChanges() = runTest {
-    val layout = TreehouseWidgetView(context, throwingWidgetSystem)
+    val layout = TreehouseWidgetView(context)
     layout.hostConfiguration.test {
       assertEquals(HostConfiguration(darkMode = false), awaitItem())
 
@@ -117,7 +116,4 @@ class TreehouseWidgetViewTest {
     override val value: View get() = view
     override var layoutModifiers: LayoutModifier = LayoutModifier
   }
-
-  private val throwingWidgetSystem =
-    WidgetSystem { _, _, _ -> throw UnsupportedOperationException() }
 }

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -25,7 +25,6 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import app.cash.redwood.treehouse.TreehouseView.CodeListener
 import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.widget.ViewGroupChildren
 import app.cash.redwood.widget.Widget
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,7 +33,6 @@ import kotlinx.coroutines.flow.StateFlow
 @SuppressLint("ViewConstructor")
 public class TreehouseWidgetView(
   context: Context,
-  override val widgetSystem: WidgetSystem,
 ) : FrameLayout(context), TreehouseView {
   public override var codeListener: CodeListener = CodeListener()
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ContentBinding.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ContentBinding.kt
@@ -48,7 +48,8 @@ public fun <A : AppService> Content<A>.bindWhenReady(view: TreehouseView): Close
 public fun <A : AppService> TreehouseContentSource<A>.bindWhenReady(
   view: TreehouseView,
   app: TreehouseApp<A>,
+  widgetSystem: WidgetSystem,
 ): Closeable {
-  val content = app.createContent(this)
+  val content = app.createContent(this, widgetSystem)
   return content.bindWhenReady(view)
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -75,10 +75,13 @@ public class TreehouseApp<A : AppService> private constructor(
    *
    * Calls to this function will [start] this app if it isn't already started.
    */
-  public fun createContent(source: TreehouseContentSource<A>): Content<A> {
+  public fun createContent(
+    source: TreehouseContentSource<A>,
+    widgetSystem: WidgetSystem,
+  ): Content<A> {
     start()
 
-    return TreehouseContent(this, source)
+    return TreehouseContent(this, source, widgetSystem)
   }
 
   /**

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseContent.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.treehouse
 internal class TreehouseContent<A : AppService>(
   private val treehouseApp: TreehouseApp<A>,
   private val source: TreehouseContentSource<A>,
+  private val widgetSystem: WidgetSystem,
 ) : Content<A> {
   private val dispatchers = treehouseApp.dispatchers
 
@@ -71,6 +72,7 @@ internal class TreehouseContent<A : AppService>(
           appScope = treehouseApp.appScope,
           eventPublisher = treehouseApp.eventPublisher,
           contentSource = source,
+          widgetSystem = widgetSystem,
           session = ziplineSession,
           view = view,
         ).apply {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -15,16 +15,12 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.protocol.widget.DiffConsumingNode
-import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
 import app.cash.redwood.widget.Widget
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.serialization.json.Json
 
 public interface TreehouseView {
   public val children: Widget.Children<*>
   public val hostConfiguration: StateFlow<HostConfiguration>
-  public val widgetSystem: WidgetSystem
   public val codeListener: CodeListener
   public val readyForContent: Boolean
   public var readyForContentChangeListener: ReadyForContentChangeListener?
@@ -35,15 +31,6 @@ public interface TreehouseView {
   public fun interface ReadyForContentChangeListener {
     /** Called when [TreehouseView.readyForContent] has changed. */
     public fun onReadyForContentChanged(view: TreehouseView)
-  }
-
-  public fun interface WidgetSystem {
-    /** Returns a widget factory for encoding and decoding changes to the contents of [view]. */
-    public fun widgetFactory(
-      app: TreehouseApp<*>,
-      json: Json,
-      protocolMismatchHandler: ProtocolMismatchHandler,
-    ): DiffConsumingNode.Factory<*>
   }
 
   public open class CodeListener {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/WidgetSystem.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/WidgetSystem.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import app.cash.redwood.protocol.widget.DiffConsumingNode
+import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
+import kotlinx.serialization.json.Json
+
+public fun interface WidgetSystem {
+  /** Returns a widget factory for encoding and decoding changes of a [Content]. */
+  public fun widgetFactory(
+    app: TreehouseApp<*>,
+    json: Json,
+    protocolMismatchHandler: ProtocolMismatchHandler,
+  ): DiffConsumingNode.Factory<*>
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/bindings.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/bindings.kt
@@ -54,6 +54,7 @@ internal class RealBinding<A : AppService>(
   val appScope: CoroutineScope,
   val eventPublisher: EventPublisher,
   val contentSource: TreehouseContentSource<A>,
+  val widgetSystem: WidgetSystem,
   session: ZiplineSession<A>,
   view: TreehouseView,
 ) : Binding, EventSink, DiffSinkService {
@@ -68,7 +69,7 @@ internal class RealBinding<A : AppService>(
   @Suppress("UNCHECKED_CAST") // We don't have a type parameter for the widget type.
   private var bridgeOrNull: ProtocolBridge<*>? = ProtocolBridge(
     container = view.children as Widget.Children<Any>,
-    factory = view.widgetSystem.widgetFactory(
+    factory = widgetSystem.widgetFactory(
       app = app,
       json = session.zipline.json,
       protocolMismatchHandler = eventPublisher.protocolMismatchHandler(app),

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -17,7 +17,6 @@ package app.cash.redwood.treehouse
 
 import app.cash.redwood.treehouse.TreehouseView.CodeListener
 import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.widget.UIViewChildren
 import app.cash.redwood.widget.Widget
 import kotlinx.cinterop.ObjCAction
@@ -33,9 +32,7 @@ import platform.UIKit.setFrame
 import platform.UIKit.subviews
 import platform.UIKit.superview
 
-public class TreehouseUIKitView(
-  override val widgetSystem: WidgetSystem,
-) : TreehouseView {
+public class TreehouseUIKitView : TreehouseView {
   public val view: UIView = RootUiView(this)
   public override var codeListener: CodeListener = CodeListener()
 

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
@@ -16,7 +16,6 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.LayoutModifier
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.widget.UIViewChildren
 import app.cash.redwood.widget.Widget
 import app.cash.turbine.test
@@ -39,7 +38,7 @@ import platform.UIKit.subviews
 @OptIn(ExperimentalCoroutinesApi::class)
 class TreehouseUIKitViewTest {
   @Test fun widgetsAddChildViews() {
-    val layout = TreehouseUIKitView(throwingWidgetSystem)
+    val layout = TreehouseUIKitView()
 
     val view = UIView()
     layout.children.insert(0, viewWidget(view))
@@ -50,7 +49,7 @@ class TreehouseUIKitViewTest {
 
   @Test fun attachAndDetachSendsStateChange() {
     val parent = UIView()
-    val layout = TreehouseUIKitView(throwingWidgetSystem)
+    val layout = TreehouseUIKitView()
     val listener = CountingReadyForContentChangeListener()
 
     layout.readyForContentChangeListener = listener
@@ -64,7 +63,7 @@ class TreehouseUIKitViewTest {
   }
 
   @Test fun resetClearsUntrackedChildren() {
-    val layout = TreehouseUIKitView(throwingWidgetSystem)
+    val layout = TreehouseUIKitView()
 
     layout.view.addSubview(UIView())
     assertEquals(1, layout.view.subviews.size)
@@ -74,7 +73,7 @@ class TreehouseUIKitViewTest {
   }
 
   @Test fun resetClearsTrackedWidgets() {
-    val layout = TreehouseUIKitView(throwingWidgetSystem)
+    val layout = TreehouseUIKitView()
 
     // Needed to access internal state which cannot be reasonably observed through the public API.
     val children = layout.children as UIViewChildren
@@ -91,7 +90,7 @@ class TreehouseUIKitViewTest {
     val parent = UIWindow()
     parent.overrideUserInterfaceStyle = UIUserInterfaceStyleDark
 
-    val layout = TreehouseUIKitView(throwingWidgetSystem)
+    val layout = TreehouseUIKitView()
     parent.addSubview(layout.view)
 
     assertEquals(HostConfiguration(darkMode = true), layout.hostConfiguration.value)
@@ -100,7 +99,7 @@ class TreehouseUIKitViewTest {
   @Test fun hostConfigurationEmitsUiModeChanges() = runTest {
     val parent = UIWindow()
 
-    val layout = TreehouseUIKitView(throwingWidgetSystem)
+    val layout = TreehouseUIKitView()
     parent.addSubview(layout.view)
 
     layout.hostConfiguration.test {
@@ -118,7 +117,4 @@ class TreehouseUIKitViewTest {
     override val value: UIView get() = view
     override var layoutModifiers: LayoutModifier = LayoutModifier
   }
-
-  private val throwingWidgetSystem =
-    WidgetSystem { _, _, _ -> throw UnsupportedOperationException() }
 }

--- a/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyColumn.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.unit.dp
 import app.cash.redwood.LayoutModifier
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.composeui.TreehouseContent
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn

--- a/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -18,7 +18,7 @@ package app.cash.redwood.treehouse.lazylayout.composeui
 import androidx.compose.runtime.Composable
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
@@ -20,7 +20,7 @@ import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseUIKitView
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
@@ -72,12 +72,12 @@ private class TableViewDataSource<A : AppService>(
   }
 
   override fun tableView(tableView: UITableView, cellForRowAtIndexPath: NSIndexPath): UITableViewCell {
-    val treehouseView = TreehouseUIKitView(widgetSystem)
+    val treehouseView = TreehouseUIKitView()
     val cellContentSource = CellContentSource<A>(
       intervals[cellForRowAtIndexPath.section.toInt()].itemProvider,
       cellForRowAtIndexPath.row.toInt(),
     )
-    cellContentSource.bindWhenReady(treehouseView, treehouseApp)
+    cellContentSource.bindWhenReady(treehouseView, treehouseApp, widgetSystem)
     return TableViewCell(treehouseView.view)
   }
 }

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
@@ -17,7 +17,7 @@ package app.cash.redwood.treehouse.lazylayout.uiview
 
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 import platform.UIKit.UIView

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -30,8 +30,8 @@ import app.cash.redwood.LayoutModifier
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseContentSource
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.TreehouseWidgetView
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
@@ -86,7 +86,7 @@ internal class ViewLazyColumn<A : AppService>(
       val container = FrameLayout(parent.context).apply {
         layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, contentHeight)
       }
-      return ViewHolder(container, widgetSystem)
+      return ViewHolder(container)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -99,16 +99,16 @@ internal class ViewLazyColumn<A : AppService>(
       holder.widgetContentBinding = itemContentSource.bindWhenReady(
         view = holder.treehouseWidgetView,
         app = treehouseApp,
+        widgetSystem = widgetSystem,
       )
     }
   }
 
   private class ViewHolder(
     container: FrameLayout,
-    widgetSystem: WidgetSystem,
   ) : RecyclerView.ViewHolder(container) {
     var widgetContentBinding: Closeable? = null
-    val treehouseWidgetView = TreehouseWidgetView(container.context, widgetSystem)
+    val treehouseWidgetView = TreehouseWidgetView(container.context)
       .apply {
         layoutParams = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
           gravity = Gravity.CENTER_HORIZONTAL

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -20,7 +20,7 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 

--- a/samples/emoji-search/android-composeui/src/main/java/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/java/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
@@ -26,7 +26,7 @@ import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseAppFactory
 import app.cash.redwood.treehouse.TreehouseContentSource
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.composeui.TreehouseContent
 import app.cash.redwood.treehouse.lazylayout.composeui.ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory
 import app.cash.zipline.loader.ManifestVerifier

--- a/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -23,8 +23,8 @@ import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseAppFactory
 import app.cash.redwood.treehouse.TreehouseContentSource
-import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseWidgetView
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.view.ViewRedwoodTreehouseLazyLayoutWidgetFactory
 import app.cash.zipline.loader.ManifestVerifier
@@ -50,7 +50,7 @@ class EmojiSearchActivity : ComponentActivity() {
     val treehouseApp = createTreehouseApp()
     val treehouseContentSource = TreehouseContentSource(EmojiSearchPresenter::launch)
 
-    val widgetSystem = object : TreehouseView.WidgetSystem {
+    val widgetSystem = object : WidgetSystem {
       override fun widgetFactory(
         app: TreehouseApp<*>,
         json: Json,
@@ -70,8 +70,8 @@ class EmojiSearchActivity : ComponentActivity() {
     }
 
     setContentView(
-      TreehouseWidgetView(this, widgetSystem).apply {
-        treehouseContentSource.bindWhenReady(this, treehouseApp)
+      TreehouseWidgetView(this).apply {
+        treehouseContentSource.bindWhenReady(this, treehouseApp, widgetSystem)
       },
     )
   }

--- a/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
+++ b/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
@@ -23,7 +23,7 @@ import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.Content
 import app.cash.redwood.treehouse.TreehouseUIKitView
 import app.cash.redwood.treehouse.TreehouseView
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.treehouse.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.uiview.UIViewRedwoodTreehouseLazyLayoutWidgetFactory
 import com.example.redwood.emojisearch.widget.EmojiSearchDiffConsumingNodeFactory

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -50,7 +50,7 @@ class EmojiSearchContent : Redwood_treehouse_hostTreehouseContentSource {
     }
 }
 
-class EmojiSearchWidgetSystem : Redwood_treehouse_hostTreehouseViewWidgetSystem {
+class EmojiSearchWidgetSystem : Redwood_treehouse_hostWidgetSystem {
     func widgetFactory(app: Redwood_treehouse_hostTreehouseApp<AnyObject>, json: Kotlinx_serialization_jsonJson, protocolMismatchHandler:
         Redwood_protocol_widgetProtocolMismatchHandler) -> Redwood_protocol_widgetDiffConsumingNodeFactory {
         return ProtocolEmojiSearchDiffConsumingNodeFactory<UIView>(

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -36,8 +36,8 @@ class EmojiSearchViewController : UIViewController {
         let emojiSearchLauncher = EmojiSearchLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
         let treehouseApp = emojiSearchLauncher.createTreehouseApp()
         let widgetSystem = EmojiSearchWidgetSystem()
-        let treehouseView = Redwood_treehouse_hostTreehouseUIKitView(widgetSystem: widgetSystem)
-        let content = treehouseApp.createContent(source: EmojiSearchContent())
+        let treehouseView = Redwood_treehouse_hostTreehouseUIKitView()
+        let content = treehouseApp.createContent(source: EmojiSearchContent(), widgetSystem: widgetSystem)
         ExposedKt.bindWhenReady(content: content, view: treehouseView)
         view = treehouseView.view
     }

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/IosEmojiSearchWidgetFactory.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/IosEmojiSearchWidgetFactory.swift
@@ -21,10 +21,10 @@ import EmojiSearchKt
 
 class IosEmojiSearchWidgetFactory<A : AnyObject>: WidgetEmojiSearchWidgetFactory {
     let treehouseApp: Redwood_treehouse_hostTreehouseApp<A>
-    let widgetSystem: Redwood_treehouse_hostTreehouseViewWidgetSystem
+    let widgetSystem: Redwood_treehouse_hostWidgetSystem
     let imageLoader = RemoteImageLoader()
 
-    init(treehouseApp: Redwood_treehouse_hostTreehouseApp<A>, widgetSystem: Redwood_treehouse_hostTreehouseViewWidgetSystem) {
+    init(treehouseApp: Redwood_treehouse_hostTreehouseApp<A>, widgetSystem: Redwood_treehouse_hostWidgetSystem) {
         self.treehouseApp = treehouseApp
         self.widgetSystem = widgetSystem
     }


### PR DESCRIPTION
It's another type that transitively depends on TreehouseApp and Zipline, that we don't need in TreehouseView.