### PR TITLE
Remove widgetFactory TreehouseApp parameter

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -135,7 +135,6 @@ private class ViewContentCodeBinding<A : AppService>(
   private var bridgeOrNull: ProtocolBridge<*>? = ProtocolBridge(
     container = view.children as Widget.Children<Any>,
     factory = view.widgetSystem.widgetFactory(
-      app = app,
       json = session.zipline.json,
       protocolMismatchHandler = eventPublisher.protocolMismatchHandler(app),
     ) as DiffConsumingNode.Factory<Any>,

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -39,7 +39,6 @@ public interface TreehouseView {
   public fun interface WidgetSystem {
     /** Returns a widget factory for encoding and decoding changes to the contents of [view]. */
     public fun widgetFactory(
-      app: TreehouseApp<*>,
       json: Json,
       protocolMismatchHandler: ProtocolMismatchHandler,
     ): DiffConsumingNode.Factory<*>

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
@@ -120,5 +120,5 @@ class TreehouseUIKitViewTest {
   }
 
   private val throwingWidgetSystem =
-    WidgetSystem { _, _, _ -> throw UnsupportedOperationException() }
+    WidgetSystem { _, _ -> throw UnsupportedOperationException() }
 }

--- a/samples/emoji-search/android-composeui/src/main/java/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/java/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
@@ -54,14 +54,13 @@ class EmojiSearchActivity : ComponentActivity() {
 
     val widgetSystem = object : WidgetSystem {
       override fun widgetFactory(
-        app: TreehouseApp<*>,
         json: Json,
         protocolMismatchHandler: ProtocolMismatchHandler,
       ) = EmojiSearchDiffConsumingNodeFactory<@Composable () -> Unit>(
         provider = EmojiSearchWidgetFactories(
-          EmojiSearch = AndroidEmojiSearchWidgetFactory(app),
+          EmojiSearch = AndroidEmojiSearchWidgetFactory(treehouseApp),
           RedwoodLayout = ComposeUiRedwoodLayoutWidgetFactory(),
-          RedwoodTreehouseLazyLayout = ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory(app, this),
+          RedwoodTreehouseLazyLayout = ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory(treehouseApp, this),
         ),
         json = json,
         mismatchHandler = protocolMismatchHandler,

--- a/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/java/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -52,7 +52,6 @@ class EmojiSearchActivity : ComponentActivity() {
 
     val widgetSystem = object : TreehouseView.WidgetSystem {
       override fun widgetFactory(
-        app: TreehouseApp<*>,
         json: Json,
         protocolMismatchHandler: ProtocolMismatchHandler,
       ) = EmojiSearchDiffConsumingNodeFactory(

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -35,7 +35,7 @@ class EmojiSearchViewController : UIViewController {
     override func loadView() {
         let emojiSearchLauncher = EmojiSearchLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
         let treehouseApp = emojiSearchLauncher.createTreehouseApp()
-        let widgetSystem = EmojiSearchWidgetSystem()
+        let widgetSystem = EmojiSearchWidgetSystem(treehouseApp: treehouseApp)
         let treehouseView = Redwood_treehouse_hostTreehouseUIKitView(widgetSystem: widgetSystem)
         let content = treehouseApp.createContent(
             source: EmojiSearchContent(),
@@ -54,14 +54,18 @@ class EmojiSearchContent : Redwood_treehouse_hostTreehouseContentSource {
 }
 
 class EmojiSearchWidgetSystem : Redwood_treehouse_hostTreehouseViewWidgetSystem {
-    func widgetFactory(app: Redwood_treehouse_hostTreehouseApp<AnyObject>, json: Kotlinx_serialization_jsonJson, protocolMismatchHandler:
+    let treehouseApp: Redwood_treehouse_hostTreehouseApp<Presenter_treehouseEmojiSearchPresenter>
+    init(treehouseApp: Redwood_treehouse_hostTreehouseApp<Presenter_treehouseEmojiSearchPresenter>) {
+        self.treehouseApp = treehouseApp
+    }
+    func widgetFactory(json: Kotlinx_serialization_jsonJson, protocolMismatchHandler:
         Redwood_protocol_widgetProtocolMismatchHandler) -> Redwood_protocol_widgetDiffConsumingNodeFactory {
         return ProtocolEmojiSearchDiffConsumingNodeFactory<UIView>(
             provider: WidgetEmojiSearchWidgetFactories<UIView>(
-                EmojiSearch: IosEmojiSearchWidgetFactory(treehouseApp: app, widgetSystem: self),
+                EmojiSearch: IosEmojiSearchWidgetFactory(treehouseApp: treehouseApp, widgetSystem: self),
                 RedwoodLayout: Redwood_layout_uiviewUIViewRedwoodLayoutWidgetFactory(),
                 RedwoodTreehouseLazyLayout: Redwood_treehouse_lazylayout_uiviewUIViewRedwoodTreehouseLazyLayoutWidgetFactory(
-                    treehouseApp: app,
+                    treehouseApp: treehouseApp,
                     widgetSystem: self
                 )
             ),


### PR DESCRIPTION
Purely done to aid the effort of #541.

The `TreehouseApp` parameter was the last dependency making `TreehouseView` Treehouse dependent. I'm missing some context as to why we were passing `app` to `widgetFactory` in the first place, and not just directly using the surrounding one.