### PR TITLE
Move LazyListScope to LazyDsl.kt

### DIFF
--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse.lazylayout.compose
+
+import androidx.compose.runtime.Composable
+import app.cash.redwood.LayoutScopeMarker
+
+@LayoutScopeMarker
+public interface LazyListScope {
+  public fun items(
+    count: Int,
+    itemContent: @Composable (index: Int) -> Unit,
+  )
+}
+
+public inline fun <T> LazyListScope.items(
+  items: List<T>,
+  crossinline itemContent: @Composable (item: T) -> Unit,
+): Unit = items(
+  count = items.size,
+) {
+  itemContent(items[it])
+}

--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
@@ -16,7 +16,6 @@
 package app.cash.redwood.treehouse.lazylayout.compose
 
 import androidx.compose.runtime.Composable
-import app.cash.redwood.LayoutScopeMarker
 import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.protocol.compose.ProtocolBridge
 import app.cash.redwood.treehouse.TreehouseUi
@@ -30,23 +29,6 @@ public fun ProtocolBridge.LazyColumn(content: LazyListScope.() -> Unit) {
   val scope = TreehouseLazyListScope(this, widgetVersion)
   content(scope)
   LazyColumn(scope.intervals)
-}
-
-@LayoutScopeMarker
-public interface LazyListScope {
-  public fun items(
-    count: Int,
-    itemContent: @Composable (index: Int) -> Unit,
-  )
-}
-
-public inline fun <T> LazyListScope.items(
-  items: List<T>,
-  crossinline itemContent: @Composable (item: T) -> Unit,
-) {
-  items(items.size) {
-    itemContent(items[it])
-  }
 }
 
 private class TreehouseLazyListScope(


### PR DESCRIPTION
These functions already are supposed to mimic those in [Compose UI](https://github.com/androidx/androidx/blob/androidx-main/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/LazyDsl.kt). I think it's best to mimic the file structure of Compose UI of the functions we're mimicking, ultimately easing implementation comparisons between Redwood and Compose UI.