### PR TITLE
Migrate from Truth to AssertK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.13.0" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.5.2" }
 junit = { module = "junit:junit", version = "4.13.2" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.11" }
-truth = { module = "com.google.truth:truth", version = "1.1.3" }
+assertk = "com.willowtreeapps.assertk:assertk:0.25"
 robolectric = { module = "org.robolectric:robolectric", version = "4.10" }
 okio = { module = "com.squareup.okio:okio", version = "3.3.0" }
 okHttp = { module = "com.squareup.okhttp3:okhttp", version = "4.11.0" }

--- a/redwood-cli/build.gradle
+++ b/redwood-cli/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   implementation libs.clikt
 
   testImplementation libs.junit
-  testImplementation libs.truth
+  testImplementation libs.assertk
   testImplementation libs.jimfs
 }
 

--- a/redwood-cli/src/test/kotlin/app/cash/redwood/cli/ApiMergeCommandTest.kt
+++ b/redwood-cli/src/test/kotlin/app/cash/redwood/cli/ApiMergeCommandTest.kt
@@ -15,9 +15,10 @@
  */
 package app.cash.redwood.cli
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.google.common.jimfs.Configuration.unix
 import com.google.common.jimfs.Jimfs
-import com.google.common.truth.Truth.assertThat
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 import org.junit.Test

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
   testImplementation libs.junit
   testImplementation libs.testParameterInjector
-  testImplementation libs.truth
+  testImplementation libs.assertk
   testImplementation gradleTestKit()
 }
 

--- a/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
+++ b/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
@@ -15,7 +15,10 @@
  */
 package app.cash.redwood.gradle
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.isNotEmpty
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Test

--- a/redwood-tooling-codegen/build.gradle
+++ b/redwood-tooling-codegen/build.gradle
@@ -8,5 +8,5 @@ dependencies {
   testImplementation projects.testSchema
   testImplementation projects.testSchema.compose
   testImplementation libs.junit
-  testImplementation libs.truth
+  testImplementation libs.assertk
 }

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeGenerationTest.kt
@@ -23,7 +23,9 @@ import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
 import app.cash.redwood.tooling.schema.FqType
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import com.google.common.truth.Truth.assertThat
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
 import org.junit.Test
 
 object RowScope
@@ -46,7 +48,7 @@ class ComposeGenerationTest {
     val schema = ProtocolSchemaSet.parse(ScopedAndUnscopedSchema::class).schema
 
     val fileSpec = generateComposable(schema, schema.widgets.single())
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains("scoped: @Composable RowScope.() -> Unit")
       contains("unscoped: @Composable () -> Unit")
     }
@@ -88,7 +90,7 @@ class ComposeGenerationTest {
     val schema = ProtocolSchemaSet.parse(DefaultSchema::class).schema
 
     val fileSpec = generateComposable(schema, schema.widgets.single())
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains("trait: String = \"test\"")
       contains("onEvent: () -> Unit = { error(\"test\") }")
       contains("block: @Composable () -> Unit = {}")

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
@@ -19,7 +19,9 @@ import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import com.google.common.truth.Truth.assertThat
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
 import example.redwood.ExampleSchema
 import org.junit.Test
 
@@ -53,7 +55,7 @@ class ComposeProtocolGenerationTest {
     val schemaSet = ProtocolSchemaSet.parse(ExampleSchema::class)
 
     val fileSpec = generateComposeProtocolLayoutModifierSerialization(schemaSet)
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains("is RowVerticalAlignment -> RowVerticalAlignmentSerializer.encode(json, this)")
       contains("is Grow -> GrowSerializer.encode(json, this)")
     }

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/LayoutModifierGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/LayoutModifierGenerationTest.kt
@@ -18,7 +18,10 @@ package app.cash.redwood.tooling.codegen
 import app.cash.redwood.schema.LayoutModifier
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import com.google.common.truth.Truth.assertThat
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
 import example.redwood.compose.TestScope
 import kotlin.DeprecationLevel.ERROR
 import kotlin.time.Duration.Companion.minutes
@@ -113,7 +116,7 @@ class LayoutModifierGenerationTest {
 
     val modifier = schema.layoutModifiers.single()
     val fileSpec = generateLayoutModifierInterface(schema, modifier)
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains(
         """
         |@Deprecated(

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/TestingGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/TestingGenerationTest.kt
@@ -21,7 +21,8 @@ import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.contains
 import org.junit.Test
 
 class TestingGenerationTest {

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetGenerationTest.kt
@@ -20,7 +20,9 @@ import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import com.google.common.truth.Truth.assertThat
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
 import kotlin.DeprecationLevel.ERROR
 import org.junit.Test
 
@@ -44,7 +46,7 @@ class WidgetGenerationTest {
     val schema = ProtocolSchemaSet.parse(SimpleNameCollisionSchema::class).schema
 
     val fileSpec = generateWidgetFactory(schema)
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains("fun WidgetGenerationTestNavigationBarButton()")
       contains("fun WidgetGenerationTestButton()")
     }
@@ -68,7 +70,7 @@ class WidgetGenerationTest {
     val button = schema.widgets.single { it.type.flatName == "WidgetGenerationTestButton" }
 
     val fileSpec = generateWidget(schema, button)
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains(
         """
         | * {tag=3}
@@ -113,7 +115,7 @@ class WidgetGenerationTest {
 
     val widget = schema.widgets.single()
     val fileSpec = generateWidget(schema, widget)
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains(
         """
         |@Deprecated(

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
@@ -19,10 +19,12 @@ import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import com.google.common.truth.Truth.assertThat
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.matchesPredicate
 import example.redwood.ExampleSchema
-import java.util.regex.Pattern
-import java.util.regex.Pattern.MULTILINE
+import kotlin.text.RegexOption.MULTILINE
 import org.junit.Test
 
 class WidgetProtocolGenerationTest {
@@ -52,16 +54,17 @@ class WidgetProtocolGenerationTest {
     val schema = ProtocolSchemaSet.parse(SortedByTagSchema::class)
 
     val fileSpec = generateProtocolNodeFactory(schema)
-    assertThat(fileSpec.toString()).containsMatch(
-      Pattern.compile("1 ->[^2]+2 ->[^3]+3 ->[^1]+12 ->", MULTILINE),
-    )
+
+    // https://github.com/willowtreeapps/assertk/issues/452
+    val regex = Regex("1 ->[^2]+2 ->[^3]+3 ->[^1]+12 ->", MULTILINE)
+    assertThat(fileSpec.toString()).matchesPredicate(regex::containsMatchIn)
   }
 
   @Test fun `dependency layout modifiers are included in serialization`() {
     val schema = ProtocolSchemaSet.parse(ExampleSchema::class)
 
     val fileSpec = generateWidgetProtocolLayoutModifierSerialization(schema)
-    assertThat(fileSpec.toString()).apply {
+    assertThat(fileSpec.toString()).all {
       contains("1 -> RowVerticalAlignmentImpl.serializer()")
       contains("1_000_001 -> GrowImpl.serializer()")
     }

--- a/redwood-tooling-lint/build.gradle
+++ b/redwood-tooling-lint/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
   testImplementation libs.kotlin.test
   testImplementation libs.junit
-  testImplementation libs.truth
+  testImplementation libs.assertk
 }

--- a/redwood-tooling-lint/src/test/kotlin/app/cash/redwood/tooling/lint/ApiMergerTest.kt
+++ b/redwood-tooling-lint/src/test/kotlin/app/cash/redwood/tooling/lint/ApiMergerTest.kt
@@ -15,7 +15,9 @@
  */
 package app.cash.redwood.tooling.lint
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
 import kotlin.test.assertFailsWith
 import org.junit.Test
 
@@ -25,8 +27,7 @@ class ApiMergerTest {
     val t = assertFailsWith<IllegalStateException> {
       merger.merge()
     }
-    assertThat(t).hasMessageThat()
-      .isEqualTo("One or more API definitions must be added in order to merge")
+    assertThat(t).hasMessage("One or more API definitions must be added in order to merge")
   }
 
   @Test fun version1Only() {
@@ -34,8 +35,7 @@ class ApiMergerTest {
     val t = assertFailsWith<IllegalArgumentException> {
       merger.add("""<api version="2"/>""")
     }
-    assertThat(t).hasMessageThat()
-      .isEqualTo("Only Redwood API XML version 1 is supported. Found: 2")
+    assertThat(t).hasMessage("Only Redwood API XML version 1 is supported. Found: 2")
   }
 
   @Test fun widgetTakesHigherSince() {

--- a/redwood-tooling-schema/build.gradle
+++ b/redwood-tooling-schema/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
   testImplementation projects.testSchema
   testImplementation libs.junit
-  testImplementation libs.truth
+  testImplementation libs.assertk
 }

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/FqTypeTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/FqTypeTest.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.tooling.schema
 import DefaultPackage
 import app.cash.redwood.tooling.schema.FqType.Variance.In
 import app.cash.redwood.tooling.schema.FqType.Variance.Out
+import assertk.assertions.hasMessage
 import java.util.PrimitiveIterator
 import kotlin.reflect.typeOf
 import org.junit.Assert.assertEquals
@@ -79,15 +80,13 @@ class FqTypeTest {
   }
 
   @Test fun classTooFewNamesThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType(listOf())
-    }.hasMessageThat()
-      .isEqualTo("At least two names are required: package and a simple name: []")
+    }.hasMessage("At least two names are required: package and a simple name: []")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType(listOf("kotlin"))
-    }.hasMessageThat()
-      .isEqualTo("At least two names are required: package and a simple name: [kotlin]")
+    }.hasMessage("At least two names are required: package and a simple name: [kotlin]")
   }
 
   @Test fun star() {
@@ -95,30 +94,25 @@ class FqTypeTest {
   }
 
   @Test fun starOtherPropertiesThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType(listOf("kotlin", "*"))
-    }.hasMessageThat()
-      .isEqualTo("Star projection must use empty package name: kotlin")
+    }.hasMessage("Star projection must use empty package name: kotlin")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType(listOf("", "*", "Nested"))
-    }.hasMessageThat()
-      .isEqualTo("Star projection cannot have nested types: [*, Nested]")
+    }.hasMessage("Star projection cannot have nested types: [*, Nested]")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType(listOf("", "*"), parameterTypes = listOf(Int::class.toFqType()))
-    }.hasMessageThat()
-      .isEqualTo("Star projection must not have parameter types: [kotlin.Int]")
+    }.hasMessage("Star projection must not have parameter types: [kotlin.Int]")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType(listOf("", "*"), variance = In)
-    }.hasMessageThat()
-      .isEqualTo("Star projection must be Invariant: In")
+    }.hasMessage("Star projection must be Invariant: In")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType(listOf("", "*"), nullable = true)
-    }.hasMessageThat()
-      .isEqualTo("Star projection must not be nullable")
+    }.hasMessage("Star projection must not be nullable")
   }
 
   @Test fun bestGuessValid() {
@@ -141,24 +135,24 @@ class FqTypeTest {
   }
 
   @Test fun bestGuessInvalid() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType.bestGuess("java")
-    }.hasMessageThat().isEqualTo("Couldn't guess: java")
+    }.hasMessage("Couldn't guess: java")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType.bestGuess("java.util.concurrent")
-    }.hasMessageThat().isEqualTo("Couldn't guess: java.util.concurrent")
+    }.hasMessage("Couldn't guess: java.util.concurrent")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType.bestGuess("java..concurrent")
-    }.hasMessageThat().isEqualTo("Couldn't guess: java..concurrent")
+    }.hasMessage("Couldn't guess: java..concurrent")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType.bestGuess("java.util.concurrent.Map..Entry")
-    }.hasMessageThat().isEqualTo("Couldn't guess: java.util.concurrent.Map..Entry")
+    }.hasMessage("Couldn't guess: java.util.concurrent.Map..Entry")
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       FqType.bestGuess("java.util.concurrent.Map.entry")
-    }.hasMessageThat().isEqualTo("Couldn't guess: java.util.concurrent.Map.entry")
+    }.hasMessage("Couldn't guess: java.util.concurrent.Map.entry")
   }
 }

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaJsonTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaJsonTest.kt
@@ -17,7 +17,9 @@ package app.cash.redwood.tooling.schema
 
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
 import org.junit.Test
 
 class SchemaJsonTest {

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -26,7 +26,11 @@ import app.cash.redwood.schema.Widget
 import app.cash.redwood.tooling.schema.Widget.Children as ChildrenTrait
 import app.cash.redwood.tooling.schema.Widget.Event
 import app.cash.redwood.tooling.schema.Widget.Property as PropertyTrait
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import example.redwood.ExampleSchema
 import kotlin.DeprecationLevel.HIDDEN
 import org.junit.Test
@@ -37,9 +41,9 @@ class SchemaParserTest {
   interface NonAnnotationSchema
 
   @Test fun nonAnnotatedSchemaThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(NonAnnotationSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "Schema app.cash.redwood.tooling.schema.SchemaParserTest.NonAnnotationSchema missing @Schema annotation",
     )
   }
@@ -55,9 +59,9 @@ class SchemaParserTest {
   )
 
   @Test fun nonAnnotatedWidgetThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(NonAnnotatedWidgetSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "app.cash.redwood.tooling.schema.SchemaParserTest.NonAnnotatedMember must be annotated with either @Widget or @LayoutModifier",
     )
   }
@@ -76,9 +80,9 @@ class SchemaParserTest {
   )
 
   @Test fun doubleAnnotatedWidgetThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(DoubleAnnotatedWidgetSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "app.cash.redwood.tooling.schema.SchemaParserTest.DoubleAnnotatedWidget must be annotated with either @Widget or @LayoutModifier",
     )
   }
@@ -108,9 +112,9 @@ class SchemaParserTest {
   )
 
   @Test fun duplicateWidgetTagThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(DuplicateWidgetTagSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |Schema @Widget tags must be unique
       |
@@ -144,9 +148,9 @@ class SchemaParserTest {
   )
 
   @Test fun duplicateLayoutModifierTagThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(DuplicateLayoutModifierTagSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |Schema @LayoutModifier tags must be unique
       |
@@ -169,9 +173,9 @@ class SchemaParserTest {
   )
 
   @Test fun repeatedWidgetTypeThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(RepeatedWidgetTypeSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |Schema contains repeated member
       |
@@ -195,9 +199,9 @@ class SchemaParserTest {
   )
 
   @Test fun duplicatePropertyTagThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(DuplicatePropertyTagSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |app.cash.redwood.tooling.schema.SchemaParserTest.DuplicatePropertyTagWidget's @Property tags must be unique
       |
@@ -221,9 +225,9 @@ class SchemaParserTest {
   )
 
   @Test fun duplicateChildrenTagThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(DuplicateChildrenTagSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |app.cash.redwood.tooling.schema.SchemaParserTest.DuplicateChildrenTagWidget's @Children tags must be unique
       |
@@ -247,9 +251,9 @@ class SchemaParserTest {
   )
 
   @Test fun unannotatedPrimaryParameterThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(UnannotatedPrimaryParameterSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "Unannotated parameter \"unannotated\" on app.cash.redwood.tooling.schema.SchemaParserTest.UnannotatedPrimaryParameterWidget",
     )
   }
@@ -267,9 +271,9 @@ class SchemaParserTest {
   )
 
   @Test fun nonDataClassWidgetThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(NonDataClassWidgetSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Widget app.cash.redwood.tooling.schema.SchemaParserTest.NonDataClassWidget must be 'data' class or 'object'",
     )
   }
@@ -287,9 +291,9 @@ class SchemaParserTest {
   )
 
   @Test fun nonDataClassLayoutModifierThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(NonDataClassLayoutModifierSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@LayoutModifier app.cash.redwood.tooling.schema.SchemaParserTest.NonDataClassLayoutModifier must be 'data' class or 'object'",
     )
   }
@@ -307,9 +311,9 @@ class SchemaParserTest {
   )
 
   @Test fun invalidChildrenTypeThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(InvalidChildrenTypeSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Children app.cash.redwood.tooling.schema.SchemaParserTest.InvalidChildrenTypeWidget#children must be of type '() -> Unit'",
     )
   }
@@ -327,9 +331,9 @@ class SchemaParserTest {
   )
 
   @Test fun invalidChildrenLambdaReturnTypeThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(InvalidChildrenLambdaReturnTypeSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Children app.cash.redwood.tooling.schema.SchemaParserTest.InvalidChildrenLambdaReturnTypeWidget#children must be of type '() -> Unit'",
     )
   }
@@ -347,9 +351,9 @@ class SchemaParserTest {
   )
 
   @Test fun childrenArgumentsInvalid() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(ChildrenArgumentsInvalidSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Children app.cash.redwood.tooling.schema.SchemaParserTest.ChildrenArgumentsInvalidWidget#children lambda type must not have any arguments. " +
         "Found: [kotlin.String]",
     )
@@ -368,9 +372,9 @@ class SchemaParserTest {
   )
 
   @Test fun scopedChildrenArgumentsInvalid() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(ScopedChildrenArgumentsInvalidSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Children app.cash.redwood.tooling.schema.SchemaParserTest.ScopedChildrenArgumentsInvalidWidget#children lambda type must not have any arguments. " +
         "Found: [kotlin.Int]",
     )
@@ -389,9 +393,9 @@ class SchemaParserTest {
   )
 
   @Test fun scopedChildrenInvalid() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(ScopedChildrenInvalidSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Children app.cash.redwood.tooling.schema.SchemaParserTest.ScopedChildrenInvalidWidget#children lambda receiver can only be a class. " +
         "Found: kotlin.collections.List<kotlin.Int>",
     )
@@ -410,9 +414,9 @@ class SchemaParserTest {
   )
 
   @Test fun scopedChildrenTypeParameterInvalid() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(ScopedChildrenTypeParameterInvalidSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Children app.cash.redwood.tooling.schema.SchemaParserTest.ScopedChildrenTypeParameterInvalidWidget#children lambda receiver can only be a class. " +
         "Found: T",
     )
@@ -477,9 +481,9 @@ class SchemaParserTest {
   )
 
   @Test fun eventArgumentsInvalid() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(EventArgumentsInvalidSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Property app.cash.redwood.tooling.schema.SchemaParserTest.EventArgumentsInvalidWidget#tooManyArguments lambda type can only have zero or one arguments. " +
         "Found: [kotlin.String, kotlin.Boolean, kotlin.Long]",
     )
@@ -512,9 +516,9 @@ class SchemaParserTest {
   object OneMillionWidget
 
   @Test fun widgetTagOneMillionThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(OneMillionWidgetSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Widget app.cash.redwood.tooling.schema.SchemaParserTest.OneMillionWidget " +
         "tag must be in range [1, 1000000): 1000000",
     )
@@ -531,9 +535,9 @@ class SchemaParserTest {
   object ZeroWidget
 
   @Test fun widgetTagZeroThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(ZeroWidgetSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@Widget app.cash.redwood.tooling.schema.SchemaParserTest.ZeroWidget " +
         "tag must be in range [1, 1000000): 0",
     )
@@ -552,9 +556,9 @@ class SchemaParserTest {
   )
 
   @Test fun layoutModifierTagOneMillionThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(OneMillionLayoutModifierSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@LayoutModifier app.cash.redwood.tooling.schema.SchemaParserTest.OneMillionLayoutModifier " +
         "tag must be in range [1, 1000000): 1000000",
     )
@@ -573,9 +577,9 @@ class SchemaParserTest {
   )
 
   @Test fun layoutModifierTagZeroThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(ZeroLayoutModifierSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@LayoutModifier app.cash.redwood.tooling.schema.SchemaParserTest.ZeroLayoutModifier " +
         "tag must be in range [1, 1000000): 0",
     )
@@ -647,15 +651,15 @@ class SchemaParserTest {
   object SchemaDependencyTagTooLow
 
   @Test fun dependencyTagTooHighThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(SchemaDependencyTagTooHigh::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "app.cash.redwood.layout.RedwoodLayout tag must be 0 for the root or in range (0, 2000] as a dependency: 2001",
     )
 
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(SchemaDependencyTagTooLow::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "app.cash.redwood.layout.RedwoodLayout tag must be 0 for the root or in range (0, 2000] as a dependency: -1",
     )
   }
@@ -669,9 +673,9 @@ class SchemaParserTest {
   object SchemaDependencyTagZero
 
   @Test fun dependencyTagZeroThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(SchemaDependencyTagZero::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "Dependency app.cash.redwood.layout.RedwoodLayout tag must not be non-zero",
     )
   }
@@ -692,9 +696,9 @@ class SchemaParserTest {
   object SchemaDuplicateDependencyTagB
 
   @Test fun schemaDuplicateDependencyTagThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(SchemaDuplicateDependencyTag::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |Schema dependency tags must be unique
       |
@@ -716,9 +720,9 @@ class SchemaParserTest {
   object SchemaDuplicateDependencyTypeOther
 
   @Test fun schemaDuplicateDependencyTypeThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(SchemaDuplicateDependencyType::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |Schema contains repeated dependency
       |
@@ -736,9 +740,9 @@ class SchemaParserTest {
   object SchemaDependencyHasDependency
 
   @Test fun schemaDependencyHasDependencyThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(SchemaDependencyHasDependency::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "Schema dependency example.redwood.ExampleSchema also has its own dependencies. " +
         "For now, only a single level of dependencies is supported.",
     )
@@ -755,9 +759,9 @@ class SchemaParserTest {
   object SchemaWidgetDuplicateInDependency
 
   @Test fun schemaWidgetDuplicateInDependencyThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(SchemaWidgetDuplicateInDependency::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       """
       |Schema dependency tree contains duplicated widgets
       |
@@ -777,9 +781,9 @@ class SchemaParserTest {
   object UnscopedLayoutModifier
 
   @Test fun `layout modifier must have at least one scope`() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(UnscopedModifierSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "@LayoutModifier app.cash.redwood.tooling.schema.SchemaParserTest.UnscopedLayoutModifier " +
         "must have at least one scope.",
     )
@@ -799,9 +803,9 @@ class SchemaParserTest {
   )
 
   @Test fun deprecationHiddenThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(DeprecationHiddenSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "Schema deprecation does not support level HIDDEN: " +
         "val app.cash.redwood.tooling.schema.SchemaParserTest.DeprecationHiddenWidget.a: kotlin.String",
     )
@@ -820,9 +824,9 @@ class SchemaParserTest {
   object DeprecationReplaceWithWidget
 
   @Test fun deprecationReplaceWithThrows() {
-    assertThrows<IllegalArgumentException> {
+    assertFailsWith<IllegalArgumentException> {
       parseProtocolSchemaSet(DeprecationReplaceWithSchema::class)
-    }.hasMessageThat().isEqualTo(
+    }.hasMessage(
       "Schema deprecation does not support replacements: " +
         "class app.cash.redwood.tooling.schema.SchemaParserTest\$DeprecationReplaceWithWidget",
     )

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/assertk.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/assertk.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,21 @@
  */
 package app.cash.redwood.tooling.schema
 
-import com.google.common.truth.Subject
-import com.google.common.truth.ThrowableSubject
-import com.google.common.truth.Truth.assertThat
+import assertk.Assert
+import assertk.assertThat
+import assertk.assertions.isFailure
+import assertk.assertions.isInstanceOf
 
-inline fun <reified T : Throwable> assertThrows(body: () -> Unit): ThrowableSubject {
-  try {
-    body()
-  } catch (t: Throwable) {
-    if (t is T) {
-      return assertThat(t)
-    }
-    throw t
-  }
-  throw AssertionError(
-    "Expect body to throw ${T::class.java.simpleName} but it completed successfully",
-  )
+inline fun <reified T : Throwable> assertFailsWith(body: () -> Any?): Assert<T> {
+  // https://github.com/willowtreeapps/assertk/issues/453
+
+  return assertThat(body)
+    .isFailure()
+    .isInstanceOf(T::class)
 }
 
-inline fun <reified T : Any> Subject.isInstanceOf() {
-  isInstanceOf(T::class.java)
+inline fun <reified T : Any> Assert<Any>.isInstanceOf(): Assert<T> {
+  // https://github.com/willowtreeapps/assertk/issues/454
+
+  return isInstanceOf(T::class)
 }


### PR DESCRIPTION
Truth simply does not hold its weight in Kotlin. kotlin.test sometimes just isn't enough. While AssertJ kinda went off the rails (causing our growing usage of Truth) back around Java 8 times, AssertK is really nice and only a mildly-inspired derivative and not a strict port. I've been throwing my weight behind it more and more, so let's use it!