### PR TITLE
Start removing the 'diff-consuming' terminology

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
@@ -675,7 +675,7 @@ internal fun generateProtocolLayoutModifierSerializers(
     .build()
 }
 
-internal fun generateProtocolLayoutModifierSerialization(
+internal fun generateComposeProtocolLayoutModifierSerialization(
   schemaSet: ProtocolSchemaSet,
 ): FileSpec {
   val schema = schemaSet.schema

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
@@ -29,7 +29,7 @@ public fun ProtocolSchemaSet.generate(type: ProtocolCodegenType, destination: Pa
   when (type) {
     Compose -> {
       generateProtocolBridge(this).writeTo(destination)
-      generateProtocolLayoutModifierSerialization(this).writeTo(destination)
+      generateComposeProtocolLayoutModifierSerialization(this).writeTo(destination)
       for (dependency in all) {
         generateProtocolWidgetFactory(dependency, host = schema).writeTo(destination)
         generateProtocolLayoutModifierSerializers(dependency, host = schema)?.writeTo(destination)
@@ -40,11 +40,11 @@ public fun ProtocolSchemaSet.generate(type: ProtocolCodegenType, destination: Pa
     }
     Widget -> {
       generateDiffConsumingNodeFactory(this).writeTo(destination)
-      generateDiffConsumingLayoutModifierSerialization(this).writeTo(destination)
+      generateWidgetProtocolLayoutModifierSerialization(this).writeTo(destination)
       for (dependency in all) {
-        generateDiffConsumingLayoutModifierImpls(dependency, host = schema).writeTo(destination)
+        generateProtocolLayoutModifierImpls(dependency, host = schema).writeTo(destination)
         for (widget in dependency.widgets) {
-          generateDiffConsumingWidget(dependency, widget, host = schema).writeTo(destination)
+          generateProtocolNode(dependency, widget, host = schema).writeTo(destination)
         }
       }
     }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -88,8 +88,8 @@ internal fun Schema.diffConsumingNodeFactoryType(): ClassName {
   return ClassName(widgetPackage(), "${type.flatName}DiffConsumingNodeFactory")
 }
 
-internal fun Schema.diffConsumingNodeType(widget: Widget, host: Schema): ClassName {
-  return ClassName(widgetPackage(host), "DiffConsuming${widget.type.flatName}")
+internal fun Schema.protocolNodeType(widget: Widget, host: Schema): ClassName {
+  return ClassName(widgetPackage(host), "Protocol${widget.type.flatName}")
 }
 
 internal fun Schema.widgetType(widget: Widget): ClassName {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
@@ -115,7 +115,7 @@ internal fun generateDiffConsumingNodeFactory(
                   addStatement(
                     "%L -> %T(parentId, parentChildren, provider.%N.%N(), json, mismatchHandler)",
                     widget.tag,
-                    dependency.diffConsumingNodeType(widget, schema),
+                    dependency.protocolNodeType(widget, schema),
                     dependency.type.flatName,
                     widget.type.flatName,
                   )
@@ -135,11 +135,11 @@ internal fun generateDiffConsumingNodeFactory(
 }
 
 /*
-internal class DiffConsumingSunspotButton<W : Any>(
-  private val delegate: SunspotButton<W>,
+internal class ProtocolButton<W : Any>(
+  private val delegate: Button<W>,
   private val json: Json,
   private val mismatchHandler: ProtocolMismatchHandler,
-) : DiffConsumingWidget<W> {
+) : DiffConsumingNode<W> {
   public override val value: W get() = delegate.value
 
   public override val layoutModifiers: LayoutModifier
@@ -166,12 +166,12 @@ internal class DiffConsumingSunspotButton<W : Any>(
   }
 }
 */
-internal fun generateDiffConsumingWidget(
+internal fun generateProtocolNode(
   schema: ProtocolSchema,
   widget: ProtocolWidget,
   host: ProtocolSchema = schema,
 ): FileSpec {
-  val type = schema.diffConsumingNodeType(widget, host)
+  val type = schema.protocolNodeType(widget, host)
   val widgetType = schema.widgetType(widget).parameterizedBy(typeVariableW)
   val protocolType = WidgetProtocol.DiffConsumingNode.parameterizedBy(typeVariableW)
   return FileSpec.builder(type)
@@ -343,7 +343,7 @@ internal fun generateDiffConsumingWidget(
     .build()
 }
 
-internal fun generateDiffConsumingLayoutModifierSerialization(
+internal fun generateWidgetProtocolLayoutModifierSerialization(
   schemaSet: ProtocolSchemaSet,
 ): FileSpec {
   return FileSpec.builder(schemaSet.schema.widgetPackage(), "layoutModifierSerialization")
@@ -352,7 +352,7 @@ internal fun generateDiffConsumingLayoutModifierSerialization(
     .build()
 }
 
-internal fun generateDiffConsumingLayoutModifierImpls(
+internal fun generateProtocolLayoutModifierImpls(
   schema: ProtocolSchema,
   host: ProtocolSchema = schema,
 ): FileSpec {

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
@@ -52,7 +52,7 @@ class ComposeProtocolGenerationTest {
   @Test fun `dependency layout modifiers are included in serialization`() {
     val schemaSet = parseProtocolSchema(ExampleSchema::class)
 
-    val fileSpec = generateProtocolLayoutModifierSerialization(schemaSet)
+    val fileSpec = generateComposeProtocolLayoutModifierSerialization(schemaSet)
     assertThat(fileSpec.toString()).apply {
       contains("is RowVerticalAlignment -> RowVerticalAlignmentSerializer.encode(json, this)")
       contains("is Grow -> GrowSerializer.encode(json, this)")

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
@@ -25,7 +25,7 @@ import java.util.regex.Pattern
 import java.util.regex.Pattern.MULTILINE
 import org.junit.Test
 
-class DiffConsumingGenerationTest {
+class WidgetProtocolGenerationTest {
   @Schema(
     [
       Node12::class,
@@ -60,7 +60,7 @@ class DiffConsumingGenerationTest {
   @Test fun `dependency layout modifiers are included in serialization`() {
     val schema = parseProtocolSchema(ExampleSchema::class)
 
-    val fileSpec = generateDiffConsumingLayoutModifierSerialization(schema)
+    val fileSpec = generateWidgetProtocolLayoutModifierSerialization(schema)
     assertThat(fileSpec.toString()).apply {
       contains("1 -> RowVerticalAlignmentImpl.serializer()")
       contains("1_000_001 -> GrowImpl.serializer()")


### PR DESCRIPTION
We're simply going to say 'protocol' as a prefix similar to what was done for the 'diff-producing' stuff.

This first-of-many refactoring PR starts be renaming `internal` codegen'd types only.