### PR TITLE
Retain a single protocol-based children wrapper

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
@@ -400,15 +400,7 @@ internal fun generateProtocolWidget(
                 addProperty(
                   PropertySpec.builder(trait.name, RedwoodWidget.WidgetChildren.parameterizedBy(NOTHING))
                     .addModifiers(OVERRIDE)
-                    .getter(
-                      FunSpec.getterBuilder()
-                        .addStatement(
-                          "return state.widgetChildren(id, %T(%L))",
-                          Protocol.ChildrenTag,
-                          trait.tag,
-                        )
-                        .build(),
-                    )
+                    .initializer("state.widgetChildren(id, %T(%L))", Protocol.ChildrenTag, trait.tag)
                     .build(),
                 )
               }


### PR DESCRIPTION
Currently we rely on the fact that Compose will only invoke this function once and retain the instance, but generally that's not a safe assumption because these instances are stateful. A future change (in non-Compose usage) will rely on multiple calls returning the same instance.

Sending this separately so it doesn't get lost in the noise of the future PR.