### PR TITLE
Add `LazyListScope#itemsIndexed`

### DIFF
--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
@@ -39,6 +39,15 @@ public inline fun <T> LazyListScope.items(
   itemContent(items[it])
 }
 
+public inline fun <T> LazyListScope.itemsIndexed(
+  items: List<T>,
+  crossinline itemContent: @Composable (index: Int, item: T) -> Unit,
+): Unit = items(
+  count = items.size,
+) {
+  itemContent(it, items[it])
+}
+
 public inline fun <T> LazyListScope.items(
   items: Array<T>,
   crossinline itemContent: @Composable (item: T) -> Unit,


### PR DESCRIPTION
Adds function to add a items where each item is aware of its index, similar to [the function in Compose UI's implementation](https://developer.android.com/reference/kotlin/androidx/compose/foundation/lazy/LazyListScope#(androidx.compose.foundation.lazy.LazyListScope).itemsIndexed(kotlin.collections.List,kotlin.Function2,kotlin.Function2,kotlin.Function3)).