### PR TITLE
Enable parallel and caching by default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: gradle/gradle-build-action@v2
 
-      - run: ./gradlew kotlinUpgradeYarnLock build dokkaHtmlMultiModule --parallel -PredwoodNoSamples
+      - run: ./gradlew kotlinUpgradeYarnLock build dokkaHtmlMultiModule -PredwoodNoSamples
 
       # If we're on the integration branch, save the site to deploy from the publish job.
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew publish dokkaHtmlMultiModule browserProductionWebpack --parallel
+        run: ./gradlew publish dokkaHtmlMultiModule browserProductionWebpack
 
       - name: Extract release notes
         id: release_notes

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,9 @@ kotlin.mpp.stability.nowarn=true
 # in their samples. Over time it should be removed once they figure out why it was needed.
 kotlin.native.cacheKind=none
 
+org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true
 
 android.useAndroidX=true
 android.enableJetifier=false


### PR DESCRIPTION
We previously avoided parallel since it broke releasing. But with the publish plugin now explicitly creating a Sonatype repository and using a build service to prevent concurrent uploads this is no longer a concern.