### PR TITLE
Invalidate all children on a modifier change

### DIFF
--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidgetChildren.kt
@@ -47,7 +47,7 @@ internal class ProtocolWidgetChildren(
     state.append(ChildrenDiff.Move(id, tag, fromIndex, toIndex, count))
   }
 
-  override fun onLayoutModifierUpdated(index: Int) {
+  override fun onLayoutModifierUpdated() {
     throw AssertionError()
   }
 }

--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNode.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNode.kt
@@ -17,7 +17,6 @@ package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.EventSink
-import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.LayoutModifierElement
 import app.cash.redwood.protocol.PropertyDiff
 import app.cash.redwood.protocol.WidgetTag
@@ -31,13 +30,8 @@ import kotlin.native.ObjCName
  */
 @ObjCName("ProtocolNode", exact = true)
 public abstract class ProtocolNode<W : Any>(
-  public val parentId: Id,
   public val parentChildren: Widget.Children<W>,
 ) {
-  private var _childIds: MutableList<Id>? = null
-  public val childIds: MutableList<Id>
-    get() = _childIds ?: mutableListOf<Id>().also { _childIds = it }
-
   public abstract val widget: Widget<W>
 
   public abstract fun apply(diff: PropertyDiff, eventSink: EventSink)
@@ -63,7 +57,6 @@ public abstract class ProtocolNode<W : Any>(
      * continue executing.
      */
     public fun create(
-      parentId: Id,
       parentChildren: Widget.Children<W>,
       tag: WidgetTag,
     ): ProtocolNode<W>?

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactoryTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactoryTest.kt
@@ -55,7 +55,7 @@ class ProtocolNodeFactoryTest {
     )
 
     val t = assertFailsWith<IllegalArgumentException> {
-      factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(345432))
+      factory.create(ThrowingWidgetChildren(), WidgetTag(345432))
     }
     assertThat(t).hasMessage("Unknown widget tag 345432")
   }
@@ -70,7 +70,7 @@ class ProtocolNodeFactoryTest {
       mismatchHandler = handler,
     )
 
-    assertThat(factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(345432))).isNull()
+    assertThat(factory.create(ThrowingWidgetChildren(), WidgetTag(345432))).isNull()
 
     assertThat(handler.events.single()).isEqualTo("Unknown widget 345432")
   }
@@ -91,7 +91,7 @@ class ProtocolNodeFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(5))!!
+    val textInput = factory.create(ThrowingWidgetChildren(), WidgetTag(5))!!
 
     textInput.updateLayoutModifier(
       listOf(
@@ -125,7 +125,7 @@ class ProtocolNodeFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(5))!!
+    val textInput = factory.create(ThrowingWidgetChildren(), WidgetTag(5))!!
 
     textInput.updateLayoutModifier(
       listOf(
@@ -155,7 +155,7 @@ class ProtocolNodeFactoryTest {
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
       ),
     )
-    val button = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(4))!!
+    val button = factory.create(ThrowingWidgetChildren(), WidgetTag(4))!!
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.updateLayoutModifier(
@@ -189,7 +189,7 @@ class ProtocolNodeFactoryTest {
       mismatchHandler = handler,
     )
 
-    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(5))!!
+    val textInput = factory.create(ThrowingWidgetChildren(), WidgetTag(5))!!
     textInput.updateLayoutModifier(
       listOf(
         LayoutModifierElement(
@@ -225,7 +225,7 @@ class ProtocolNodeFactoryTest {
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
       ),
     )
-    val button = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(4))!!
+    val button = factory.create(ThrowingWidgetChildren(), WidgetTag(4))!!
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.children(ChildrenTag(345432))
@@ -243,7 +243,7 @@ class ProtocolNodeFactoryTest {
       mismatchHandler = handler,
     )
 
-    val button = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(4))!!
+    val button = factory.create(ThrowingWidgetChildren(), WidgetTag(4))!!
     assertThat(button.children(ChildrenTag(345432))).isNull()
 
     assertThat(handler.events.single()).isEqualTo("Unknown children 345432 for 4")
@@ -265,7 +265,7 @@ class ProtocolNodeFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(5))!!
+    val textInput = factory.create(ThrowingWidgetChildren(), WidgetTag(5))!!
 
     val throwingEventSink = EventSink { error(it) }
     textInput.apply(PropertyDiff(Id(1), PropertyTag(2), JsonPrimitive("PT10S")), throwingEventSink)
@@ -280,7 +280,7 @@ class ProtocolNodeFactoryTest {
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
       ),
     )
-    val button = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(4))!!
+    val button = factory.create(ThrowingWidgetChildren(), WidgetTag(4))!!
 
     val diff = PropertyDiff(Id(1), PropertyTag(345432))
     val eventSink = EventSink { throw UnsupportedOperationException() }
@@ -299,7 +299,7 @@ class ProtocolNodeFactoryTest {
       ),
       mismatchHandler = handler,
     )
-    val button = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(4))!!
+    val button = factory.create(ThrowingWidgetChildren(), WidgetTag(4))!!
 
     button.apply(PropertyDiff(Id(1), PropertyTag(345432))) { throw UnsupportedOperationException() }
 
@@ -322,7 +322,7 @@ class ProtocolNodeFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.create(Id.Root, ThrowingWidgetChildren(), WidgetTag(5))!!
+    val textInput = factory.create(ThrowingWidgetChildren(), WidgetTag(5))!!
 
     val eventSink = RecordingEventSink()
     textInput.apply(PropertyDiff(Id(1), PropertyTag(4), JsonPrimitive(true)), eventSink)

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ThrowingWidgetChildren.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ThrowingWidgetChildren.kt
@@ -21,5 +21,5 @@ class ThrowingWidgetChildren<W : Any> : Widget.Children<W> {
   override fun insert(index: Int, widget: Widget<W>) = throw AssertionError()
   override fun move(fromIndex: Int, toIndex: Int, count: Int) = throw AssertionError()
   override fun remove(index: Int, count: Int) = throw AssertionError()
-  override fun onLayoutModifierUpdated(index: Int) = throw AssertionError()
+  override fun onLayoutModifierUpdated() = throw AssertionError()
 }

--- a/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
+++ b/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
@@ -16,41 +16,41 @@
 package app.cash.redwood.widget.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
-import app.cash.redwood.LayoutModifier
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import app.cash.redwood.widget.Widget
 
 public class ComposeWidgetChildren : Widget.Children<@Composable () -> Unit> {
-  private val layoutModifiers = mutableStateListOf<LayoutModifier>()
+  private var layoutModifierTick by mutableStateOf(0)
 
   private val _widgets = mutableStateListOf<Widget<@Composable () -> Unit>>()
   public val widgets: List<Widget<@Composable () -> Unit>> get() = _widgets
 
   @Composable
   public fun render() {
+    // Observe the layout modifier count so we recompose if it changes.
+    layoutModifierTick
+
     for (index in _widgets.indices) {
-      // Observe the layout modifier so we recompose if it changes.
-      layoutModifiers[index]
       _widgets[index].value()
     }
   }
 
   override fun insert(index: Int, widget: Widget<@Composable () -> Unit>) {
     _widgets.add(index, widget)
-    layoutModifiers.add(index, widget.layoutModifiers)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {
     _widgets.move(fromIndex, toIndex, count)
-    layoutModifiers.move(fromIndex, toIndex, count)
   }
 
   override fun remove(index: Int, count: Int) {
     _widgets.remove(index, count)
-    layoutModifiers.remove(index, count)
   }
 
-  override fun onLayoutModifierUpdated(index: Int) {
-    layoutModifiers.set(index, _widgets[index].layoutModifiers)
+  override fun onLayoutModifierUpdated() {
+    layoutModifierTick++
   }
 }

--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
@@ -52,7 +52,7 @@ public class ViewGroupChildren(
     parent.removeViews(index, count)
   }
 
-  override fun onLayoutModifierUpdated(index: Int) {
-    parent.getChildAt(index).requestLayout()
+  override fun onLayoutModifierUpdated() {
+    parent.requestLayout()
   }
 }

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
@@ -38,5 +38,5 @@ public class MutableListChildren<W : Any>(
     list.remove(index, count)
   }
 
-  override fun onLayoutModifierUpdated(index: Int) {}
+  override fun onLayoutModifierUpdated() {}
 }

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -65,7 +65,7 @@ public interface Widget<W : Any> {
     /** Remove [count] child widgets starting from [index]. */
     public fun remove(index: Int, count: Int)
 
-    /** Indicates that the [LayoutModifier] for the widget at [index] has changed. */
-    public fun onLayoutModifierUpdated(index: Int)
+    /** Indicates that [LayoutModifier]s for the child widgets have changed. */
+    public fun onLayoutModifierUpdated()
   }
 }

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -62,7 +62,7 @@ public class UIViewChildren(
     invalidate()
   }
 
-  override fun onLayoutModifierUpdated(index: Int) {
+  override fun onLayoutModifierUpdated() {
     invalidate()
   }
 

--- a/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
+++ b/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
@@ -61,9 +61,11 @@ public class HTMLElementChildren(
     }
   }
 
-  override fun onLayoutModifierUpdated(index: Int) {
-    val element = parent.children[index] as HTMLElement
+  override fun onLayoutModifierUpdated() {
+    // If this function is being invoked we are guaranteed to have at least one child.
+
+    val element = parent.children[0] as HTMLElement
     parent.removeChild(element)
-    parent.insertBefore(element, parent.children[index])
+    parent.insertBefore(element, parent.children[0])
   }
 }


### PR DESCRIPTION
This is the lead up to a change where the child will notify the enclosing children container directly of a modifier change.

Refs #998

I'm not super happy with this entire mechanism. There's clear deficiencies in how the Compose UI and HTML parts work. This change and another that will follow it are solely to unblock some other work first. Then we can circle back on cleaning up the relationship between children and their containers.