### PR TITLE
Build treehouse-lazylayout-compose on all platforms

### DIFF
--- a/redwood-treehouse-lazylayout-compose/build.gradle
+++ b/redwood-treehouse-lazylayout-compose/build.gradle
@@ -1,12 +1,12 @@
+import app.cash.redwood.buildsupport.KmpTargets
+
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.compose'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  js {
-    browser()
-  }
+  KmpTargets.addAllTargets(project)
 
   sourceSets {
     commonMain {


### PR DESCRIPTION
So we can run unit tests on the JVM.