### PR TITLE
Move layout modifiers into 'modifier' package

### DIFF
--- a/build-support/src/main/resources/app/cash/redwood/buildsupport/flexboxHelpers.kt
+++ b/build-support/src/main/resources/app/cash/redwood/buildsupport/flexboxHelpers.kt
@@ -27,15 +27,15 @@ import app.cash.redwood.flexbox.Measurable
 import app.cash.redwood.flexbox.Spacing
 import app.cash.redwood.flexbox.isHorizontal
 import app.cash.redwood.flexbox.isVertical
-import app.cash.redwood.layout.Grow as GrowModifier
-import app.cash.redwood.layout.HorizontalAlignment as HorizontalAlignmentModifier
-import app.cash.redwood.layout.Margin as MarginModifier
-import app.cash.redwood.layout.Shrink as ShrinkModifier
-import app.cash.redwood.layout.VerticalAlignment as VerticalAlignmentModifier
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.Density
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Margin
+import app.cash.redwood.layout.modifier.Grow as GrowModifier
+import app.cash.redwood.layout.modifier.HorizontalAlignment as HorizontalAlignmentModifier
+import app.cash.redwood.layout.modifier.Margin as MarginModifier
+import app.cash.redwood.layout.modifier.Shrink as ShrinkModifier
+import app.cash.redwood.layout.modifier.VerticalAlignment as VerticalAlignmentModifier
 
 internal fun MainAxisAlignment.toJustifyContent() = when (this) {
   MainAxisAlignment.Start -> JustifyContent.FlexStart

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -23,6 +23,8 @@ import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.Margin
 import app.cash.redwood.layout.api.dp
+import app.cash.redwood.layout.modifier.HorizontalAlignment
+import app.cash.redwood.layout.modifier.VerticalAlignment
 import app.cash.redwood.widget.Widget
 import org.junit.Test
 

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -131,7 +131,7 @@ internal fun Schema.widgetPackage(host: Schema? = null): String {
 }
 
 internal fun Schema.layoutModifierType(layoutModifier: LayoutModifier): ClassName {
-  return ClassName(type.names[0], layoutModifier.type.flatName)
+  return ClassName(type.names[0] + ".modifier", layoutModifier.type.flatName)
 }
 
 internal fun Schema.layoutModifierSerializer(layoutModifier: LayoutModifier, host: Schema): ClassName {


### PR DESCRIPTION
This sits as a sibling to 'compose' and 'widget' rather than using the base package which is commonly used for the schema and potentially common types.

Unblocks #939 