### PR TITLE
Migrate to the new Kotlin compilerOptions property API.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.SonatypeHost
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
@@ -69,42 +70,38 @@ allprojects {
   ]
 
   if (project.path.startsWith(':redwood-') && !privateApiModules.contains(project.path)) {
-    plugins.withId('org.jetbrains.kotlin.jvm') {
-      kotlin {
-        explicitApi()
-      }
-    }
-
     plugins.withId('org.jetbrains.kotlin.multiplatform') {
       kotlin {
         explicitApi()
       }
     }
 
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach { task ->
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { task ->
       // Only enable strict mode for non-test sources.
       if (!task.name.toLowerCase().contains('test')) {
-        task.kotlinOptions {
-          freeCompilerArgs += '-Xexplicit-api=strict'
+        compilerOptions {
+          freeCompilerArgs.addAll([
+            '-Xexplicit-api=strict',
+          ])
         }
       }
     }
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile).configureEach { task ->
-    task.kotlinOptions {
-      freeCompilerArgs += [
+    compilerOptions {
+      freeCompilerArgs.addAll([
         '-progressive', // https://kotlinlang.org/docs/whatsnew13.html#progressive-mode
-      ]
+      ])
     }
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach { task ->
-    task.kotlinOptions {
-      jvmTarget = '1.8'
-      freeCompilerArgs += [
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_1_8)
+      freeCompilerArgs.addAll([
         '-Xjvm-default=all',
-      ]
+      ])
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ allprojects {
     }
   }
 
-  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach { task ->
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach {
     compilerOptions {
       jvmTarget.set(JvmTarget.JVM_1_8)
       freeCompilerArgs.addAll([

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ allprojects {
     }
   }
 
-  tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile).configureEach { task ->
+  tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile).configureEach {
     compilerOptions {
       freeCompilerArgs.addAll([
         '-progressive', // https://kotlinlang.org/docs/whatsnew13.html#progressive-mode


### PR DESCRIPTION
[The `kotlinOptions` API was deprecated in Kotlin 1.8.](https://kotlinlang.org/docs/whatsnew18.html#exposing-kotlin-compiler-options-as-gradle-lazy-properties)