### PR TITLE
Revert "Update kotlinx-coroutines to v1.7.0 (#1025)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.8.20"
-kotlinx-coroutines = "1.7.0"
+kotlinx-coroutines = "1.6.4"
 kotlinx-serialization = "1.5.0"
 androidxComposeCompiler = "1.4.5"
 androidx-activity = "1.7.1"


### PR DESCRIPTION
This reverts commit c1b5ce00e562fdf2b536e7310b435dfdb8888750.

Blocked by https://github.com/Kotlin/kotlinx.coroutines/issues/3673