### PR TITLE
Add `LazyListScope#items(Array<T>, …)` and `LazyListScope#itemsIndexed(Array<T>, …)`

### DIFF
--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
@@ -34,3 +34,21 @@ public inline fun <T> LazyListScope.items(
 ) {
   itemContent(items[it])
 }
+
+public inline fun <T> LazyListScope.items(
+  items: Array<T>,
+  crossinline itemContent: @Composable (item: T) -> Unit,
+): Unit = items(
+  count = items.size,
+) {
+  itemContent(items[it])
+}
+
+public inline fun <T> LazyListScope.itemsIndexed(
+  items: Array<T>,
+  crossinline itemContent: @Composable (index: Int, item: T) -> Unit,
+): Unit = items(
+  count = items.size,
+) {
+  itemContent(it, items[it])
+}


### PR DESCRIPTION
Adds function to add array of items (optionally index aware), similar to the functions in Compose UI's implementation ([1](https://developer.android.com/reference/kotlin/androidx/compose/foundation/lazy/LazyListScope#(androidx.compose.foundation.lazy.LazyListScope).items(kotlin.Array,kotlin.Function1,kotlin.Function1,kotlin.Function2)), [2](https://developer.android.com/reference/kotlin/androidx/compose/foundation/lazy/LazyListScope#(androidx.compose.foundation.lazy.LazyListScope).itemsIndexed(kotlin.Array,kotlin.Function2,kotlin.Function2,kotlin.Function3))).