### PR TITLE
Increase the Android emulator timeout.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
+  ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
 
 jobs:
   build:
@@ -64,6 +65,7 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          emulator-boot-timeout: 20000
           script: ./gradlew -p samples/counter connectedCheck
 
       - name: Build Counter iOS (UIKit)


### PR DESCRIPTION
Increases `ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL` and `emulator-boot-timeout` to hopefully make running the emulator less flaky.

I'm not 100% sure, but I believe they control independent timeouts as [`ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL` defaults to 20](https://github.com/cashapp/redwood/actions/runs/4482540733/jobs/7880707563) and `emulator-boot-timeout` defaults to 6000.