### PR TITLE
Write the schema version to JSON

### DIFF
--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaClasses.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaClasses.kt
@@ -21,6 +21,8 @@ import app.cash.redwood.tooling.schema.ProtocolWidget.ProtocolChildren
 import app.cash.redwood.tooling.schema.ProtocolWidget.ProtocolEvent
 import app.cash.redwood.tooling.schema.ProtocolWidget.ProtocolProperty
 import app.cash.redwood.tooling.schema.ProtocolWidget.ProtocolTrait
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode.ALWAYS
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -35,12 +37,21 @@ internal data class ParsedProtocolSchemaSet(
 
 @Serializable
 internal data class ParsedProtocolSchema(
+  /** The format version of this JSON. */
+  @EncodeDefault(ALWAYS)
+  val version: Int = 1,
   override val type: FqType,
   override val scopes: List<FqType> = emptyList(),
   override val widgets: List<ParsedProtocolWidget> = emptyList(),
   override val layoutModifiers: List<ParsedProtocolLayoutModifier> = emptyList(),
   override val dependencies: List<FqType> = emptyList(),
 ) : ProtocolSchema {
+  init {
+    require(version == 1) {
+      "Only version 1 is supported"
+    }
+  }
+
   override fun toEmbeddedSchema(): EmbeddedSchema {
     return EmbeddedSchema(
       path = type.names[0].replace('.', '/') + "/" + type.names.drop(1).joinToString(".") + ".json",

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
@@ -169,11 +169,11 @@ public fun parseProtocolSchema(schemaType: KClass<*>, tag: Int = 0): ProtocolSch
     }
 
   val schema = ParsedProtocolSchema(
-    schemaType.toFqType(),
-    scopes.toList(),
-    widgets,
-    layoutModifiers,
-    dependencies.map { it.type },
+    type = schemaType.toFqType(),
+    scopes = scopes.toList(),
+    widgets = widgets,
+    layoutModifiers = layoutModifiers,
+    dependencies = dependencies.map { it.type },
   )
   val schemaSet = ParsedProtocolSchemaSet(
     schema,

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaJsonTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaJsonTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.tooling.schema
+
+import app.cash.redwood.schema.Schema
+import app.cash.redwood.schema.Widget
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SchemaJsonTest {
+  @Schema(
+    members = [
+      MyWidget::class,
+    ],
+  )
+  interface MySchema
+
+  @Widget(1)
+  object MyWidget
+
+  @Test fun pathReflectsFqcn() {
+    val embeddedSchema = parseSchema(MySchema::class).schema.toEmbeddedSchema()
+    assertThat(embeddedSchema.path).isEqualTo("app/cash/redwood/tooling/schema/SchemaJsonTest.MySchema.json")
+  }
+
+  @Test fun versioned() {
+    val embeddedSchema = parseSchema(MySchema::class).schema.toEmbeddedSchema()
+    assertThat(embeddedSchema.json).contains(""""version": 1,""")
+  }
+}


### PR DESCRIPTION
This will allow us to quickly reject or parse old versions in the future, if there ever are any future versions.