### PR TITLE
Assign a string key to every single item in a LazyColumn

### DIFF
--- a/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/LazyListIntervalContent.kt
+++ b/redwood-treehouse-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/api/LazyListIntervalContent.kt
@@ -24,9 +24,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 @ObjCName("LazyListInterval", exact = true)
 public class LazyListInterval(
-  @Contextual public val count: Int,
+  public val keys: List<String>,
   @Contextual public val itemProvider: Item,
 ) {
+  public val count: Int = keys.size
 
   @ObjCName("LazyListIntervalItem", exact = true)
   public interface Item : ZiplineService {

--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyDsl.kt
@@ -22,47 +22,52 @@ import app.cash.redwood.treehouse.StandardAppLifecycle
 @LayoutScopeMarker
 public interface LazyListScope {
   public fun item(
+    key: String,
     content: @Composable () -> Unit,
   )
 
   public fun items(
-    count: Int,
+    keys: List<String>,
     itemContent: @Composable (index: Int) -> Unit,
   )
 }
 
 public inline fun <T> LazyListScope.items(
   items: List<T>,
+  itemToKey: (item: T) -> String,
   crossinline itemContent: @Composable (item: T) -> Unit,
 ): Unit = items(
-  count = items.size,
+  keys = items.map(itemToKey),
 ) {
   itemContent(items[it])
 }
 
 public inline fun <T> LazyListScope.itemsIndexed(
   items: List<T>,
+  itemToKey: (item: T) -> String,
   crossinline itemContent: @Composable (index: Int, item: T) -> Unit,
 ): Unit = items(
-  count = items.size,
+  keys = items.map(itemToKey),
 ) {
   itemContent(it, items[it])
 }
 
 public inline fun <T> LazyListScope.items(
   items: Array<T>,
+  itemToKey: (item: T) -> String,
   crossinline itemContent: @Composable (item: T) -> Unit,
 ): Unit = items(
-  count = items.size,
+  keys = items.map(itemToKey),
 ) {
   itemContent(items[it])
 }
 
 public inline fun <T> LazyListScope.itemsIndexed(
   items: Array<T>,
+  itemToKey: (item: T) -> String,
   crossinline itemContent: @Composable (index: Int, item: T) -> Unit,
 ): Unit = items(
-  count = items.size,
+  keys = items.map(itemToKey),
 ) {
   itemContent(it, items[it])
 }

--- a/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyListIntervalContent.kt
+++ b/redwood-treehouse-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/compose/LazyListIntervalContent.kt
@@ -39,18 +39,21 @@ internal class LazyListIntervalContent(
   }
 
   override fun items(
-    count: Int,
+    keys: List<String>,
     itemContent: @Composable (index: Int) -> Unit,
   ) {
     intervals += LazyListInterval(
-      count,
-      itemProvider = Item(appLifecycle, itemContent),
+      keys,
+      Item(appLifecycle, itemContent),
     )
   }
 
-  override fun item(content: @Composable () -> Unit) {
+  override fun item(
+    key: String,
+    content: @Composable () -> Unit,
+  ) {
     intervals += LazyListInterval(
-      1,
+      listOf(key),
       Item(appLifecycle) { content() },
     )
   }

--- a/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyList.kt
+++ b/redwood-treehouse-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/composeui/ComposeUiLazyList.kt
@@ -60,7 +60,7 @@ internal class ComposeUiLazyList<A : AppService>(
     val itemBoxModifier = if (isVertical) Modifier.height(64.dp) else Modifier.width(64.dp)
     val content: LazyListScope.() -> Unit = {
       intervals.forEach { interval ->
-        items(interval.count) { index ->
+        items(interval.keys.size) { index ->
           Box(itemBoxModifier) {
             TreehouseContent(treehouseApp, widgetSystem) { interval.itemProvider.get(index) }
           }

--- a/redwood-treehouse-lazylayout-paging/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/paging/LazyPagingItems.kt
+++ b/redwood-treehouse-lazylayout-paging/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/paging/LazyPagingItems.kt
@@ -31,11 +31,10 @@ import app.cash.redwood.treehouse.lazylayout.compose.LazyListScope
  */
 public fun <T : Any> LazyListScope.items(
   items: LazyPagingItems<T>,
+  itemToKey: (item: T?) -> String,
   itemContent: @Composable (value: T?) -> Unit,
 ) {
-  items(
-    count = items.itemCount,
-  ) { index ->
+  items(items.keys(itemToKey)) { index ->
     itemContent(items[index])
   }
 }
@@ -53,11 +52,19 @@ public fun <T : Any> LazyListScope.items(
  */
 public fun <T : Any> LazyListScope.itemsIndexed(
   items: LazyPagingItems<T>,
+  itemToKey: (item: T?) -> String,
   itemContent: @Composable (index: Int, value: T?) -> Unit,
 ) {
-  items(
-    count = items.itemCount,
-  ) { index ->
+  items(items.keys(itemToKey)) { index ->
     itemContent(index, items[index])
+  }
+}
+
+private fun <T : Any> LazyPagingItems<T>.keys(
+  itemToKey: (item: T?) -> String,
+): List<String> {
+  return List(itemCount) {
+    val item = this[it]
+    itemToKey(item)
   }
 }

--- a/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-treehouse-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/treehouse/lazylayout/uiview/UIViewLazyList.kt
@@ -73,7 +73,7 @@ private class TableViewDataSource<A : AppService>(
   }
 
   override fun tableView(tableView: UITableView, numberOfRowsInSection: NSInteger): NSInteger {
-    return intervals[numberOfRowsInSection.toInt()].count.toLong()
+    return intervals[numberOfRowsInSection.toInt()].keys.size.toLong()
   }
 
   override fun tableView(tableView: UITableView, cellForRowAtIndexPath: NSIndexPath): UITableViewCell {

--- a/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyList.kt
+++ b/redwood-treehouse-lazylayout-view/src/main/kotlin/app/cash/redwood/treehouse/lazylayout/view/ViewLazyList.kt
@@ -115,7 +115,7 @@ internal class ViewLazyList<A : AppService>(
         data = List(if (nextPosToLoad <= count) limit else count - offset) { index ->
           val (indexInInterval, interval) = findInterval(index + offset)
           val content = treehouseApp.createContent(
-            source = { interval.itemProvider.get(indexInInterval) }
+            source = { interval.itemProvider.get(indexInInterval) },
           )
           val keyAndContent = KeyAndContent(
             key = interval.keys[indexInInterval],

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -79,7 +79,7 @@ private object TruncatingColumnProvider : ColumnProvider {
   override fun <T> create(
     items: List<T>,
     itemToKey: (item: T) -> String,
-    itemContent: (item: T) -> Unit,
+    itemContent: @Composable (item: T) -> Unit,
   ) {
     Column {
       for (item in items.take(25)) {

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -78,7 +78,8 @@ private object TruncatingColumnProvider : ColumnProvider {
   @Composable
   override fun <T> create(
     items: List<T>,
-    itemContent: @Composable (item: T) -> Unit,
+    itemToKey: (item: T) -> String,
+    itemContent: (item: T) -> Unit,
   ) {
     Column {
       for (item in items.take(25)) {

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -106,7 +106,7 @@ fun EmojiSearch(
     )
     columnProvider.create(
       filteredEmojis,
-      itemToKey = { it.label }
+      itemToKey = { it.label },
     ) { image ->
       Row(
         width = Constraint.Fill,

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -57,6 +57,7 @@ interface ColumnProvider {
   @Composable
   fun <T> create(
     items: List<T>,
+    itemToKey: (item: T) -> String,
     itemContent: @Composable (item: T) -> Unit,
   )
 }
@@ -103,7 +104,10 @@ fun EmojiSearch(
       hint = "Search",
       onChange = { searchTerm = it },
     )
-    columnProvider.create(filteredEmojis) { image ->
+    columnProvider.create(
+      filteredEmojis,
+      itemToKey = { it.label }
+    ) { image ->
       Row(
         width = Constraint.Fill,
         verticalAlignment = CrossAxisAlignment.Center,

--- a/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
+++ b/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
@@ -39,10 +39,11 @@ private class LazyColumnProvider(
   @Composable
   override fun <T> create(
     items: List<T>,
+    itemToKey: (item: T) -> String,
     itemContent: @Composable (item: T) -> Unit,
   ) {
     LazyColumn(appLifecycle) {
-      items(items, itemContent)
+      items(items, itemToKey, itemContent)
     }
   }
 }

--- a/samples/repo-search/presenter/src/jsMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
+++ b/samples/repo-search/presenter/src/jsMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
@@ -50,7 +50,7 @@ class RepoSearchTreehouseUi(
     LazyColumn(appLifecycle) {
       items(
         items = lazyPagingItems,
-        itemToKey = { it!!.fullName }
+        itemToKey = { it!!.fullName },
       ) {
         RepoSearch(it!!)
       }

--- a/samples/repo-search/presenter/src/jsMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
+++ b/samples/repo-search/presenter/src/jsMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
@@ -48,7 +48,10 @@ class RepoSearchTreehouseUi(
   override fun Show() {
     val lazyPagingItems = pager.flow.collectAsLazyPagingItems()
     LazyColumn(appLifecycle) {
-      items(lazyPagingItems) {
+      items(
+        items = lazyPagingItems,
+        itemToKey = { it!!.fullName }
+      ) {
         RepoSearch(it!!)
       }
     }


### PR DESCRIPTION
This fixes issues with items being recreated repeatedly.

I don't like that we need to create lots of strings with this, but it's a simple fix that's likely to prove useful with other features like keeping scroll position.

I've only honored this for Android views. For follow-up it's necessary to honor it for Compose and iOS.