### PR TITLE
Move lint check command to tooling module

### DIFF
--- a/redwood-cli/build.gradle
+++ b/redwood-cli/build.gradle
@@ -11,21 +11,9 @@ application {
   mainClass.set('app.cash.redwood.cli.Main')
 }
 
-tasks.withType(JavaCompile).configureEach {
-  sourceCompatibility = JavaVersion.VERSION_11.toString()
-  targetCompatibility = JavaVersion.VERSION_11.toString()
-}
-
-tasks.withType(KotlinJvmCompile).configureEach {
-  compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_11)
-  }
-}
-
 dependencies {
   implementation projects.redwoodToolingCodegen
   implementation projects.redwoodToolingSchema
-  implementation libs.lint.core
   implementation libs.clikt
 }
 

--- a/redwood-cli/src/main/kotlin/app/cash/redwood/cli/main.kt
+++ b/redwood-cli/src/main/kotlin/app/cash/redwood/cli/main.kt
@@ -25,7 +25,6 @@ public fun main(vararg args: String) {
     .subcommands(
       GenerateCommand(),
       JsonCommand(),
-      LintCommand(),
     )
     .main(args)
 }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintPlugin.kt
@@ -198,8 +198,8 @@ private fun Project.createRedwoodLintTask(
   sourceDirs: () -> Collection<File>,
   classpath: () -> Configuration,
 ): TaskProvider<out Task> {
-  val configuration = configurations.maybeCreate("redwood")
-  dependencies.add(configuration.name, project.redwoodDependency("redwood-cli"))
+  val configuration = configurations.maybeCreate("redwoodToolingLint")
+  dependencies.add(configuration.name, project.redwoodDependency("redwood-tooling-lint"))
 
   return tasks.register(name, RedwoodLintTask::class.java) { task ->
     task.group = VERIFICATION_GROUP

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintTask.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintTask.kt
@@ -70,10 +70,10 @@ private abstract class RedwoodLintWorker @Inject constructor(
   override fun execute() {
     execOperations.javaexec { exec ->
       exec.classpath = parameters.toolClasspath
-      exec.mainClass.set("app.cash.redwood.cli.Main")
+      exec.mainClass.set("app.cash.redwood.tooling.lint.Main")
 
       exec.args = mutableListOf<String>().apply {
-        add("lint")
+        add("check")
         add(parameters.projectDirectoryPath.get())
 
         for (file in parameters.sourceDirectories.get()) {

--- a/redwood-tooling-lint/build.gradle
+++ b/redwood-tooling-lint/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.vanniktech.maven.publish'
@@ -12,11 +15,23 @@ dependencies {
   implementation libs.clikt
   implementation libs.kotlinx.serialization.core
   implementation libs.xmlutil.serialization
+  implementation libs.lint.core
 
   testImplementation libs.kotlin.test
   testImplementation libs.junit
   testImplementation libs.assertk
   testImplementation libs.jimfs
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_11.toString()
+  targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+
+tasks.withType(KotlinJvmCompile).configureEach {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
+  }
 }
 
 tasks.named("distTar").configure { task ->

--- a/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/LintCommand.kt
+++ b/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/LintCommand.kt
@@ -16,7 +16,7 @@
 @file:JvmName("Main")
 @file:Suppress("UnstableApiUsage" /* Lint 🙄 */)
 
-package app.cash.redwood.cli
+package app.cash.redwood.tooling.lint
 
 import com.android.tools.lint.LintResourceRepository.Companion.EmptyRepository
 import com.android.tools.lint.LintStats
@@ -56,7 +56,7 @@ import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.utils.PathUtil.getJdkClassesRootsFromCurrentJre
 
-internal class LintCommand : CliktCommand(name = "lint") {
+internal class LintCommand : CliktCommand(name = "check") {
   private val projectDirectory by argument("PROJECT_DIR")
     .file()
   private val sourceDirectories by option("-s", "--sources", metavar = "DIR")

--- a/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/main.kt
+++ b/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/main.kt
@@ -25,6 +25,7 @@ public fun main(vararg args: String) {
   NoOpCliktCommand(name = "redwood-lint")
     .subcommands(
       ApiMergeCommand(FileSystems.getDefault()),
+      LintCommand(),
     )
     .main(args)
 }


### PR DESCRIPTION
A monolithic CLI module is bad for the classpath, as the tools we want to use depend on different versions of unstable APIs.

See https://github.com/cashapp/redwood/pull/992#issuecomment-1526820013