### PR TITLE
Remove old Spotless excludes

### DIFF
--- a/redwood-protocol-compose/build.gradle
+++ b/redwood-protocol-compose/build.gradle
@@ -49,12 +49,3 @@ android {
     unitTests.returnDefaultValues = true
   }
 }
-
-spotless {
-  kotlin {
-    targetExclude(
-      // Apache 2-licensed files from AOSP.
-      "src/commonMain/kotlin/app/cash/redwood/protocol/compose/utils.kt",
-    )
-  }
-}

--- a/redwood-protocol-widget/build.gradle
+++ b/redwood-protocol-widget/build.gradle
@@ -31,12 +31,3 @@ kotlin {
 android {
   namespace 'app.cash.redwood.protocol.widget'
 }
-
-spotless {
-  kotlin {
-    targetExclude(
-      // Apache 2-licensed files from AOSP.
-      "src/commonMain/kotlin/app/cash/redwood/protocol/widget/utils.kt",
-    )
-  }
-}

--- a/redwood-widget-compose/build.gradle
+++ b/redwood-widget-compose/build.gradle
@@ -19,12 +19,3 @@ kotlin {
     }
   }
 }
-
-spotless {
-  kotlin {
-    targetExclude(
-      // Apache 2-licensed files from AOSP.
-      "src/commonMain/kotlin/app/cash/redwood/widget/compose/utils.kt",
-    )
-  }
-}

--- a/redwood-widget/build.gradle
+++ b/redwood-widget/build.gradle
@@ -34,12 +34,3 @@ kotlin {
 android {
   namespace 'app.cash.redwood.widget'
 }
-
-spotless {
-  kotlin {
-    targetExclude(
-      // Apache 2-licensed files from AOSP.
-      "src/commonMain/kotlin/app/cash/redwood/widget/utils.kt",
-    )
-  }
-}


### PR DESCRIPTION
These were for code copied from the Compose runtime. We now generate the files into the build directory which Spotless does not run over.