### PR TITLE
Prevent Emoji Search Compose Crash

### DIFF
--- a/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -18,7 +18,6 @@ package app.cash.redwood.treehouse.composeui
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import app.cash.redwood.treehouse.AppService
@@ -57,11 +56,9 @@ public fun <A : AppService> TreehouseContent(
   LaunchedEffect(treehouseView, hostConfiguration) {
     treehouseView.hostConfiguration.value = hostConfiguration
   }
-  DisposableEffect(treehouseView, contentSource, codeListener) {
+  LaunchedEffect(treehouseView, contentSource, codeListener) {
     val closeable = contentSource.bindWhenReady(treehouseView, treehouseApp, codeListener)
-    onDispose {
-      closeable.close()
-    }
+    closeable.close()
   }
 
   Box {


### PR DESCRIPTION
Emoji Search compose sample is crashing before Zipline loads:

```
FATAL EXCEPTION: main
Process: com.example.redwood.emojisearch.android.composeui, PID: 22840
java.lang.IllegalStateException: unexpected receiveZiplineSession with no view bound and no preload
	at app.cash.redwood.treehouse.TreehouseAppContent.receiveZiplineSession$redwood_treehouse_host_debug(TreehouseAppContent.kt:171)
	at app.cash.redwood.treehouse.TreehouseApp$onCodeChanged$1.invokeSuspend(TreehouseApp.kt:185)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at android.os.Handler.handleCallback(Handler.java:942)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7872)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@930749e, Dispatchers.Main]
```
