### PR TITLE
`ViewTree` nodes should be created top-down but added bottom-up

### DIFF
--- a/redwood-compose-testing/src/commonTest/kotlin/app/cash/redwood/compose/testing/ViewTreesTest.kt
+++ b/redwood-compose-testing/src/commonTest/kotlin/app/cash/redwood/compose/testing/ViewTreesTest.kt
@@ -51,29 +51,23 @@ class ViewTreesTest {
 
     val expected = listOf(
       Create(Id(1), WidgetTag(1)),
-      Add(Id.Root, ChildrenTag.Root, Id(1), 0),
-
       Create(Id(2), WidgetTag(1)),
-      Add(Id(1), ChildrenTag(2), Id(2), 0),
-
       Create(Id(3), WidgetTag(3)),
-      Add(Id(2), ChildrenTag(3), Id(3), 0),
       PropertyChange(Id(3), PropertyTag(1), JsonPrimitive("One Fish")),
-
+      Add(Id(2), ChildrenTag(3), Id(3), 0),
       Create(Id(4), WidgetTag(3)),
-      Add(Id(2), ChildrenTag(3), Id(4), 1),
       PropertyChange(Id(4), PropertyTag(1), JsonPrimitive("Two Fish")),
-
+      Add(Id(2), ChildrenTag(3), Id(4), 1),
+      Add(Id(1), ChildrenTag(2), Id(2), 0),
       Create(Id(5), WidgetTag(1)),
-      Add(Id(1), ChildrenTag(2), Id(5), 1),
-
       Create(Id(6), WidgetTag(3)),
-      Add(Id(5), ChildrenTag(3), Id(6), 0),
       PropertyChange(Id(6), PropertyTag(1), JsonPrimitive("Red Fish")),
-
+      Add(Id(5), ChildrenTag(3), Id(6), 0),
       Create(Id(7), WidgetTag(3)),
-      Add(Id(5), ChildrenTag(3), Id(7), 1),
       PropertyChange(Id(7), PropertyTag(1), JsonPrimitive("Blue Fish")),
+      Add(Id(5), ChildrenTag(3), Id(7), 1),
+      Add(Id(1), ChildrenTag(2), Id(5), 1),
+      Add(Id.Root, ChildrenTag.Root, Id(1), 0),
     )
 
     assertThat(snapshot.viewTree.changes).isEqualTo(expected)


### PR DESCRIPTION
This mimics the behavior of the real applier/protocol bridge.

Closes #1105.