### PR TITLE
[WIP] Migrate to Dokkatoo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,16 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 buildscript {
   dependencies {
+    // TODO: find a way to get a kotlinx-serialization-json version that's compatible with the
+    //     kotlinx-serialization-core that Dokkatoo wants to use. Something is pinning this down
+    //     but unclear what.
+    classpath("org.jetbrains.kotlinx:kotlinx-serialization-core") {
+      version { strictly("1.1.0") }
+    }
+    classpath("org.jetbrains.kotlinx:kotlinx-serialization-json") {
+      version { strictly("1.1.0") }
+    }
+
     classpath libs.kotlin.gradlePlugin
     classpath libs.kotlin.serializationPlugin
     classpath libs.jetbrains.compose.gradlePlugin

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     classpath libs.androidGradlePlugin
     classpath libs.gradleMavenPublishPlugin
     classpath libs.dokkaPlugin
+    classpath libs.dokkatooPlugin
     classpath libs.spotlessPlugin
     classpath libs.buildConfigPlugin
     classpath libs.zipline.gradlePlugin
@@ -117,6 +118,15 @@ allprojects {
   tasks.withType(org.jetbrains.dokka.gradle.DokkaTaskPartial) {
     dokkaSourceSets.configureEach {
       suppressGeneratedFiles.set(false) // document generated code
+    }
+  }
+
+  plugins.withId('dev.adamko.dokkatoo-html') {
+    dokkatoo {
+      // TODO: remove this once we remove the Dokka plugin
+      dokkatooPublicationDirectory.set(layout.buildDirectory.dir("dokkatoo"))
+
+      // TODO: work out if we need to customize anything here
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,9 @@ allprojects {
       // TODO: remove this once we remove the Dokka plugin
       dokkatooPublicationDirectory.set(layout.buildDirectory.dir("dokkatoo"))
 
-      // TODO: work out if we need to customize anything here
+      dokkatooSourceSets.configureEach {
+        suppressGeneratedFiles.set(false) // document generated code
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ buildscript {
     mavenCentral()
     google()
     gradlePluginPortal()
+    // FIXME: Remove this before landing
+    maven { url 'https://raw.githubusercontent.com/adamko-dev/dokkatoo/artifacts/m2' }
   }
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'dev.adamko.dokkatoo-html'
+
+dependencies {
+  rootProject.subprojects.each {
+    if (it.name == name) return
+    evaluationDependsOn(it.path)
+
+    // Each submodule needs to have the dokkatoo plugin applied
+    if (!it.plugins.hasPlugin('dev.adamko.dokkatoo-html')) return
+
+    // FIXME: remove this before landing
+    println("Adding dokkatoo to: ${it.path}")
+
+    dokkatoo(project(it.path))
+  }
+
+  // TODO: check if we need this
+  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin:1.8.10")
+  dokkatooPluginHtml("org.jetbrains.dokka:templating-plugin:1.8.10")
+}

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -16,6 +16,10 @@
 
 apply plugin: 'dev.adamko.dokkatoo-html'
 
+dokkatoo {
+  moduleName.set("Redwood")
+}
+
 dependencies {
   rootProject.subprojects.each {
     if (it.name == name) return
@@ -26,4 +30,8 @@ dependencies {
 
     dokkatoo(project(it.path))
   }
+
+  // Need to manually depend on this due to https://github.com/adamko-dev/dokkatoo/issues/14
+  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin:1.8.10")
+  dokkatooPluginHtml("org.jetbrains.dokka:templating-plugin:1.8.10")
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -24,13 +24,6 @@ dependencies {
     // Each submodule needs to have the dokkatoo plugin applied
     if (!it.plugins.hasPlugin('dev.adamko.dokkatoo-html')) return
 
-    // FIXME: remove this before landing
-    println("Adding dokkatoo to: ${it.path}")
-
     dokkatoo(project(it.path))
   }
-
-  // TODO: check if we need this
-  dokkatooPluginHtml("org.jetbrains.dokka:all-modules-page-plugin:1.8.10")
-  dokkatooPluginHtml("org.jetbrains.dokka:templating-plugin:1.8.10")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jbCompose = "1.4.0"
 lint = "31.0.0"
 zipline = "0.9.18"
 coil = "2.3.0"
+dokka = "1.8.10"
 
 [libraries]
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
@@ -25,7 +26,8 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 
 xmlutil-serialization = 'io.github.pdvrieze.xmlutil:serialization:0.85.0'
 
-dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.8.10"
+dokkatooPlugin = "dev.adamko.dokkatoo:dokkatoo-plugin:1.2.0"
+dokkaPlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 spotlessPlugin = "com.diffplug.spotless:spotless-plugin-gradle:6.18.0"
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.25.2"
 buildConfigPlugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 
 xmlutil-serialization = 'io.github.pdvrieze.xmlutil:serialization:0.85.0'
 
-dokkatooPlugin = "dev.adamko.dokkatoo:dokkatoo-plugin:1.2.0"
+dokkatooPlugin = "dev.adamko.dokkatoo:dokkatoo-plugin:1.2.1-SNAPSHOT"
 dokkaPlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 spotlessPlugin = "com.diffplug.spotless:spotless-plugin-gradle:6.18.0"
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.25.2"

--- a/redwood-compose-testing/build.gradle
+++ b/redwood-compose-testing/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-flexbox/build.gradle
+++ b/redwood-flexbox/build.gradle
@@ -3,6 +3,7 @@ import app.cash.redwood.buildsupport.KmpTargets
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-layout-api/build.gradle
+++ b/redwood-layout-api/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-layout-compose/build.gradle
+++ b/redwood-layout-compose/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.compose'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-layout-composeui/build.gradle
+++ b/redwood-layout-composeui/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'app.cash.paparazzi'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-layout-dom/build.gradle
+++ b/redwood-layout-dom/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.jetbrains.kotlin.js'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   js {

--- a/redwood-layout-layoutmodifiers/build.gradle
+++ b/redwood-layout-layoutmodifiers/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.layoutmodifiers'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-layout-schema/build.gradle
+++ b/redwood-layout-schema/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.schema'
 
 dependencies {

--- a/redwood-layout-testing/build.gradle
+++ b/redwood-layout-testing/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.testing'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-layout-uiview/build.gradle
+++ b/redwood-layout-uiview/build.gradle
@@ -3,6 +3,7 @@ import app.cash.redwood.buildsupport.FlexboxHelpers
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   iosArm64()

--- a/redwood-layout-view/build.gradle
+++ b/redwood-layout-view/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'app.cash.paparazzi'
 apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 dependencies {

--- a/redwood-layout-view/build.gradle
+++ b/redwood-layout-view/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'app.cash.paparazzi'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 dependencies {
   api projects.redwoodLayoutWidget

--- a/redwood-layout-widget/build.gradle
+++ b/redwood-layout-widget/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.widget'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-protocol-compose/build.gradle
+++ b/redwood-protocol-compose/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-protocol-widget/build.gradle
+++ b/redwood-protocol-widget/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-protocol/build.gradle
+++ b/redwood-protocol/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-runtime/build.gradle
+++ b/redwood-runtime/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-treehouse-composeui-insets/build.gradle
+++ b/redwood-treehouse-composeui-insets/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.build.compose'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   android {

--- a/redwood-treehouse-composeui/build.gradle
+++ b/redwood-treehouse-composeui/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.build.compose'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   android {

--- a/redwood-treehouse-configuration/build.gradle
+++ b/redwood-treehouse-configuration/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-treehouse-guest-compose/build.gradle
+++ b/redwood-treehouse-guest-compose/build.gradle
@@ -3,6 +3,7 @@ import app.cash.redwood.buildsupport.KmpTargets
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-treehouse-guest/build.gradle
+++ b/redwood-treehouse-guest/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.zipline'
 
 kotlin {

--- a/redwood-treehouse-host/build.gradle
+++ b/redwood-treehouse-host/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.zipline'
 
 kotlin {

--- a/redwood-treehouse-lazylayout-api/build.gradle
+++ b/redwood-treehouse-lazylayout-api/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'app.cash.zipline'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-treehouse-lazylayout-compose/build.gradle
+++ b/redwood-treehouse-lazylayout-compose/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.compose'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-treehouse-lazylayout-composeui/build.gradle
+++ b/redwood-treehouse-lazylayout-composeui/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-treehouse-lazylayout-paging/build.gradle
+++ b/redwood-treehouse-lazylayout-paging/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.build.compose'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   js {

--- a/redwood-treehouse-lazylayout-schema/build.gradle
+++ b/redwood-treehouse-lazylayout-schema/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.schema'
 
 dependencies {

--- a/redwood-treehouse-lazylayout-testing/build.gradle
+++ b/redwood-treehouse-lazylayout-testing/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.testing'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-treehouse-lazylayout-uiview/build.gradle
+++ b/redwood-treehouse-lazylayout-uiview/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   iosArm64()

--- a/redwood-treehouse-lazylayout-view/build.gradle
+++ b/redwood-treehouse-lazylayout-view/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 dependencies {
   api projects.redwoodTreehouseHost

--- a/redwood-treehouse-lazylayout-widget/build.gradle
+++ b/redwood-treehouse-lazylayout-widget/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.widget'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/redwood-treehouse/build.gradle
+++ b/redwood-treehouse/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.zipline'
 
 kotlin {

--- a/redwood-widget-compose/build.gradle
+++ b/redwood-widget-compose/build.gradle
@@ -4,6 +4,7 @@ import app.cash.redwood.buildsupport.KmpTargets
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 apply plugin: 'app.cash.redwood.build.compose'
 
 kotlin {

--- a/redwood-widget/build.gradle
+++ b/redwood-widget/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'dev.adamko.dokkatoo-html' // Must be applied here for publish plugin.
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,8 @@ include ':redwood-treehouse-lazylayout-widget'
 include ':redwood-widget'
 include ':redwood-widget-compose'
 
+include ':docs'
+
 include ':test-schema'
 include ':test-schema:compose'
 include ':test-schema:compose:protocol'


### PR DESCRIPTION
- [x] The way to aggregate docs from submodules looks [very explicit](https://github.com/adamko-dev/dokkatoo#combining-subprojects). Might be able to generate this in Gradle somehow.
- [ ] `com.vanniktech:gradle-maven-publish-plugin` has specific support for Dokka itself, so that will need resolving before we can land this.
- [ ] Verify the output of Dokka plugin vs Dokkatoo

Looks like this is blocked by https://github.com/adamko-dev/dokkatoo/issues/57

Closes #933
