### PR TITLE
Move lint merge command to tooling module

### DIFF
--- a/redwood-cli/build.gradle
+++ b/redwood-cli/build.gradle
@@ -24,14 +24,9 @@ tasks.withType(KotlinJvmCompile).configureEach {
 
 dependencies {
   implementation projects.redwoodToolingCodegen
-  implementation projects.redwoodToolingLint
   implementation projects.redwoodToolingSchema
   implementation libs.lint.core
   implementation libs.clikt
-
-  testImplementation libs.junit
-  testImplementation libs.assertk
-  testImplementation libs.jimfs
 }
 
 tasks.named("distTar").configure { task ->

--- a/redwood-tooling-lint/build.gradle
+++ b/redwood-tooling-lint/build.gradle
@@ -1,12 +1,27 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'application'
+
+application {
+  applicationName = 'redwood-lint'
+  mainClass.set('app.cash.redwood.tooling.lint.Main')
+}
 
 dependencies {
+  implementation libs.clikt
   implementation libs.kotlinx.serialization.core
   implementation libs.xmlutil.serialization
 
   testImplementation libs.kotlin.test
   testImplementation libs.junit
   testImplementation libs.assertk
+  testImplementation libs.jimfs
+}
+
+tasks.named("distTar").configure { task ->
+  task.enabled = false
+}
+tasks.named("assemble").configure { task ->
+  task.dependsOn(tasks.named("installDist"))
 }

--- a/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/ApiMergeCommand.kt
+++ b/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/ApiMergeCommand.kt
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.cli
+package app.cash.redwood.tooling.lint
 
-import app.cash.redwood.tooling.lint.ApiMerger
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.help

--- a/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/main.kt
+++ b/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/main.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Square, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,16 @@
  */
 @file:JvmName("Main")
 
-package app.cash.redwood.cli
+package app.cash.redwood.tooling.lint
 
 import com.github.ajalt.clikt.core.NoOpCliktCommand
 import com.github.ajalt.clikt.core.subcommands
+import java.nio.file.FileSystems
 
 public fun main(vararg args: String) {
-  NoOpCliktCommand(name = "redwood")
+  NoOpCliktCommand(name = "redwood-lint")
     .subcommands(
-      GenerateCommand(),
-      JsonCommand(),
-      LintCommand(),
+      ApiMergeCommand(FileSystems.getDefault()),
     )
     .main(args)
 }

--- a/redwood-tooling-lint/src/test/kotlin/app/cash/redwood/tooling/lint/ApiMergeCommandTest.kt
+++ b/redwood-tooling-lint/src/test/kotlin/app/cash/redwood/tooling/lint/ApiMergeCommandTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.cli
+package app.cash.redwood.tooling.lint
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo


### PR DESCRIPTION
A monolithic CLI module is bad for the classpath, as the tools we want to use depend on different versions of unstable APIs.

See https://github.com/cashapp/redwood/pull/992#issuecomment-1526820013