### PR TITLE
Restore removing removed nodes from widget-side of protocol

### DIFF
--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolWidgetChildren.kt
@@ -35,11 +35,15 @@ internal class ProtocolWidgetChildren(
   }
 
   override fun remove(index: Int, count: Int) {
-    for (i in index until index + count) {
-      state.removeWidget(ids[i])
+    val removingIds = ids.subList(index, index + count)
+    val removedIds = removingIds.toList()
+    removingIds.clear()
+
+    for (removedId in removedIds) {
+      state.removeWidget(removedId)
     }
-    ids.remove(index, count)
-    state.append(ChildrenDiff.Remove(id, tag, index, count))
+
+    state.append(ChildrenDiff.Remove(id, tag, index, count, removedIds))
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {

--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
@@ -64,6 +64,8 @@ public class ProtocolBridge<W : Any>(
         }
         is ChildrenDiff.Remove -> {
           children.remove(childrenDiff.index, childrenDiff.count)
+          @Suppress("ConvertArgumentToSet") // Compose side guarantees set semantics.
+          nodes.keys.removeAll(childrenDiff.removedIds)
         }
       }
     }
@@ -80,7 +82,7 @@ public class ProtocolBridge<W : Any>(
   }
 
   private fun node(id: Id): ProtocolNode<W> {
-    return checkNotNull(nodes[id]) { "Unknown widget ID $id" }
+    return checkNotNull(nodes[id]) { "Unknown widget ID ${id.value}" }
   }
 }
 

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
@@ -34,7 +34,7 @@ open class EmptyExampleSchemaWidgetFactory : ExampleSchemaWidgetFactory<Nothing>
       get() = TODO()
       set(_) { TODO() }
 
-    override fun text(text: String?) {}
+    override fun text(text: String?) = TODO()
     override fun onClick(onClick: (() -> Unit)?) = TODO()
   }
   override fun TextInput(): TextInput<Nothing> = TODO()

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
@@ -34,7 +34,7 @@ open class EmptyExampleSchemaWidgetFactory : ExampleSchemaWidgetFactory<Nothing>
       get() = TODO()
       set(_) { TODO() }
 
-    override fun text(text: String?) = TODO()
+    override fun text(text: String?) {}
     override fun onClick(onClick: (() -> Unit)?) = TODO()
   }
   override fun TextInput(): TextInput<Nothing> = TODO()

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
@@ -138,5 +138,12 @@ public sealed class ChildrenDiff {
     override val tag: ChildrenTag,
     val index: Int,
     val count: Int,
-  ) : ChildrenDiff()
+    val removedIds: List<Id>,
+  ) : ChildrenDiff() {
+    init {
+      require(count == removedIds.size) {
+        "Count $count != Removed ID list size ${removedIds.size}"
+      }
+    }
+  }
 }

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
@@ -56,7 +56,7 @@ class ProtocolTest {
       childrenDiffs = listOf(
         ChildrenDiff.Insert(Id(1), ChildrenTag(2), Id(3), WidgetTag(4), 5),
         ChildrenDiff.Move(Id(1), ChildrenTag(2), 3, 4, 5),
-        ChildrenDiff.Remove(Id(1), ChildrenTag(2), 3, 4),
+        ChildrenDiff.Remove(Id(1), ChildrenTag(2), 3, 4, listOf(Id(5), Id(6), Id(7), Id(8))),
       ),
       layoutModifiers = listOf(
         LayoutModifiers(
@@ -93,7 +93,7 @@ class ProtocolTest {
       """{"childrenDiffs":[""" +
       """["insert",{"id":1,"tag":2,"childId":3,"widgetTag":4,"index":5}],""" +
       """["move",{"id":1,"tag":2,"fromIndex":3,"toIndex":4,"count":5}],""" +
-      """["remove",{"id":1,"tag":2,"index":3,"count":4}]""" +
+      """["remove",{"id":1,"tag":2,"index":3,"count":4,"removedIds":[5,6,7,8]}]""" +
       """],"layoutModifiers":[""" +
       """{"id":1,"elements":[[1,{}],[2,3],[3,[]],[4],[5]]}""" +
       """],"propertyDiffs":[""" +
@@ -111,6 +111,13 @@ class ProtocolTest {
     )
     val json = "{}"
     assertJsonRoundtrip(Diff.serializer(), model, json)
+  }
+
+  @Test fun removeCountMustMatchListSize() {
+    val t = assertFailsWith<IllegalArgumentException> {
+      ChildrenDiff.Remove(Id(1), ChildrenTag(2), 3, 4, listOf(Id(5), Id(6), Id(7)))
+    }
+    assertThat(t).hasMessage("Count 4 != Removed ID list size 3")
   }
 
   @Test fun layoutModifierElementSerialization() {


### PR DESCRIPTION
This was lost as part of #1017. Add a test for it.