### PR TITLE
Add support for `LazyRow`

### DIFF
--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.treehouse.lazylayout.compose
 
 import androidx.compose.runtime.Composable
 import app.cash.redwood.LayoutScopeMarker
+import app.cash.redwood.protocol.compose.ProtocolBridge
 
 @LayoutScopeMarker
 public interface LazyListScope {
@@ -64,4 +65,28 @@ public inline fun <T> LazyListScope.itemsIndexed(
   count = items.size,
 ) {
   itemContent(it, items[it])
+}
+
+@Composable
+public fun LazyRow(
+  bridge: ProtocolBridge,
+  content: LazyListScope.() -> Unit,
+) {
+  LazyList(
+    bridge = bridge,
+    isVertical = false,
+    content = content,
+  )
+}
+
+@Composable
+public fun LazyColumn(
+  bridge: ProtocolBridge,
+  content: LazyListScope.() -> Unit,
+) {
+  LazyList(
+    bridge = bridge,
+    isVertical = true,
+    content = content,
+  )
 }

--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyList.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyList.kt
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("LazyList") // Conflicts with generated LazyList compose widget
+
 package app.cash.redwood.treehouse.lazylayout.compose
 
 import androidx.compose.runtime.Composable
 import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.protocol.compose.ProtocolBridge
+import kotlin.jvm.JvmName
 
 @Composable
-public fun LazyColumn(bridge: ProtocolBridge, content: LazyListScope.() -> Unit) {
+internal fun LazyList(
+  bridge: ProtocolBridge,
+  isVertical: Boolean,
+  content: LazyListScope.() -> Unit,
+) {
   val widgetVersion = LocalWidgetVersion.current
   val scope = LazyListIntervalContent(bridge, widgetVersion)
   content(scope)
-  LazyColumn(scope.intervals)
+  LazyList(isVertical, scope.intervals)
 }

--- a/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -19,12 +19,12 @@ import androidx.compose.runtime.Composable
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
-import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
+import app.cash.redwood.treehouse.lazylayout.widget.LazyList
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 
 public class ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory<A : AppService>(
   private val treehouseApp: TreehouseApp<A>,
   private val widgetSystem: WidgetSystem,
 ) : RedwoodTreehouseLazyLayoutWidgetFactory<@Composable () -> Unit> {
-  override fun LazyColumn(): LazyColumn<@Composable () -> Unit> = ComposeUiLazyColumn(treehouseApp, widgetSystem)
+  override fun LazyList(): LazyList<@Composable () -> Unit> = ComposeUiLazyList(treehouseApp, widgetSystem)
 }

--- a/redwood-treehouse-lazylayout-schema/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/schema.kt
+++ b/redwood-treehouse-lazylayout-schema/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/schema.kt
@@ -19,7 +19,7 @@ import app.cash.redwood.schema.Schema
 
 @Schema(
   [
-    LazyColumn::class,
+    LazyList::class,
   ],
 )
 public interface RedwoodTreehouseLazyLayout

--- a/redwood-treehouse-lazylayout-schema/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/widgets.kt
+++ b/redwood-treehouse-lazylayout-schema/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/widgets.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.schema.Widget
 import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
 
 @Widget(1)
-public data class LazyColumn(
-  @Property(1) val intervals: List<LazyListInterval>,
+public data class LazyList(
+  @Property(1) val isVertical: Boolean,
+  @Property(2) val intervals: List<LazyListInterval>,
 )

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyList.kt
@@ -24,7 +24,7 @@ import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.ZiplineTreehouseUi
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
-import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
+import app.cash.redwood.treehouse.lazylayout.widget.LazyList
 import platform.Foundation.NSIndexPath
 import platform.QuartzCore.CALayer
 import platform.UIKit.UITableView
@@ -36,13 +36,20 @@ import platform.UIKit.row
 import platform.UIKit.section
 import platform.darwin.NSInteger
 
-internal class UIViewLazyColumn<A : AppService>(
+internal class UIViewLazyList<A : AppService>(
   treehouseApp: TreehouseApp<A>,
   widgetSystem: WidgetSystem,
-) : LazyColumn<UIView> {
+) : LazyList<UIView> {
   private val dataSource = TableViewDataSource(treehouseApp, widgetSystem)
   private val root = UITableView().apply {
-    this.dataSource = this@UIViewLazyColumn.dataSource
+    this.dataSource = this@UIViewLazyList.dataSource
+  }
+
+  override fun isVertical(isVertical: Boolean) {
+    if (!isVertical) {
+      // TODO UITableView only supports vertical scrolling. Switch to UICollectionView.
+      TODO()
+    }
   }
 
   override fun intervals(intervals: List<LazyListInterval>) {

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
@@ -18,7 +18,7 @@ package app.cash.redwood.treehouse.lazylayout.uiview
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
-import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
+import app.cash.redwood.treehouse.lazylayout.widget.LazyList
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 import platform.UIKit.UIView
 
@@ -27,5 +27,5 @@ public class UIViewRedwoodTreehouseLazyLayoutWidgetFactory<A : AppService>(
   private var treehouseApp: TreehouseApp<A>,
   private var widgetSystem: WidgetSystem,
 ) : RedwoodTreehouseLazyLayoutWidgetFactory<UIView> {
-  override fun LazyColumn(): LazyColumn<UIView> = UIViewLazyColumn(treehouseApp, widgetSystem)
+  override fun LazyList(): LazyList<UIView> = UIViewLazyList(treehouseApp, widgetSystem)
 }

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyList.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyList.kt
@@ -38,26 +38,27 @@ import app.cash.redwood.treehouse.TreehouseContentSource
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.TreehouseWidgetView
 import app.cash.redwood.treehouse.lazylayout.api.LazyListInterval
-import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
+import app.cash.redwood.treehouse.lazylayout.widget.LazyList
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-internal class ViewLazyColumn<A : AppService>(
+internal class ViewLazyList<A : AppService>(
   private val treehouseApp: TreehouseApp<A>,
   widgetSystem: WidgetSystem,
   override val value: RecyclerView,
-) : LazyColumn<View> {
+) : LazyList<View> {
   private val scope = MainScope()
 
   override var layoutModifiers: LayoutModifier = LayoutModifier
 
+  private val linearLayoutManager = LinearLayoutManager(value.context)
   private val adapter = LazyContentItemListAdapter(widgetSystem)
 
   init {
     value.apply {
-      layoutManager = LinearLayoutManager(value.context)
+      layoutManager = linearLayoutManager
       layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
     }
     value.adapter = adapter
@@ -71,6 +72,10 @@ internal class ViewLazyColumn<A : AppService>(
         }
       },
     )
+  }
+
+  override fun isVertical(isVertical: Boolean) {
+    linearLayoutManager.orientation = if (isVertical) RecyclerView.VERTICAL else RecyclerView.HORIZONTAL
   }
 
   override fun intervals(intervals: List<LazyListInterval>) {

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -21,7 +21,7 @@ import androidx.recyclerview.widget.RecyclerView
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
-import app.cash.redwood.treehouse.lazylayout.widget.LazyColumn
+import app.cash.redwood.treehouse.lazylayout.widget.LazyList
 import app.cash.redwood.treehouse.lazylayout.widget.RedwoodTreehouseLazyLayoutWidgetFactory
 
 public class ViewRedwoodTreehouseLazyLayoutWidgetFactory<A : AppService>(
@@ -29,5 +29,5 @@ public class ViewRedwoodTreehouseLazyLayoutWidgetFactory<A : AppService>(
   private val treehouseApp: TreehouseApp<A>,
   private val widgetSystem: WidgetSystem,
 ) : RedwoodTreehouseLazyLayoutWidgetFactory<View> {
-  public override fun LazyColumn(): LazyColumn<View> = ViewLazyColumn(treehouseApp, widgetSystem, RecyclerView(context))
+  public override fun LazyList(): LazyList<View> = ViewLazyList(treehouseApp, widgetSystem, RecyclerView(context))
 }

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -49,7 +49,7 @@ fun main() {
       RedwoodLayout = HTMLElementRedwoodLayoutWidgetFactory(document),
       RedwoodTreehouseLazyLayout = object : RedwoodTreehouseLazyLayoutWidgetFactory<HTMLElement> {
         // For now we use a ColumnProvider to replace this with a normal Column.
-        override fun LazyColumn() = throw UnsupportedOperationException()
+        override fun LazyList() = throw UnsupportedOperationException()
       },
     ),
   )


### PR DESCRIPTION
Much of this mimics that of Compose UI as much as possible (e.g., file names, the use of `isVertical`).

I've also renamed our GitHub tab from `redwood/lazycolumn` to `redwood/lazylist`, as there are almost zero differences between `LazyColumn` and `LazyRow`, and any issues with either one probably means the other one also has such an issue.