### PR TITLE
Eliminate scope parameter from tester

### DIFF
--- a/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/RedwoodTester.kt
+++ b/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/RedwoodTester.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -39,8 +40,7 @@ import kotlinx.coroutines.withTimeout
  */
 @OptIn(RedwoodCodegenApi::class)
 public class RedwoodTester @RedwoodCodegenApi constructor(
-  scope: CoroutineScope,
-  provider: Widget.Provider<MutableWidget>,
+  private val provider: Widget.Provider<MutableWidget>,
 ) {
   /** Emit frames manually in [sendFrames]. */
   private val clock = BroadcastFrameClock()
@@ -50,40 +50,45 @@ public class RedwoodTester @RedwoodCodegenApi constructor(
   /** Channel with the most recent snapshot, if any. */
   private val snapshots = Channel<List<WidgetValue>>(Channel.CONFLATED)
 
-  /** Top-level children of the composition. */
-  private val mutableChildren = MutableListChildren<MutableWidget>()
-
-  private val composition = RedwoodComposition(
-    scope = scope + clock,
-    container = mutableChildren,
-    provider = provider,
-    onEndChanges = {
-      val newSnapshot = mutableChildren.map { it.value.snapshot() }
-
-      // trySend always succeeds on a CONFLATED channel.
-      check(snapshots.trySend(newSnapshot).isSuccess)
-    },
-  )
-
   /** Execute [testBody] and then cancel this tester. */
-  public suspend fun test(testBody: suspend RedwoodTester.() -> Unit) {
-    try {
-      testBody()
-    } finally {
-      cancel()
-    }
-  }
+  public suspend fun test(testBody: suspend TestScope.() -> Unit) {
+    coroutineScope {
+      val mutableChildren = MutableListChildren<MutableWidget>()
+      val composition = RedwoodComposition(
+        scope = this + clock,
+        container = mutableChildren,
+        provider = provider,
+        onEndChanges = {
+          val newSnapshot = mutableChildren.map { it.value.snapshot() }
 
-  public fun setContent(content: @Composable () -> Unit) {
-    composition.setContent(content)
+          // trySend always succeeds on a CONFLATED channel.
+          check(snapshots.trySend(newSnapshot).isSuccess)
+        },
+      )
+
+      val scope = object : TestScope {
+        override fun setContent(content: @Composable () -> Unit) {
+          composition.setContent(content)
+        }
+        override suspend fun awaitSnapshot(timeout: Duration): List<WidgetValue> {
+          return this@RedwoodTester.awaitSnapshot(timeout)
+        }
+      }
+
+      try {
+        scope.testBody()
+      } finally {
+        composition.cancel()
+      }
+    }
   }
 
   /**
    * Returns a snapshot, waiting if necessary for changes to occur since the previous snapshot.
    *
-   * @throws TimeoutCancellationException if no new snapshot is produced before [timeoutMillis].
+   * @throws TimeoutCancellationException if no new snapshot is produced before [timeout].
    */
-  public suspend fun awaitSnapshot(timeout: Duration = 1.seconds): List<WidgetValue> {
+  private suspend fun awaitSnapshot(timeout: Duration): List<WidgetValue> {
     // Await at least one change, sending frames while we wait.
     return withTimeout(timeout) {
       val sendFramesJob = sendFrames()
@@ -105,8 +110,9 @@ public class RedwoodTester @RedwoodCodegenApi constructor(
       }
     }
   }
+}
 
-  public fun cancel() {
-    composition.cancel()
-  }
+public interface TestScope {
+  public fun setContent(content: @Composable () -> Unit)
+  public suspend fun awaitSnapshot(timeout: Duration = 1.seconds): List<WidgetValue>
 }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -43,9 +43,8 @@ import com.squareup.kotlinpoet.TypeSpec
 
 /*
 @OptIn(RedwoodCodegenApi::class)
-public fun SunspotTester(scope: CoroutineScope): RedwoodTester {
+public fun SunspotTester(): RedwoodTester {
   return RedwoodTester(
-    scope = scope,
     provider = SunspotWidgetFactories(
       Sunspot = MutableSunspotWidgetFactory(),
       RedwoodLayout = MutableRedwoodLayoutWidgetFactory(),
@@ -60,10 +59,8 @@ internal fun generateTester(schemaSet: SchemaSet): FileSpec {
     .addFunction(
       FunSpec.builder(testerFunction.simpleName)
         .addAnnotation(Redwood.OptInToRedwoodCodegenApi)
-        .addParameter("scope", KotlinxCoroutines.CoroutineScope)
         .returns(RedwoodTesting.RedwoodTester)
         .addCode("return %T(⇥\n", RedwoodTesting.RedwoodTester)
-        .addCode("scope = scope,\n")
         .addCode("provider = %T(⇥\n", schema.getWidgetFactoriesType())
         .apply {
           for (dependency in schemaSet.all) {

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/TestingGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/TestingGenerationTest.kt
@@ -54,9 +54,7 @@ class TestingGenerationTest {
     assertThat(testerFileSpec.toString()).contains(
       """
       |@OptIn(RedwoodCodegenApi::class)
-      |public fun TestingGenerationTestHappyPathSchemaTester(scope: CoroutineScope): RedwoodTester =
-      |    RedwoodTester(
-      |  scope = scope,
+      |public fun TestingGenerationTestHappyPathSchemaTester(): RedwoodTester = RedwoodTester(
       |  provider = TestingGenerationTestHappyPathSchemaWidgetFactories(
       |    TestingGenerationTestHappyPathSchema =
       |        MutableTestingGenerationTestHappyPathSchemaWidgetFactory(),

--- a/samples/emoji-search/presenter/src/commonTest/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTest.kt
+++ b/samples/emoji-search/presenter/src/commonTest/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTest.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.test.runTest
 class EmojiSearchTest {
   @Test
   fun recomposed() = runTest {
-    EmojiSearchTester(this).test {
+    EmojiSearchTester().test {
       setContent {
         BasicEmojiSearch()
       }


### PR DESCRIPTION
Closes #806.

Probably still some API massaging to do here in the future for the tester API and the regular protocol widgets, but it at least fixes the issue.