### PR TITLE
Add missing `open` to event listener function

### DIFF
--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -34,7 +34,7 @@ public fun TreehouseAppFactory(
   context: Context,
   httpClient: OkHttpClient,
   manifestVerifier: ManifestVerifier,
-  eventListener: EventListener = EventListener.NONE,
+  eventListener: EventListener = EventListener(),
   embeddedDir: Path? = null,
   embeddedFileSystem: FileSystem? = null,
   cacheName: String = "zipline",

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
@@ -28,7 +28,7 @@ import app.cash.zipline.ZiplineService
 import kotlin.native.ObjCName
 
 @ObjCName("EventListener", exact = true)
-public abstract class EventListener {
+public open class EventListener {
   /**
    * Invoked each time a [TreehouseApp] is created. When this is triggered the app may not yet have
    * any code loaded; but it will always attempt to load code.
@@ -159,7 +159,7 @@ public abstract class EventListener {
   }
 
   /** Invoked for an event whose node [id] is unknown. */
-  public fun onUnknownEventNode(
+  public open fun onUnknownEventNode(
     app: TreehouseApp<*>,
     id: Id,
     tag: EventTag,
@@ -355,10 +355,5 @@ public abstract class EventListener {
     app: TreehouseApp<*>,
     name: String,
   ) {
-  }
-
-  public companion object {
-    public val NONE: EventListener = object : EventListener() {
-    }
   }
 }

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
@@ -30,7 +30,7 @@ import platform.Foundation.NSThread
 public fun TreehouseAppFactory(
   httpClient: ZiplineHttpClient,
   manifestVerifier: ManifestVerifier,
-  eventListener: EventListener = EventListener.NONE,
+  eventListener: EventListener = EventListener(),
   embeddedDir: Path? = null,
   embeddedFileSystem: FileSystem? = null,
   cacheName: String = "zipline",


### PR DESCRIPTION
Also switch the type from `abstract` to `open` to eliminate the need for a second class just to handle the `NONE` variable. Replace `NONE`'s usage with simple instantiation since this value will generally be single-use within an application and not a widely needed singleton.