### PR TITLE
Scope CodeListener initial to the current content

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeListener.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeListener.kt
@@ -28,6 +28,8 @@ public open class CodeListener {
   /**
    * Invoked each time new code is loaded. This is called after the view's old children have
    * been cleared but before the children of the new code have been added.
+   *
+   * @param initial true if this is the first code loaded for this view's current content.
    */
   public open fun onCodeLoaded(view: TreehouseView, initial: Boolean) {}
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -169,9 +169,8 @@ public class TreehouseApp<A : AppService> private constructor(
         app = this@TreehouseApp,
         appScope = appScope,
         sessionScope = sessionScope,
-        zipline = zipline,
         appService = appService,
-        isInitialLaunch = previous == null,
+        zipline = zipline,
         frameClock = factory.frameClock,
       )
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineSession.kt
@@ -32,7 +32,6 @@ internal class ZiplineSession<A : AppService>(
   val sessionScope: CoroutineScope,
   val appService: A,
   val zipline: Zipline,
-  val isInitialLaunch: Boolean,
   private val frameClock: FrameClock,
 ) {
   private val ziplineScope = ZiplineScope()


### PR DESCRIPTION
If we create a brand new TreehouseView, or set a brand new Content on an old TreehouseView, then the first code it receives should always have 'initial = true'. As-is that depends on whether the TreehouseApp has ever seen a code update.