### PR TITLE
Fix implicit task dependency issue

### DIFF
--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintPlugin.kt
@@ -206,7 +206,7 @@ private fun Project.createRedwoodLintTask(
     task.description = taskDescription(descriptionTarget)
 
     task.toolClasspath.setFrom(configuration.incoming.artifacts.artifactFiles)
-    task.projectDirectory.set(project.projectDir)
+    task.projectDirectoryPath.set(project.projectDir.absolutePath)
     task.sourceDirectories.set(sourceDirs())
     task.classpath.setFrom(
       classpath().incoming.artifactView {


### PR DESCRIPTION
Redwood Lint can't use the project directory as a "directory" input as gradle considers all the contents of the directory to be inputs to the task. The "official" recommendation is to use a String input with the absolute path as the input.