### PR TITLE
Fix JS build by specifying unique module names

### DIFF
--- a/samples/counter/browser/build.gradle
+++ b/samples/counter/browser/build.gradle
@@ -1,10 +1,13 @@
 apply plugin: 'org.jetbrains.kotlin.js'
 apply plugin: 'app.cash.redwood'
 
+// The name of the final JS file to be referenced from HTML.
 archivesBaseName = 'counter'
 
 kotlin {
   js {
+    // The name of the JS module which needs to be unique within the repo.
+    moduleName = 'counter-browser'
     browser()
     binaries.executable()
   }

--- a/samples/emoji-search/browser/build.gradle
+++ b/samples/emoji-search/browser/build.gradle
@@ -1,10 +1,13 @@
 apply plugin: 'org.jetbrains.kotlin.js'
 apply plugin: 'app.cash.redwood'
 
+// The name of the final JS file to be referenced from HTML.
 archivesBaseName = 'emoji-search'
 
 kotlin {
   js {
+    // The name of the JS module which needs to be unique within the repo.
+    moduleName = 'emoji-search-browser'
     browser()
     binaries.executable()
   }

--- a/samples/emoji-search/presenter-treehouse/build.gradle
+++ b/samples/emoji-search/presenter-treehouse/build.gradle
@@ -10,6 +10,8 @@ kotlin {
   jvm()
 
   js {
+    // The name of the JS module which needs to be unique within the repo.
+    moduleName = 'emoji-search-presenter-treehouse'
     browser()
     binaries.executable()
   }

--- a/samples/repo-search/presenter-treehouse/build.gradle
+++ b/samples/repo-search/presenter-treehouse/build.gradle
@@ -6,6 +6,8 @@ kotlin {
   jvm()
 
   js {
+    // The name of the JS module which needs to be unique within the repo.
+    moduleName = 'repo-search-presenter-treehouse'
     browser()
     binaries.executable()
   }


### PR DESCRIPTION
By default these JS modules inherit the project name which was either 'browser' or 'presenter-treehouse', except those names are used twice because we have multiple samples with the same folder structure. When these modules were installed into a repo-local folder of all modules, the duplication would cause the second task to overwrite the first. As of Gradle 8, this is a build-time error.

Specifying unique module names ensures these write to separate folders and thus are able to be built without stomping on each other.

Closes #988