### PR TITLE
Default to targeting Java 8, Lint-using things get 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,13 +47,6 @@ allprojects {
     outputs.upToDateWhen { false }
   }
 
-  plugins.withId('java-base') {
-    java {
-      sourceCompatibility = JavaVersion.VERSION_11
-      targetCompatibility = JavaVersion.VERSION_11
-    }
-  }
-
   plugins.withId('com.vanniktech.maven.publish') {
     mavenPublishing {
       publishToMavenCentral(SonatypeHost.DEFAULT)
@@ -103,6 +96,11 @@ allprojects {
         '-progressive', // https://kotlinlang.org/docs/whatsnew13.html#progressive-mode
       ])
     }
+  }
+
+  tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach {

--- a/redwood-cli/build.gradle
+++ b/redwood-cli/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.vanniktech.maven.publish'
@@ -6,6 +9,17 @@ apply plugin: 'application'
 application {
   applicationName = 'redwood'
   mainClass.set('app.cash.redwood.cli.Main')
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_11.toString()
+  targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+
+tasks.withType(KotlinJvmCompile).configureEach {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
+  }
 }
 
 dependencies {

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'com.github.gmazzo.buildconfig'
@@ -9,6 +12,17 @@ apply plugin: 'com.github.gmazzo.buildconfig'
 // We only want to publish when it's being built in the root project.
 if (rootProject.name == 'redwood') {
   apply plugin: 'com.vanniktech.maven.publish'
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_11.toString()
+  targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+
+tasks.withType(KotlinJvmCompile).configureEach {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
+  }
 }
 
 dependencies {


### PR DESCRIPTION
In Gradle 8 the old version skew would have failed the build.