### PR TITLE
Add ‘pull to refresh’ and indicator support to LazyLists

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version = "1.6.1" }
 androidx-core = { module = "androidx.core:core-ktx", version = "1.10.1" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.3.0" }
+androidx-swipeRefreshLayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 androidx-test-core = "androidx.test:core-ktx:1.5.0"
 androidx-test-runner = "androidx.test:runner:1.5.2"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyDsl.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyDsl.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.lazylayout.compose
 
 import androidx.compose.runtime.Composable
+import app.cash.redwood.LayoutModifier
 import app.cash.redwood.LayoutScopeMarker
 
 @LayoutScopeMarker
@@ -64,22 +65,63 @@ public inline fun <T> LazyListScope.itemsIndexed(
   itemContent(it, items[it])
 }
 
+@RequiresOptIn("This API is for use by Redwood's generated code only")
+public annotation class ExperimentalRedwoodLazyLayoutApi
+
 @Composable
 public fun LazyRow(
+  layoutModifier: LayoutModifier = LayoutModifier,
   content: LazyListScope.() -> Unit,
 ) {
   LazyList(
     isVertical = false,
+    layoutModifier = layoutModifier,
+    content = content,
+  )
+}
+
+@ExperimentalRedwoodLazyLayoutApi
+@Composable
+public fun LazyRow(
+  refreshing: Boolean,
+  onRefresh: (() -> Unit)?,
+  layoutModifier: LayoutModifier = LayoutModifier,
+  content: LazyListScope.() -> Unit,
+) {
+  RefreshableLazyList(
+    isVertical = false,
+    refreshing = refreshing,
+    onRefresh = onRefresh,
+    layoutModifier = layoutModifier,
     content = content,
   )
 }
 
 @Composable
 public fun LazyColumn(
+  layoutModifier: LayoutModifier = LayoutModifier,
   content: LazyListScope.() -> Unit,
 ) {
   LazyList(
     isVertical = true,
+    layoutModifier = layoutModifier,
+    content = content,
+  )
+}
+
+@ExperimentalRedwoodLazyLayoutApi
+@Composable
+public fun LazyColumn(
+  refreshing: Boolean,
+  onRefresh: (() -> Unit)?,
+  layoutModifier: LayoutModifier = LayoutModifier,
+  content: LazyListScope.() -> Unit,
+) {
+  RefreshableLazyList(
+    isVertical = true,
+    refreshing = refreshing,
+    onRefresh = onRefresh,
+    layoutModifier = layoutModifier,
     content = content,
   )
 }

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyDsl.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyDsl.kt
@@ -65,7 +65,7 @@ public inline fun <T> LazyListScope.itemsIndexed(
   itemContent(it, items[it])
 }
 
-@RequiresOptIn("This API is for use by Redwood's generated code only")
+@RequiresOptIn("This Redwood LazyLayout API is experimental and may change in the future.")
 public annotation class ExperimentalRedwoodLazyLayoutApi
 
 @Composable

--- a/redwood-lazylayout-composeui/build.gradle
+++ b/redwood-lazylayout-composeui/build.gradle
@@ -27,6 +27,7 @@ kotlin {
         api projects.redwoodLazylayoutWidget
         implementation projects.redwoodWidgetCompose
         implementation libs.jetbrains.compose.foundation
+        implementation libs.jetbrains.compose.material
       }
     }
   }

--- a/redwood-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/lazylayout/composeui/ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/lazylayout/composeui/ComposeUiRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -18,8 +18,11 @@ package app.cash.redwood.lazylayout.composeui
 import androidx.compose.runtime.Composable
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory
+import app.cash.redwood.lazylayout.widget.RefreshableLazyList
 
 public class ComposeUiRedwoodLazyLayoutWidgetFactory :
   RedwoodLazyLayoutWidgetFactory<@Composable () -> Unit> {
   override fun LazyList(): LazyList<@Composable () -> Unit> = ComposeUiLazyList()
+
+  override fun RefreshableLazyList(): RefreshableLazyList<@Composable () -> Unit> = ComposeUiLazyList()
 }

--- a/redwood-lazylayout-schema/src/main/kotlin/app/cash/redwood/lazylayout/schema.kt
+++ b/redwood-lazylayout-schema/src/main/kotlin/app/cash/redwood/lazylayout/schema.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.schema.Schema
 @Schema(
   [
     LazyList::class,
+    RefreshableLazyList::class,
   ],
 )
 public interface RedwoodLazyLayout

--- a/redwood-lazylayout-schema/src/main/kotlin/app/cash/redwood/lazylayout/widgets.kt
+++ b/redwood-lazylayout-schema/src/main/kotlin/app/cash/redwood/lazylayout/widgets.kt
@@ -25,3 +25,12 @@ public data class LazyList(
   @Property(2) val onPositionDisplayed: (position: Int) -> Unit,
   @Children(1) val items: () -> Unit,
 )
+
+@Widget(2)
+public data class RefreshableLazyList(
+  @Property(1) val isVertical: Boolean,
+  @Property(2) val onPositionDisplayed: (position: Int) -> Unit,
+  @Property(3) val refreshing: Boolean,
+  @Property(4) val onRefresh: (() -> Unit)?,
+  @Children(1) val items: () -> Unit,
+)

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIControlExt.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIControlExt.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.lazylayout.uiview
+
+import kotlinx.cinterop.ExportObjCClass
+import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.cstr
+import platform.Foundation.NSSelectorFromString
+import platform.UIKit.UIControl
+import platform.UIKit.UIControlEvents
+import platform.darwin.NSObject
+import platform.objc.OBJC_ASSOCIATION_RETAIN
+import platform.objc.objc_setAssociatedObject
+
+/**
+ * Thanks to this magic incantation from:
+ * https://github.com/icerockdev/moko-mvvm/blob/e8d66557499e568dc7bfb9bf6c8c4782a8790f09/mvvm-livedata/src/iosMain/kotlin/dev/icerock/moko/mvvm/utils/UIControlExt.kt
+ */
+
+internal fun <T : UIControl> T.setEventHandler(
+  event: UIControlEvents,
+  lambda: T.() -> Unit,
+) {
+  val lambdaTarget = ControlLambdaTarget(lambda)
+  val action = NSSelectorFromString("action:")
+
+  addTarget(
+    target = lambdaTarget,
+    action = action,
+    forControlEvents = event,
+  )
+
+  objc_setAssociatedObject(
+    `object` = this,
+    key = "event$event".cstr,
+    value = lambdaTarget,
+    policy = OBJC_ASSOCIATION_RETAIN,
+  )
+}
+
+@ExportObjCClass
+private class ControlLambdaTarget<T : UIControl>(
+  private val lambda: T.() -> Unit,
+) : NSObject() {
+  @ObjCAction
+  fun action(sender: UIControl) {
+    @Suppress("UNCHECKED_CAST")
+    lambda(sender as T)
+  }
+}

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
@@ -17,9 +17,15 @@ package app.cash.redwood.lazylayout.uiview
 
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory
+import app.cash.redwood.lazylayout.widget.RefreshableLazyList
+import platform.UIKit.UIRefreshControl
 import platform.UIKit.UIView
 
 @ObjCName("UIViewRedwoodLazyLayoutWidgetFactory", exact = true)
 public class UIViewRedwoodLazyLayoutWidgetFactory : RedwoodLazyLayoutWidgetFactory<UIView> {
   override fun LazyList(): LazyList<UIView> = UIViewLazyList()
+
+  override fun RefreshableLazyList(): RefreshableLazyList<UIView> = UIViewRefreshableLazyList(
+    refreshControlFactory = { UIRefreshControl() },
+  )
 }

--- a/redwood-lazylayout-view/build.gradle
+++ b/redwood-lazylayout-view/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation libs.androidx.core
   implementation libs.androidx.paging.runtime
   implementation libs.androidx.recyclerview
+  implementation libs.androidx.swipeRefreshLayout
 }
 
 android {

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -18,11 +18,20 @@ package app.cash.redwood.lazylayout.view
 import android.content.Context
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory
+import app.cash.redwood.lazylayout.widget.RefreshableLazyList
 
 public class ViewRedwoodLazyLayoutWidgetFactory(
   private val context: Context,
 ) : RedwoodLazyLayoutWidgetFactory<View> {
-  public override fun LazyList(): LazyList<View> = ViewLazyList(RecyclerView(context))
+  public override fun LazyList(): LazyList<View> = ViewLazyList(
+    recyclerViewFactory = { RecyclerView(context) },
+  )
+
+  public override fun RefreshableLazyList(): RefreshableLazyList<View> = ViewRefreshableLazyList(
+    recyclerViewFactory = { RecyclerView(context) },
+    swipeRefreshLayoutFactory = { SwipeRefreshLayout(context) },
+  )
 }

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -16,6 +16,7 @@
 package com.example.redwood.emojisearch.browser
 
 import androidx.compose.runtime.Composable
+import app.cash.redwood.LayoutModifier
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.compose.WindowAnimationFrameClock
 import app.cash.redwood.layout.compose.Column
@@ -78,9 +79,12 @@ private object TruncatingColumnProvider : ColumnProvider {
   @Composable
   override fun <T> create(
     items: List<T>,
+    refreshing: Boolean,
+    onRefresh: (() -> Unit)?,
+    layoutModifier: LayoutModifier,
     itemContent: @Composable (item: T) -> Unit,
   ) {
-    Column {
+    Column(layoutModifier = layoutModifier) {
       for (item in items.take(25)) {
         itemContent(item)
       }

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -49,8 +49,9 @@ fun main() {
       EmojiSearch = HTMLElementEmojiSearchWidgetFactory(document),
       RedwoodLayout = HTMLElementRedwoodLayoutWidgetFactory(document),
       RedwoodLazyLayout = object : RedwoodLazyLayoutWidgetFactory<HTMLElement> {
-        // For now we use a ColumnProvider to replace this with a normal Column.
+        // For now we use a ColumnProvider to replace these with a normal Column.
         override fun LazyList() = throw UnsupportedOperationException()
+        override fun RefreshableLazyList() = throw UnsupportedOperationException()
       },
     ),
   )

--- a/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
+++ b/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
@@ -16,6 +16,8 @@
 package com.example.redwood.emojisearch.presenter
 
 import androidx.compose.runtime.Composable
+import app.cash.redwood.LayoutModifier
+import app.cash.redwood.lazylayout.compose.ExperimentalRedwoodLazyLayoutApi
 import app.cash.redwood.treehouse.TreehouseUi
 import app.cash.redwood.lazylayout.compose.LazyColumn
 import app.cash.redwood.lazylayout.compose.items
@@ -32,12 +34,20 @@ class EmojiSearchTreehouseUi(
 }
 
 private class LazyColumnProvider : ColumnProvider {
+  @OptIn(ExperimentalRedwoodLazyLayoutApi::class)
   @Composable
   override fun <T> create(
     items: List<T>,
+    refreshing: Boolean,
+    onRefresh: (() -> Unit)?,
+    layoutModifier: LayoutModifier,
     itemContent: @Composable (item: T) -> Unit,
   ) {
-    LazyColumn {
+    LazyColumn(
+      refreshing = refreshing,
+      onRefresh = onRefresh,
+      layoutModifier = layoutModifier,
+    ) {
       items(items, itemContent)
     }
   }


### PR DESCRIPTION
This maps to:

- Android views: SwipeRefreshLayout
- Compose UI: Material's Modifier.pullRefresh()
- UIKit: UIRefreshControl

https://github.com/cashapp/redwood/assets/227486/b02e83b4-bc52-48db-8434-2816aa1e9302

https://github.com/cashapp/redwood/assets/227486/616e81bc-dfaf-4054-a2e0-d29c8bd5c162

https://github.com/cashapp/redwood/assets/227486/9dafb10b-6939-4d0d-9c3d-b17bd75d936e


