### PR TITLE
Write dependency tags into JSON

### DIFF
--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schema.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schema.kt
@@ -129,6 +129,8 @@ public interface ProtocolSchemaSet : SchemaSet {
 public interface ProtocolSchema : Schema {
   override val widgets: List<ProtocolWidget>
   override val layoutModifiers: List<ProtocolLayoutModifier>
+  override val dependencies: List<FqType> get() = taggedDependencies.values.toList()
+  public val taggedDependencies: Map<Int, FqType>
 }
 
 public interface ProtocolWidget : Widget {

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaClasses.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaClasses.kt
@@ -44,7 +44,8 @@ internal data class ParsedProtocolSchema(
   override val scopes: List<FqType> = emptyList(),
   override val widgets: List<ParsedProtocolWidget> = emptyList(),
   override val layoutModifiers: List<ParsedProtocolLayoutModifier> = emptyList(),
-  override val dependencies: List<FqType> = emptyList(),
+  @SerialName("dependencies")
+  override val taggedDependencies: Map<Int, FqType> = emptyMap(),
 ) : ProtocolSchema {
   init {
     require(version == 1) {


### PR DESCRIPTION
We need this to rehydrate a full schema+dependencies solely from JSON.

JSON before:
```json
"dependencies": [
  {
    "names": [
      "app.cash.redwood.layout",
      "RedwoodLayout"
    ]
  }
]
```
JSON after:
```json
"dependencies": {
  "1": {
    "names": [
      "app.cash.redwood.layout",
      "RedwoodLayout"
    ]
  }
}
```