### PR TITLE
Rename TreehouseLazyColumn to LazyListIntervalContent

### DIFF
--- a/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/LazyListIntervalContent.kt
+++ b/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/LazyListIntervalContent.kt
@@ -17,26 +17,19 @@ package app.cash.redwood.treehouse.lazylayout.api
 
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.zipline.ZiplineService
-import app.cash.zipline.ziplineServiceSerializer
 import kotlin.native.ObjCName
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.contextual
 
 @Serializable
-@ObjCName("LazyListIntervalContent", exact = true)
-public class LazyListIntervalContent(
+@ObjCName("LazyListInterval", exact = true)
+public class LazyListInterval(
   @Contextual public val count: Int,
   @Contextual public val itemProvider: Item,
 ) {
 
-  @ObjCName("LazyListIntervalContentItem", exact = true)
+  @ObjCName("LazyListIntervalItem", exact = true)
   public interface Item : ZiplineService {
     public fun get(index: Int): ZiplineTreehouseUi
   }
-}
-
-public val treehouseLazyLayoutSerializersModule: SerializersModule = SerializersModule {
-  contextual(ziplineServiceSerializer<LazyListIntervalContent.Item>())
 }

--- a/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/serializers.kt
+++ b/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/serializers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Square, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.treehouse.lazylayout
+package app.cash.redwood.treehouse.lazylayout.api
 
-import app.cash.redwood.schema.Property
-import app.cash.redwood.schema.Widget
-import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
+import app.cash.zipline.ziplineServiceSerializer
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 
-@Widget(1)
-public data class LazyColumn(
-  @Property(1) val intervals: List<LazyListInterval>,
-)
+public val treehouseLazyLayoutSerializersModule: SerializersModule = SerializersModule {
+  contextual(ziplineServiceSerializer<LazyListInterval.Item>())
+}

--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyListIntervalContent.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyListIntervalContent.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse.lazylayout.compose
+
+import androidx.compose.runtime.Composable
+import app.cash.redwood.protocol.compose.ProtocolBridge
+import app.cash.redwood.treehouse.TreehouseUi
+import app.cash.redwood.treehouse.ZiplineTreehouseUi
+import app.cash.redwood.treehouse.asZiplineTreehouseUi
+import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
+
+internal class LazyListIntervalContent(
+  private val provider: ProtocolBridge,
+  private val widgetVersion: UInt,
+) : LazyListScope {
+  val intervals = mutableListOf<LazyListInterval>()
+
+  private class Item(
+    private val provider: ProtocolBridge,
+    private val widgetVersion: UInt,
+    private val content: @Composable (index: Int) -> Unit,
+  ) : LazyListInterval.Item {
+
+    override fun get(index: Int): ZiplineTreehouseUi {
+      val treehouseUi = IndexedTreehouseUi(content, index)
+      return treehouseUi.asZiplineTreehouseUi(provider, widgetVersion)
+    }
+  }
+
+  override fun items(
+    count: Int,
+    itemContent: @Composable (index: Int) -> Unit,
+  ) {
+    intervals += LazyListInterval(
+      count,
+      itemProvider = Item(provider, widgetVersion, itemContent),
+    )
+  }
+
+  override fun item(content: @Composable () -> Unit) {
+    intervals += LazyListInterval(
+      1,
+      Item(provider, widgetVersion) { content() },
+    )
+  }
+}
+
+private class IndexedTreehouseUi(
+  private val content: @Composable (index: Int) -> Unit,
+  private val index: Int,
+) : TreehouseUi {
+  @Composable
+  override fun Show() {
+    content(index)
+  }
+}

--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
@@ -18,61 +18,11 @@ package app.cash.redwood.treehouse.lazylayout.compose
 import androidx.compose.runtime.Composable
 import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.protocol.compose.ProtocolBridge
-import app.cash.redwood.treehouse.TreehouseUi
-import app.cash.redwood.treehouse.ZiplineTreehouseUi
-import app.cash.redwood.treehouse.asZiplineTreehouseUi
-import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
 
 @Composable
 public fun ProtocolBridge.LazyColumn(content: LazyListScope.() -> Unit) {
   val widgetVersion = LocalWidgetVersion.current
-  val scope = TreehouseLazyListScope(this, widgetVersion)
+  val scope = LazyListIntervalContent(this, widgetVersion)
   content(scope)
   LazyColumn(scope.intervals)
-}
-
-private class TreehouseLazyListScope(
-  private val provider: ProtocolBridge,
-  private val widgetVersion: UInt,
-) : LazyListScope {
-  val intervals = mutableListOf<LazyListIntervalContent>()
-
-  private class Item(
-    private val provider: ProtocolBridge,
-    private val widgetVersion: UInt,
-    private val content: @Composable (index: Int) -> Unit,
-  ) : LazyListIntervalContent.Item {
-
-    override fun get(index: Int): ZiplineTreehouseUi {
-      val treehouseUi = IndexedTreehouseUi(content, index)
-      return treehouseUi.asZiplineTreehouseUi(provider, widgetVersion)
-    }
-  }
-
-  override fun items(
-    count: Int,
-    itemContent: @Composable (index: Int) -> Unit,
-  ) {
-    intervals += LazyListIntervalContent(
-      count,
-      itemProvider = Item(provider, widgetVersion, itemContent),
-    )
-  }
-
-  override fun item(content: @Composable () -> Unit) {
-    intervals += LazyListIntervalContent(
-      1,
-      Item(provider, widgetVersion) { content() },
-    )
-  }
-}
-
-private class IndexedTreehouseUi(
-  private val content: @Composable (index: Int) -> Unit,
-  private val index: Int,
-) : TreehouseUi {
-  @Composable
-  override fun Show() {
-    content(index)
-  }
 }

--- a/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyColumn.kt
@@ -31,18 +31,18 @@ import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.composeui.TreehouseContent
-import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
+import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 
 internal class ComposeUiLazyColumn<A : AppService>(
   treehouseApp: TreehouseApp<A>,
   widgetSystem: WidgetSystem,
 ) : LazyColumn<@Composable () -> Unit> {
-  private var intervals by mutableStateOf<List<LazyListIntervalContent>>(emptyList())
+  private var intervals by mutableStateOf<List<LazyListInterval>>(emptyList())
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
 
-  override fun intervals(intervals: List<LazyListIntervalContent>) {
+  override fun intervals(intervals: List<LazyListInterval>) {
     this.intervals = intervals
   }
 

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyColumn.kt
@@ -23,7 +23,7 @@ import app.cash.redwood.treehouse.TreehouseUIKitView
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.redwood.treehouse.bindWhenReady
-import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
+import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import platform.Foundation.NSIndexPath
 import platform.QuartzCore.CALayer
@@ -45,7 +45,7 @@ internal class UIViewLazyColumn<A : AppService>(
     this.dataSource = this@UIViewLazyColumn.dataSource
   }
 
-  override fun intervals(intervals: List<LazyListIntervalContent>) {
+  override fun intervals(intervals: List<LazyListInterval>) {
     dataSource.intervals = intervals
     root.reloadData()
   }
@@ -59,7 +59,7 @@ private class TableViewDataSource<A : AppService>(
   private val treehouseApp: TreehouseApp<A>,
   private val widgetSystem: WidgetSystem,
 ) : UITableViewDiffableDataSource() {
-  var intervals = emptyList<LazyListIntervalContent>()
+  var intervals = emptyList<LazyListInterval>()
 
   override fun numberOfSectionsInTableView(tableView: UITableView): NSInteger {
     return intervals.size.toLong()
@@ -81,7 +81,7 @@ private class TableViewDataSource<A : AppService>(
 }
 
 private class CellContentSource<A : AppService>(
-  private val itemProvider: LazyListIntervalContent.Item,
+  private val itemProvider: LazyListInterval.Item,
   private val index: Int,
 ) : TreehouseContentSource<A> {
 

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyColumn.kt
@@ -37,7 +37,7 @@ import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.TreehouseWidgetView
-import app.cash.redwood.treehouse.lazylayout.api.LazyListIntervalContent
+import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
 import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -73,7 +73,7 @@ internal class ViewLazyColumn<A : AppService>(
     )
   }
 
-  override fun intervals(intervals: List<LazyListIntervalContent>) {
+  override fun intervals(intervals: List<LazyListInterval>) {
     // TODO Don't hardcode pageSizes
     // TODO Enable placeholder support
     // TODO Set a maxSize so we don't keep _too_ many views in memory
@@ -89,14 +89,14 @@ internal class ViewLazyColumn<A : AppService>(
 
   private class ItemPagingSource<A : AppService>(
     private val treehouseApp: TreehouseApp<A>,
-    private val intervals: List<LazyListIntervalContent>,
+    private val intervals: List<LazyListInterval>,
   ) : PagingSource<Int, Content>() {
 
     override suspend fun load(
       params: LoadParams<Int>,
     ): LoadResult<Int, Content> {
       val key = params.key ?: 0
-      val count = intervals.sumOf(LazyListIntervalContent::count)
+      val count = intervals.sumOf(LazyListInterval::count)
       val limit = when (params) {
         is LoadParams.Prepend<*> -> minOf(key, params.loadSize)
         else -> params.loadSize


### PR DESCRIPTION
Same reasoning as https://github.com/cashapp/redwood/pull/915. `TreehouseLazyColumn` is supposed to mimic that of [`LazyListIntervalContent`](https://github.com/androidx/androidx/blob/androidx-main/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/LazyListIntervalContent.kt).

In previous versions of Compose UI, what we called `LazyListIntervalContent` was also what they called `LazyListIntervalContent`. Recently, they renamed their version of `TreehouseLazyColumn` to `LazyListIntervalContent`, and renamed the original `LazyListIntervalContent` to `LazyListInterval`. It's confusing, and keeping the names aligned removes the confusion!