### PR TITLE
Deregister from boundContents unconditionally

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -150,8 +150,8 @@ internal class TreehouseAppContent<A : AppService>(
     val nextCodeState = CodeState.Idle<A>()
 
     // Cancel the code if necessary.
+    treehouseApp.boundContents.remove(this)
     if (previousState.codeState is CodeState.Running) {
-      treehouseApp.boundContents.remove(this)
       previousState.codeState.viewContentCodeBinding.cancel()
     }
 


### PR DESCRIPTION
We had a bug where this sequence of calls would put a TreehouseAppContent into an invalid state:

  content.preload(...)
  content.unbind()

In particular, this would have a view state of None but the TreehouseAppContent would still be observing code loads in TreehouseApp.boundContents.

Closes #892 