### PR TITLE
Completely hide our applier from the public API

### DIFF
--- a/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/RedwoodTester.kt
+++ b/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/RedwoodTester.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.compose.RedwoodComposition
-import app.cash.redwood.compose.WidgetApplier
 import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
 import kotlin.time.Duration
@@ -56,7 +55,9 @@ public class RedwoodTester @RedwoodCodegenApi constructor(
 
   private val composition = RedwoodComposition(
     scope = scope + clock,
-    applier = WidgetApplier(provider, mutableChildren) {
+    container = mutableChildren,
+    provider = provider,
+    onEndChanges = {
       val newSnapshot = mutableChildren.map { it.value.snapshot() }
 
       // trySend always succeeds on a CONFLATED channel.

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
@@ -71,15 +71,9 @@ public fun <W : Any> RedwoodComposition(
   scope: CoroutineScope,
   container: Widget.Children<W>,
   provider: Widget.Provider<W>,
+  onEndChanges: () -> Unit = {},
 ): RedwoodComposition {
-  return WidgetRedwoodComposition(scope, WidgetApplier(provider, container))
-}
-
-public fun RedwoodComposition(
-  scope: CoroutineScope,
-  applier: WidgetApplier<*>,
-): RedwoodComposition {
-  return WidgetRedwoodComposition(scope, applier)
+  return WidgetRedwoodComposition(scope, WidgetApplier(provider, container, onEndChanges))
 }
 
 private class WidgetRedwoodComposition(
@@ -118,6 +112,12 @@ private class WidgetRedwoodComposition(
   }
 }
 
+/** @suppress For generated code usage only. */
+@RedwoodCodegenApi
+public interface RedwoodApplier<W : Any> {
+  public val provider: Widget.Provider<W>
+}
+
 /**
  * A version of [ComposeNode] which exposes the applier to the [factory] function. Through this
  * we expose the provider type [P] to our factory function so the correct widget can be created.
@@ -137,7 +137,7 @@ public inline fun <P : Widget.Provider<*>, W : Widget<*>> RedwoodComposeNode(
 
   if (currentComposer.inserting) {
     @Suppress("UNCHECKED_CAST") // Safe so long as you use generated composition function.
-    val applier = currentComposer.applier as WidgetApplier<P>
+    val applier = currentComposer.applier as RedwoodApplier<P>
     currentComposer.createNode {
       @Suppress("UNCHECKED_CAST") // Safe so long as you use generated composition function.
       factory(applier.provider as P)
@@ -186,8 +186,6 @@ public class RedwoodComposeContent<out W : Widget<*>> {
  * supports one or more groups of children will have one or more of these synthetic nodes as its
  * direct descendants. The nodes which are produced by each group of children will then become the
  * descendants of those synthetic nodes.
- *
- * @suppress For generated code usage only.
  */
 internal class ChildrenWidget<W : Any> private constructor(
   var accessor: ((Widget<W>) -> Widget.Children<W>)?,

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.compose
 
 import androidx.compose.runtime.AbstractApplier
 import androidx.compose.runtime.Applier
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.widget.Widget
 
 /**
@@ -44,11 +45,12 @@ import app.cash.redwood.widget.Widget
  * user widgets to the synthetic children widgets as they can never be individually moved/removed.
  * The hierarchy is maintained by Compose's slot table and is represented by dotted lines above.
  */
-public class WidgetApplier<W : Any>(
-  public val provider: Widget.Provider<W>,
+@OptIn(RedwoodCodegenApi::class)
+internal class WidgetApplier<W : Any>(
+  override val provider: Widget.Provider<W>,
   root: Widget.Children<W>,
-  private val onEndChanges: () -> Unit = {},
-) : AbstractApplier<Widget<W>>(ChildrenWidget(root)) {
+  private val onEndChanges: () -> Unit,
+) : AbstractApplier<Widget<W>>(ChildrenWidget(root)), RedwoodApplier<W> {
   private var closed = false
 
   override fun onEndChanges() {

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MonotonicFrameClock
 import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.compose.RedwoodComposition
-import app.cash.redwood.compose.WidgetApplier
 import app.cash.redwood.protocol.DiffSink
 import kotlinx.coroutines.CoroutineScope
 
@@ -34,10 +33,9 @@ public fun ProtocolRedwoodComposition(
   diffSink: DiffSink,
   widgetVersion: UInt,
 ): RedwoodComposition {
-  val applier = WidgetApplier(bridge.provider, bridge.root) {
+  val composition = RedwoodComposition(scope, bridge.root, bridge.provider) {
     bridge.createDiffOrNull()?.let(diffSink::sendDiff)
   }
-  val composition = RedwoodComposition(scope, applier)
   return ProtocolRedwoodComposition(composition, widgetVersion)
 }
 


### PR DESCRIPTION
I need to make some fundamental changes to how it works and realized that it can trivially be hidden from the public API.

This was going to come after my change to fix #998, but decided to pull it out before because it makes that one smaller.