### PR TITLE
Move ItemPagingSource to LazyList and attribute LazyListIntervalContent to Android

### DIFF
--- a/redwood-lazylayout-compose/build.gradle
+++ b/redwood-lazylayout-compose/build.gradle
@@ -30,6 +30,7 @@ spotless {
   kotlin {
     targetExclude(
       // Apache 2-licensed files from AOSP.
+      "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListIntervalContent.kt",
       "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/layout/IntervalList.kt",
       "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/layout/LazyLayoutIntervalContent.kt",
     )


### PR DESCRIPTION
`ItemPagingSource` is highly specific to our use case, while the rest of `LazyListIntervalContent.kt` is a slightly pruned copy of AndroidX's. The refactor makes this point evident.