### PR TITLE
Fix layout and button click for iOS Counter sample

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -122,7 +122,7 @@ public class UIViewFlexContainer(
       } else if (direction.isVertical) {
         NSLayoutConstraint.activateConstraints(listOf(heightConstraint))
       } else {
-        //Unknown??
+      throw AssertionError()
       }
       super.didMoveToSuperview()
     }

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -16,7 +16,13 @@
 package app.cash.redwood.layout.uiview
 
 import app.cash.redwood.LayoutModifier
-import app.cash.redwood.flexbox.*
+import app.cash.redwood.flexbox.AlignItems
+import app.cash.redwood.flexbox.FlexContainer
+import app.cash.redwood.flexbox.FlexDirection
+import app.cash.redwood.flexbox.JustifyContent
+import app.cash.redwood.flexbox.Size
+import app.cash.redwood.flexbox.isHorizontal
+import app.cash.redwood.flexbox.isVertical
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.Default
@@ -113,16 +119,17 @@ public class UIViewFlexContainer(
     private var heightConstraint: NSLayoutConstraint? = null
 
     override fun didMoveToSuperview() {
-      if (superview == null) return
-      translatesAutoresizingMaskIntoConstraints = false
-      widthContraint = widthAnchor.constraintEqualToConstant(0.0)
-      heightConstraint = heightAnchor.constraintEqualToConstant(0.0)
-      if(direction.isHorizontal) {
-        NSLayoutConstraint.activateConstraints(listOf(widthContraint))
-      } else if (direction.isVertical) {
-        NSLayoutConstraint.activateConstraints(listOf(heightConstraint))
-      } else {
-      throw AssertionError()
+      if (superview != null) {
+        translatesAutoresizingMaskIntoConstraints = false
+        widthContraint = widthAnchor.constraintEqualToConstant(0.0)
+        heightConstraint = heightAnchor.constraintEqualToConstant(0.0)
+        if (direction.isHorizontal) {
+          NSLayoutConstraint.activateConstraints(listOf(widthContraint))
+        } else if (direction.isVertical) {
+          NSLayoutConstraint.activateConstraints(listOf(heightConstraint))
+        } else {
+          throw AssertionError()
+        }
       }
       super.didMoveToSuperview()
     }

--- a/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/IosButton.kt
+++ b/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/IosButton.kt
@@ -24,7 +24,7 @@ import platform.UIKit.UIControlStateNormal
 import platform.UIKit.UIView
 import platform.objc.sel_registerName
 
-internal class IosButton : Button<UIView> {
+class IosButton : Button<UIView> {
   override val value = UIButton()
 
   override var layoutModifiers: LayoutModifier = LayoutModifier


### PR DESCRIPTION
Fix? for #930 and #903 
![Screenshot 2023-04-21 at 9 19 31 pm](https://user-images.githubusercontent.com/304517/233628456-847083ee-cbe4-4f2e-b8f8-38ccb72755d7.png)


Specifically there are 2 main issues 
1. It seems that internal classes don't get Obj-c classes generated, so they can't be added to views or used as selectors for messages (ie, clicked). So I made the `FlexContainerHostView` and `IosButton` classes public for those reasons.
2. The UIStackView that contained the FlexContainerHostView has NSLayoutConstraints enabled, so the layoutSubviews needs to set the height constraints (or width depending on the direction).

I haven't done iOS dev in about 4 years so please review with caution. :)

Another alternative to implementing the constraints would have been to change the `CounterViewController`'s `container.alignment` to `.fill` which also disables layout constraints and just sets the height to the UIStackView's height. I guess the best alternative depends on the use case. 

There is another issue where the Counter text get's ellipsized when it's too wide, I'm not sure what's causing that though.
