### PR TITLE
Use javac release flag on all compilations

### DIFF
--- a/build-support/build.gradle
+++ b/build-support/build.gradle
@@ -55,8 +55,7 @@ buildConfig {
 }
 
 tasks.withType(JavaCompile).configureEach {
-  sourceCompatibility = JavaVersion.VERSION_11.toString()
-  targetCompatibility = JavaVersion.VERSION_11.toString()
+  options.release.set(11)
 }
 
 tasks.withType(KotlinJvmCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,7 @@ allprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    options.release.set(8)
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach {

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-layout-modifiers/build.gradle
@@ -28,8 +28,7 @@ allprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    options.release.set(8)
   }
 
   tasks.withType(KotlinJvmCompile).configureEach {

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/build.gradle
@@ -27,8 +27,7 @@ allprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    options.release.set(8)
   }
 
   tasks.withType(KotlinJvmCompile).configureEach {

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-reference/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-reference/build.gradle
@@ -27,8 +27,7 @@ allprojects {
   }
 
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    options.release.set(8)
   }
 
   tasks.withType(KotlinJvmCompile).configureEach {

--- a/redwood-tooling-lint/build.gradle
+++ b/redwood-tooling-lint/build.gradle
@@ -23,8 +23,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile).configureEach {
-  sourceCompatibility = JavaVersion.VERSION_11.toString()
-  targetCompatibility = JavaVersion.VERSION_11.toString()
+  options.release.set(11)
 }
 
 tasks.withType(KotlinJvmCompile).configureEach {


### PR DESCRIPTION
This fixes a mismatch of target/release usage in the Gradle plugin:

    Execution failed for task ':redwood-gradle-plugin:compileKotlin'.
    > 'compileJava' task (current target is 1.8) and 'compileKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.

No idea why this wasn't caught on the PR. We absolutely run the Gradle plugin tests on CI.

cc @ZacSweers