### PR TITLE
Remove redundant activity labels

### DIFF
--- a/samples/emoji-search/android-composeui/src/main/AndroidManifest.xml
+++ b/samples/emoji-search/android-composeui/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
     <activity
       android:name=".EmojiSearchActivity"
       android:exported="true"
-      android:label="@string/app_name"
       android:theme="@style/Theme.MyApplication.NoActionBar"
       >
       <intent-filter>

--- a/samples/emoji-search/android-views/src/main/AndroidManifest.xml
+++ b/samples/emoji-search/android-views/src/main/AndroidManifest.xml
@@ -33,7 +33,6 @@
     <activity
       android:name=".EmojiSearchActivity"
       android:exported="true"
-      android:label="@string/app_name"
       android:theme="@style/Theme.MyApplication.NoActionBar"
       >
       <intent-filter>


### PR DESCRIPTION
Android Studio prompts that these are redundant and can be removed.