### PR TITLE
Simplify internal LazyList#items block

### DIFF
--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -60,9 +60,9 @@ internal fun LazyList(
       }
     },
     items = {
-      for (index in (0 until lazyPagingItems.itemCount)) {
+      repeat(lazyPagingItems.itemCount) { index ->
         // Only invokes Composable lambdas that are loaded.
-        lazyPagingItems.peek(index)?.invoke() ?: break
+        lazyPagingItems.peek(index)!!()
       }
     },
   )


### PR DESCRIPTION
Per [the docs](https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems#peek(kotlin.Int)), `LazyPagingItems#peek` only returns `null` if placeholders are enabled (which they aren't).