### PR TITLE
Split schema JSON from general code generation

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/cli/main.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/cli/main.kt
@@ -26,6 +26,7 @@ public fun main(vararg args: String) {
     .subcommands(
       ApiMergeCommand(FileSystems.getDefault()),
       GenerateCommand(),
+      JsonCommand(),
       LintCommand(),
     )
     .main(args)

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaPlugin.kt
@@ -52,13 +52,12 @@ public class RedwoodSchemaPlugin : Plugin<Project> {
     val compilation = kotlin.target.compilations.getByName(MAIN_COMPILATION_NAME)
     val classpath = project.configurations.getByName(compilation.compileDependencyConfigurationName)
 
-    val generate = project.tasks.register("redwoodGenerate", RedwoodGeneratorTask::class.java) {
+    val generate = project.tasks.register("redwoodGenerate", RedwoodSchemaTask::class.java) {
       it.group = LifecycleBasePlugin.BUILD_GROUP
       it.description = "Generate parsed schema JSON"
 
       it.toolClasspath.from(cliConfiguration)
       it.outputDir.set(project.layout.buildDirectory.dir("generated/redwood"))
-      it.generatorFlag.set("--json")
       it.schemaType.set(extension.type)
       it.classpath.from(classpath, compilation.output.classesDirs)
     }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaTask.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaTask.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.gradle
+
+import java.io.File
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+
+@CacheableTask
+internal abstract class RedwoodSchemaTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+  @get:Classpath
+  abstract val toolClasspath: ConfigurableFileCollection
+
+  @get:Classpath
+  abstract val classpath: ConfigurableFileCollection
+
+  @get:Input
+  abstract val schemaType: Property<String>
+
+  @get:OutputDirectory
+  abstract val outputDir: DirectoryProperty
+
+  @TaskAction
+  fun run() {
+    val queue = workerExecutor.noIsolation()
+    queue.submit(RedwoodSchemaWorker::class.java) {
+      it.toolClasspath.from(toolClasspath)
+      it.classpath.setFrom(classpath)
+      it.schemaType.set(schemaType)
+      it.outputDir.set(outputDir)
+    }
+  }
+}
+
+private interface RedwoodSchemaParameters : WorkParameters {
+  val toolClasspath: ConfigurableFileCollection
+  val classpath: ConfigurableFileCollection
+  val schemaType: Property<String>
+  val outputDir: DirectoryProperty
+}
+
+private abstract class RedwoodSchemaWorker @Inject constructor(
+  private val execOperations: ExecOperations,
+) : WorkAction<RedwoodSchemaParameters> {
+  override fun execute() {
+    parameters.outputDir.get().asFile.deleteRecursively()
+
+    execOperations.javaexec { exec ->
+      exec.classpath = parameters.toolClasspath
+      exec.mainClass.set("app.cash.redwood.cli.Main")
+
+      exec.args = listOf(
+        "json",
+        "--out",
+        parameters.outputDir.get().asFile.absolutePath,
+        "--class-path",
+        parameters.classpath.files.joinToString(File.pathSeparator),
+        parameters.schemaType.get(),
+      )
+    }
+  }
+}

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
@@ -16,16 +16,12 @@
 package app.cash.redwood.tooling.codegen
 
 import app.cash.redwood.tooling.codegen.ProtocolCodegenType.Compose
-import app.cash.redwood.tooling.codegen.ProtocolCodegenType.Json
 import app.cash.redwood.tooling.codegen.ProtocolCodegenType.Widget
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
 import java.nio.file.Path
-import kotlin.io.path.createDirectories
-import kotlin.io.path.writeText
 
 public enum class ProtocolCodegenType {
   Compose,
-  Json,
   Widget,
 }
 
@@ -41,12 +37,6 @@ public fun ProtocolSchemaSet.generate(type: ProtocolCodegenType, destination: Pa
           generateProtocolWidget(dependency, widget, host = schema).writeTo(destination)
         }
       }
-    }
-    Json -> {
-      val embeddedSchema = schema.toEmbeddedSchema()
-      val path = destination.resolve(embeddedSchema.path)
-      path.parent.createDirectories()
-      path.writeText(embeddedSchema.json)
     }
     Widget -> {
       generateDiffConsumingNodeFactory(this).writeTo(destination)


### PR DESCRIPTION
The code generation is moving to only operate on loading JSON so as to become agnostic to how parsing happens. Parsing is, as we know, moving from reflection to PSI. This change create clean separation between the two (at least in the CLI and Gradle plugin).

Refs #19