### PR TITLE
Respect event type nullability

### DIFF
--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingNodeFactoryTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/DiffConsumingNodeFactoryTest.kt
@@ -342,14 +342,14 @@ class DiffConsumingNodeFactoryTest {
     var onChange: ((String) -> Unit)? = null
       private set
 
-    override fun onChange(onChange: ((String) -> Unit)?) {
+    override fun onChange(onChange: (String) -> Unit) {
       this.onChange = onChange
     }
 
     var onChangeCustomType: ((Duration) -> Unit)? = null
       private set
 
-    override fun onChangeCustomType(onChangeCustomType: ((Duration) -> Unit)?) {
+    override fun onChangeCustomType(onChangeCustomType: (Duration) -> Unit) {
       this.onChangeCustomType = onChangeCustomType
     }
 

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
@@ -107,7 +107,9 @@ internal fun generateComposable(
                 }
                 is Event -> {
                   ParameterSpec.builder(trait.name, trait.lambdaType)
-                    .defaultValue(trait.defaultExpression ?: "null")
+                    .apply {
+                      trait.defaultExpression?.let { defaultValue(it) }
+                    }
                     .build()
                 }
                 is Children -> {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/diffConsumingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/diffConsumingGeneration.kt
@@ -264,7 +264,11 @@ internal fun generateDiffConsumingWidget(
                         )
                       }
                       nextControlFlow("else")
-                      addStatement("null")
+                      if (trait.isNullable) {
+                        addStatement("null")
+                      } else {
+                        addStatement("throw %T()", Stdlib.AssertionError)
+                      }
                       endControlFlow()
                       addStatement("widget.%1N(%1N)", trait.name)
                       endControlFlow()

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -51,14 +51,16 @@ internal val FqType.flatName: String
 
 internal val Event.lambdaType: TypeName
   get() {
-    parameterType?.let { parameterType ->
-      return LambdaTypeName.get(null, parameterType.asTypeName(), returnType = UNIT)
-        .copy(nullable = true)
-    }
-    return noArgumentEventLambda
+    val lambda = parameterType
+      ?.let { parameterType ->
+        LambdaTypeName.get(null, parameterType.asTypeName(), returnType = UNIT)
+      }
+      ?: noArgumentEventLambda
+
+    return lambda.copy(nullable = isNullable)
   }
 
-private val noArgumentEventLambda = LambdaTypeName.get(returnType = UNIT).copy(nullable = true)
+private val noArgumentEventLambda = LambdaTypeName.get(returnType = UNIT)
 
 internal fun Schema.composePackage(host: Schema? = null): String {
   return if (host == null) {

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeGenerationTest.kt
@@ -90,7 +90,7 @@ class ComposeGenerationTest {
     val fileSpec = generateComposable(schema, schema.widgets.single())
     assertThat(fileSpec.toString()).apply {
       contains("trait: String = \"test\"")
-      contains("onEvent: (() -> Unit)? = { error(\"test\") }")
+      contains("onEvent: () -> Unit = { error(\"test\") }")
       contains("block: @Composable () -> Unit = {}")
     }
   }

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/TestingGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/TestingGenerationTest.kt
@@ -98,7 +98,7 @@ class TestingGenerationTest {
       |    this.trait = trait
       |  }
       |
-      |  public override fun onEvent(onEvent: (() -> Unit)?): Unit {
+      |  public override fun onEvent(onEvent: () -> Unit): Unit {
       |    this.onEvent = onEvent
       |  }
       |
@@ -106,7 +106,7 @@ class TestingGenerationTest {
       |      TestingGenerationTestBasicWidgetValue(
       |    layoutModifiers = layoutModifiers,
       |    trait = trait!!,
-      |    onEvent = onEvent,
+      |    onEvent = onEvent!!,
       |    block = block.map { it.`value`.snapshot() },
       |  )
       |}
@@ -119,7 +119,7 @@ class TestingGenerationTest {
       |public class TestingGenerationTestBasicWidgetValue(
       |  public override val layoutModifiers: LayoutModifier = LayoutModifier,
       |  public val trait: String = "test",
-      |  public val onEvent: (() -> Unit)? = { error("test") },
+      |  public val onEvent: () -> Unit = { error("test") },
       |  public val block: List<WidgetValue> = listOf(),
       |) : WidgetValue {
       |  public override val childrenLists: List<List<WidgetValue>>

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schema.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schema.kt
@@ -84,6 +84,7 @@ public interface Widget {
 
   public interface Event : Trait {
     public val parameterType: FqType?
+    public val isNullable: Boolean
   }
 
   public interface Children : Trait {

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaClasses.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaClasses.kt
@@ -94,6 +94,7 @@ internal data class ParsedProtocolEvent(
   override val tag: Int,
   override val name: String,
   override val parameterType: FqType?,
+  override val isNullable: Boolean,
   override val defaultExpression: String? = null,
   override val deprecation: ParsedDeprecation? = null,
 ) : ProtocolEvent

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
@@ -230,6 +230,7 @@ private fun parseWidget(
             tag = property.tag,
             name = name,
             parameterType = arguments.singleOrNull()?.type?.toFqType(),
+            isNullable = type.isMarkedNullable,
             defaultExpression = defaultExpression,
             deprecation = deprecation,
           )

--- a/samples/emoji-search/schema/src/main/kotlin/com/example/redwood/emojisearch/schema.kt
+++ b/samples/emoji-search/schema/src/main/kotlin/com/example/redwood/emojisearch/schema.kt
@@ -47,7 +47,7 @@ data class TextInput(
   val hint: String,
   @Property(3)
   @Default("null")
-  val onChange: (TextFieldState) -> Unit,
+  val onChange: ((TextFieldState) -> Unit)?,
 )
 
 @Widget(2)

--- a/test-schema/src/main/kotlin/example/redwood/schema.kt
+++ b/test-schema/src/main/kotlin/example/redwood/schema.kt
@@ -66,7 +66,7 @@ public data class Text(
 @Widget(4)
 public data class Button(
   @Property(1) val text: String?,
-  @Property(2) val onClick: () -> Unit,
+  @Property(2) val onClick: (() -> Unit)?,
 )
 
 @Widget(5)


### PR DESCRIPTION
If an event is declared as non-nullable then it is required and non-null. If an event is declared as nullable then it is still required but can be set to null. And, of course, nullable event can have a default of null.

This brings it directly in line with property behavior. I'm not sure why we had the weird nullability behavior from before.

Closes #921