### PR TITLE
Avoid indirection for storing widgets in children implementations

### DIFF
--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
@@ -21,11 +21,11 @@ import android.view.ViewGroup
 public class ViewGroupChildren(
   private val parent: ViewGroup,
 ) : Widget.Children<View> {
-  private val _widgets = MutableListChildren<View>()
+  private val _widgets = ArrayList<Widget<View>>()
   public val widgets: List<Widget<View>> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<View>) {
-    _widgets.insert(index, widget)
+    _widgets.add(index, widget)
     parent.addView(widget.value, index)
   }
 

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -26,11 +26,11 @@ public class UIViewChildren(
     parent.insertSubview(view, index.convert<NSInteger>())
   },
 ) : Widget.Children<UIView> {
-  private val _widgets = MutableListChildren<UIView>()
+  private val _widgets = ArrayList<Widget<UIView>>()
   public val widgets: List<Widget<UIView>> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<UIView>) {
-    _widgets.insert(index, widget)
+    _widgets.add(index, widget)
     insert(widget.value, index)
     invalidate()
   }

--- a/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
+++ b/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
@@ -21,11 +21,11 @@ import org.w3c.dom.get
 public class HTMLElementChildren(
   private val parent: HTMLElement,
 ) : Widget.Children<HTMLElement> {
-  private val _widgets = MutableListChildren<HTMLElement>()
+  private val _widgets = ArrayList<Widget<HTMLElement>>()
   public val widgets: List<Widget<HTMLElement>> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<HTMLElement>) {
-    _widgets.insert(index, widget)
+    _widgets.add(index, widget)
 
     // Null element returned when index == childCount causes insertion at end.
     val current = parent.children[index]


### PR DESCRIPTION
`MutableListChildren` wraps an `ArrayList`, so using an `ArrayList` directly saves an allocation.