### PR TITLE
Fix layout and button click for iOS Counter sample

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -135,7 +135,7 @@ internal class UIViewFlexContainer(
       setContentSize(
         CGSizeMake(
           width = container.items.maxOfOrNull { it.right } ?: 0.0,
-          height = container.items.maxOfOrNull { it.top } ?: 0.0,
+          height = container.items.maxOfOrNull { it.bottom } ?: 0.0,
         ),
       )
       superview?.setNeedsLayout()

--- a/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/IosButton.kt
+++ b/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/IosButton.kt
@@ -24,7 +24,7 @@ import platform.UIKit.UIControlStateNormal
 import platform.UIKit.UIView
 import platform.objc.sel_registerName
 
-internal class IosButton : Button<UIView> {
+class IosButton : Button<UIView> {
   override val value = UIButton()
 
   override var layoutModifiers: LayoutModifier = LayoutModifier

--- a/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/IosButton.kt
+++ b/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/IosButton.kt
@@ -24,6 +24,7 @@ import platform.UIKit.UIControlStateNormal
 import platform.UIKit.UIView
 import platform.objc.sel_registerName
 
+// NOTE: This class must be public for the click selector to work.
 class IosButton : Button<UIView> {
   override val value = UIButton()
 

--- a/samples/counter/ios-uikit/CounterApp/CounterViewController.swift
+++ b/samples/counter/ios-uikit/CounterApp/CounterViewController.swift
@@ -9,7 +9,7 @@ class CounterViewController : UIViewController {
     override func viewDidLoad() {
         let container = UIStackView()
         container.axis = .horizontal
-        container.alignment = .center
+        container.alignment = .fill
         container.distribution = .fillEqually
         container.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
Closes #930. Closes #903.

Mostly slimilar to my previous PR #951 - see that for more details on the other changes, but I removed the `NSLayoutConstraints`. They were breaking nested Rows and Columns and it turns out it was just over complicating things. 

Tracking through the existing code it was clear that the `UIViewFlexContainer` was mostly working as intended (aside from using top instead of bottom for the content size). The main layout issue was that the UIStackView that contained the root Compose view was using `.center` instead of `.fill` for the alignment, which doesn't work at the boundary between the Flexbox and NSAutoLayout code because the Flexbox and NSAutoLayout treat "intrinsicSize" differently - UIStackView with alignment `.center` makes it shrink the content to the minimum size (which is 0 for scrollviews), but the flex layouts will set it to wrap by default I believe.

I think the takeaway here is that the Compose root view should always just be set to fill the available space or have the frame set manually in the host view.
