### PR TITLE
Make ProtocolBridge an argument of LazyColumn

### DIFF
--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/TreehouseLazyColumn.kt
@@ -20,9 +20,9 @@ import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.protocol.compose.ProtocolBridge
 
 @Composable
-public fun ProtocolBridge.LazyColumn(content: LazyListScope.() -> Unit) {
+public fun LazyColumn(bridge: ProtocolBridge, content: LazyListScope.() -> Unit) {
   val widgetVersion = LocalWidgetVersion.current
-  val scope = LazyListIntervalContent(this, widgetVersion)
+  val scope = LazyListIntervalContent(bridge, widgetVersion)
   content(scope)
   LazyColumn(scope.intervals)
 }

--- a/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
+++ b/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
@@ -40,8 +40,8 @@ private class LazyColumnProvider(
   override fun <T> create(
     items: List<T>,
     itemContent: @Composable (item: T) -> Unit,
-  ) = with(bridge) {
-    LazyColumn {
+  ) {
+    LazyColumn(bridge) {
       items(items, itemContent)
     }
   }


### PR DESCRIPTION
I've footgunned myself countless times thinking that `LazyColumn` wasn't imported properly, but it just ended up being that the `ProtocolBridge` receiver wasn't within the current scope.

The initial reason for `ProtocolBridge` being a receiver instead of an argument was for the API of `LazyColumn` to be as similar to that of Compose UI's implementation as possible. I think the (debatable) upside of that is far outweighed by the annonyingness of having to remember that `ProcolBridge` has to be within the scope — seemingly without reason.