### PR TITLE
Use correct env var convention for signing key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
         run: ./gradlew publish dokkaHtmlMultiModule browserProductionWebpack --parallel
 
       - name: Extract release notes

--- a/build.gradle
+++ b/build.gradle
@@ -211,14 +211,6 @@ allprojects {
     }
   }
 
-  plugins.withId('signing') {
-    signing {
-      def signingKey = findProperty('signingKey')
-      def signingPassword = ''
-      useInMemoryPgpKeys(signingKey, signingPassword)
-    }
-  }
-
   apply plugin: 'com.diffplug.spotless'
   spotless {
     kotlin {


### PR DESCRIPTION
This eliminates the need to manually bind it in build script.

Successfully used already on Molecule, Turbine, others.