### PR TITLE
Centralize type name guessing algorithm

### DIFF
--- a/redwood-cli/src/main/kotlin/app/cash/redwood/cli/GenerateCommand.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/cli/GenerateCommand.kt
@@ -55,14 +55,7 @@ internal class GenerateCommand : CliktCommand(name = "generate") {
 
   private val schemaType by argument("schema")
     .help("Fully-qualified class name for the @Schema-annotated interface")
-    .convert {
-      FqType(
-        listOf(
-          it.substringBeforeLast(".", missingDelimiterValue = ""), // Package name.
-          it.substringAfterLast("."), // Simple name.
-        ),
-      )
-    }
+    .convert { FqType.bestGuess(it) }
 
   override fun run() {
     val classLoader = URLClassLoader(classpath.map { it.toURI().toURL() }.toTypedArray())

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/FqType.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/FqType.kt
@@ -98,6 +98,29 @@ public data class FqType(
 
   public companion object {
     public val Star: FqType = FqType(listOf("", "*"))
+
+    public fun bestGuess(name: String): FqType {
+      val names = mutableListOf<String>()
+
+      // Add the package name, like "java.util.concurrent", or "" for no package.
+      var p = 0
+      while (p < name.length && Character.isLowerCase(name.codePointAt(p))) {
+        p = name.indexOf('.', p) + 1
+        require(p != 0) { "Couldn't guess: $name" }
+      }
+      names += if (p != 0) name.substring(0, p - 1) else ""
+
+      // Add the class names, like "Map" and "Entry".
+      for (part in name.substring(p).split('.')) {
+        require(part.isNotEmpty() && Character.isUpperCase(part.codePointAt(0))) {
+          "Couldn't guess: $name"
+        }
+        names += part
+      }
+
+      require(names.size >= 2) { "couldn't make a guess for $name" }
+      return FqType(names)
+    }
   }
 }
 

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/FqTypeTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/FqTypeTest.kt
@@ -120,4 +120,45 @@ class FqTypeTest {
     }.hasMessageThat()
       .isEqualTo("Star projection must not be nullable")
   }
+
+  @Test fun bestGuessValid() {
+    assertEquals(
+      FqType(listOf("", "Map")),
+      FqType.bestGuess("Map"),
+    )
+    assertEquals(
+      FqType(listOf("", "Map", "Entry")),
+      FqType.bestGuess("Map.Entry"),
+    )
+    assertEquals(
+      FqType(listOf("java", "Map", "Entry")),
+      FqType.bestGuess("java.Map.Entry"),
+    )
+    assertEquals(
+      FqType(listOf("java.util.concurrent", "Map", "Entry")),
+      FqType.bestGuess("java.util.concurrent.Map.Entry"),
+    )
+  }
+
+  @Test fun bestGuessInvalid() {
+    assertThrows<IllegalArgumentException> {
+      FqType.bestGuess("java")
+    }.hasMessageThat().isEqualTo("Couldn't guess: java")
+
+    assertThrows<IllegalArgumentException> {
+      FqType.bestGuess("java.util.concurrent")
+    }.hasMessageThat().isEqualTo("Couldn't guess: java.util.concurrent")
+
+    assertThrows<IllegalArgumentException> {
+      FqType.bestGuess("java..concurrent")
+    }.hasMessageThat().isEqualTo("Couldn't guess: java..concurrent")
+
+    assertThrows<IllegalArgumentException> {
+      FqType.bestGuess("java.util.concurrent.Map..Entry")
+    }.hasMessageThat().isEqualTo("Couldn't guess: java.util.concurrent.Map..Entry")
+
+    assertThrows<IllegalArgumentException> {
+      FqType.bestGuess("java.util.concurrent.Map.entry")
+    }.hasMessageThat().isEqualTo("Couldn't guess: java.util.concurrent.Map.entry")
+  }
 }


### PR DESCRIPTION
Stolen from KotlinPoet.

PSI parsing will also need to guess at a `FqType` from a `String` so figured I'd pull this into a central location ahead of time.