### PR TITLE
Use a schema's `ProtocolBridge` to record changes from a `WidgetValue`

### DIFF
--- a/redwood-compose-testing/build.gradle
+++ b/redwood-compose-testing/build.gradle
@@ -18,8 +18,7 @@ kotlin {
       dependencies {
         api libs.jetbrains.compose.runtime
         api libs.kotlinx.coroutines.core
-        api projects.redwoodCompose
-        api projects.redwoodRuntime
+        api projects.redwoodProtocolCompose
       }
     }
     commonTest {
@@ -28,6 +27,7 @@ kotlin {
         implementation libs.assertk
         implementation libs.kotlinx.coroutines.test
         implementation projects.testSchema.compose
+        implementation projects.testSchema.composeProtocol
         implementation projects.testSchema.testing
       }
     }

--- a/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/ViewTrees.kt
+++ b/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/ViewTrees.kt
@@ -15,21 +15,17 @@
  */
 package app.cash.redwood.compose.testing
 
-import app.cash.redwood.protocol.ChildrenTag
-import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.ViewTree
+import app.cash.redwood.protocol.compose.ProtocolBridge
 
-public val List<WidgetValue>.viewTree: ViewTree
-  get() {
-    val builder = ViewTree.Builder()
-    val root = builder.nextId++
-
-    for ((index, widget) in this.withIndex()) {
-      widget.addTo(Id(root), ChildrenTag.Root, index, builder)
-    }
-
-    return builder.build()
+public fun List<WidgetValue>.toViewTree(factory: ProtocolBridge.Factory): ViewTree {
+  val bridge = factory.create()
+  for ((index, child) in withIndex()) {
+    bridge.root.insert(index, child.toWidget(bridge.provider))
   }
+  return ViewTree(bridge.getChangesOrNull() ?: emptyList())
+}
 
-public val WidgetValue.viewTree: ViewTree
-  get() = listOf(this).viewTree
+public fun WidgetValue.toViewTree(factory: ProtocolBridge.Factory): ViewTree {
+  return listOf(this).toViewTree(factory)
+}

--- a/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/WidgetValue.kt
+++ b/redwood-compose-testing/src/commonMain/kotlin/app/cash/redwood/compose/testing/WidgetValue.kt
@@ -16,9 +16,7 @@
 package app.cash.redwood.compose.testing
 
 import app.cash.redwood.Modifier
-import app.cash.redwood.protocol.ChildrenTag
-import app.cash.redwood.protocol.Id
-import app.cash.redwood.protocol.ViewTree
+import app.cash.redwood.widget.Widget
 
 /**
  * A widget that's implemented as a value class, appropriate for use in tests.
@@ -33,12 +31,7 @@ public interface WidgetValue {
   public val childrenLists: List<List<WidgetValue>>
     get() = listOf()
 
-  public fun addTo(
-    parentId: Id,
-    childrenTag: ChildrenTag,
-    childrenIndex: Int,
-    builder: ViewTree.Builder,
-  )
+  public fun <W : Any> toWidget(provider: Widget.Provider<W>): Widget<W>
 }
 
 /**

--- a/redwood-compose-testing/src/commonTest/kotlin/app/cash/redwood/compose/testing/ViewTreesTest.kt
+++ b/redwood-compose-testing/src/commonTest/kotlin/app/cash/redwood/compose/testing/ViewTreesTest.kt
@@ -24,6 +24,7 @@ import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import example.redwood.compose.ExampleSchemaProtocolBridge
 import example.redwood.compose.Row
 import example.redwood.compose.Text
 import example.redwood.widget.ExampleSchemaTester
@@ -54,23 +55,25 @@ class ViewTreesTest {
       Create(Id(2), WidgetTag(1)),
       Create(Id(3), WidgetTag(3)),
       PropertyChange(Id(3), PropertyTag(1), JsonPrimitive("One Fish")),
-      Add(Id(2), ChildrenTag(3), Id(3), 0),
+      Add(Id(2), ChildrenTag(1), Id(3), 0),
       Create(Id(4), WidgetTag(3)),
       PropertyChange(Id(4), PropertyTag(1), JsonPrimitive("Two Fish")),
-      Add(Id(2), ChildrenTag(3), Id(4), 1),
-      Add(Id(1), ChildrenTag(2), Id(2), 0),
+      Add(Id(2), ChildrenTag(1), Id(4), 1),
+      Add(Id(1), ChildrenTag(1), Id(2), 0),
       Create(Id(5), WidgetTag(1)),
       Create(Id(6), WidgetTag(3)),
       PropertyChange(Id(6), PropertyTag(1), JsonPrimitive("Red Fish")),
-      Add(Id(5), ChildrenTag(3), Id(6), 0),
+      Add(Id(5), ChildrenTag(1), Id(6), 0),
       Create(Id(7), WidgetTag(3)),
       PropertyChange(Id(7), PropertyTag(1), JsonPrimitive("Blue Fish")),
-      Add(Id(5), ChildrenTag(3), Id(7), 1),
-      Add(Id(1), ChildrenTag(2), Id(5), 1),
+      Add(Id(5), ChildrenTag(1), Id(7), 1),
+      Add(Id(1), ChildrenTag(1), Id(5), 1),
       Add(Id.Root, ChildrenTag.Root, Id(1), 0),
     )
 
-    assertThat(snapshot.viewTree.changes).isEqualTo(expected)
-    assertThat(snapshot.single().viewTree.changes).isEqualTo(expected)
+    assertThat(snapshot.toViewTree(ExampleSchemaProtocolBridge).changes)
+      .isEqualTo(expected)
+    assertThat(snapshot.single().toViewTree(ExampleSchemaProtocolBridge).changes)
+      .isEqualTo(expected)
   }
 }

--- a/redwood-compose-testing/src/commonTest/kotlin/app/cash/redwood/compose/testing/WidgetValueTest.kt
+++ b/redwood-compose-testing/src/commonTest/kotlin/app/cash/redwood/compose/testing/WidgetValueTest.kt
@@ -16,9 +16,8 @@
 package app.cash.redwood.compose.testing
 
 import app.cash.redwood.Modifier
-import app.cash.redwood.protocol.ChildrenTag
-import app.cash.redwood.protocol.Id
-import app.cash.redwood.protocol.ViewTree
+import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.Widget.Provider
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
@@ -68,7 +67,7 @@ class WidgetValueTest {
     override val modifier: Modifier = Modifier,
     override val childrenLists: List<List<WidgetValue>> = listOf(),
   ) : WidgetValue {
-    override fun addTo(parentId: Id, childrenTag: ChildrenTag, childrenIndex: Int, builder: ViewTree.Builder) {
+    override fun <W : Any> toWidget(provider: Provider<W>): Widget<W> {
       throw AssertionError()
     }
   }

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/ViewTree.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/ViewTree.kt
@@ -16,7 +16,6 @@
 package app.cash.redwood.protocol
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 
 /**
  * A snapshot of a view hierarchy, intended for use in tests, debugging, and development tools.
@@ -24,13 +23,4 @@ import kotlinx.serialization.json.Json
 @Serializable
 public class ViewTree(
   public val changes: List<Change>,
-) {
-  public class Builder {
-    public var nextId: Int = Id.Root.value
-    public val json: Json = Json
-
-    public val changes: MutableList<Change> = mutableListOf()
-
-    public fun build(): ViewTree = ViewTree(changes.toList())
-  }
-}
+)


### PR DESCRIPTION
This adds a function which given a `WidgetValue` can re-hydrate a full `Widget` given an appropriate `Widget.Provider`. When the protocol-based `Widget.Provider` is used, the result is the same set of changes that normal protocol-based composition produces.

Closes #1033 