### PR TITLE
Read schema dependency information from their JSON

### DIFF
--- a/redwood-tooling-schema/build.gradle
+++ b/redwood-tooling-schema/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   api libs.kotlin.reflect
   implementation libs.kotlinx.serialization.json
 
+  testImplementation projects.testSchema
   testImplementation libs.junit
   testImplementation libs.truth
 }

--- a/test-schema/build.gradle
+++ b/test-schema/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.redwood.schema'
 
 dependencies {
-  implementation projects.redwoodLayoutSchema
+  api projects.redwoodLayoutSchema
 }
 
 redwoodSchema {


### PR DESCRIPTION
We no longer do any reflection on dependent schemas which will allow switching the parsing to use PSI in the future.

Refs #19