### PR TITLE
Remove pagination dependency in Redwood Lazy Layout guest code

### DIFF
--- a/redwood-lazylayout-compose/build.gradle
+++ b/redwood-lazylayout-compose/build.gradle
@@ -15,7 +15,6 @@ kotlin {
     commonMain {
       dependencies {
         api projects.redwoodLazylayoutWidget
-        implementation libs.paging.compose.common
       }
     }
   }
@@ -31,8 +30,10 @@ spotless {
     targetExclude(
       // Apache 2-licensed files from AOSP.
       "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListIntervalContent.kt",
+      "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListItemProvider.kt",
       "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/layout/IntervalList.kt",
       "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/layout/LazyLayoutIntervalContent.kt",
+      "src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/layout/LazyLayoutItemProvider.kt",
     )
   }
 }

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListItemProvider.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListItemProvider.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.lazylayout.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.referentialEqualityPolicy
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import app.cash.redwood.lazylayout.compose.layout.LazyLayoutIntervalContent
+import app.cash.redwood.lazylayout.compose.layout.LazyLayoutItemProvider
+
+// Copied from https://github.com/androidx/androidx/blob/a733905d282ecdba574bc5e35d6b0ebf83c82dcd/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/LazyListItemProvider.kt
+// Removed support for content types, header indices, item scope, and pinnable items.
+
+internal interface LazyListItemProvider : LazyLayoutItemProvider
+
+@Composable
+internal fun rememberLazyListItemProvider(
+  content: LazyListScope.() -> Unit,
+): LazyListItemProvider {
+  val latestContent = rememberUpdatedState(content)
+  return remember(latestContent) {
+    LazyListItemProviderImpl(
+      latestContent = { latestContent.value },
+    )
+  }
+}
+
+private class LazyListItemProviderImpl(
+  private val latestContent: () -> (LazyListScope.() -> Unit),
+) : LazyListItemProvider {
+  private val listContent by derivedStateOf(referentialEqualityPolicy()) {
+    LazyListIntervalContent(latestContent())
+  }
+
+  override val itemCount: Int get() = listContent.itemCount
+
+  @Composable
+  override fun Item(index: Int) {
+    listContent.withInterval(index) { localIndex, content ->
+      content.item(localIndex)
+    }
+  }
+}

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/layout/LazyLayoutItemProvider.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/layout/LazyLayoutItemProvider.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.lazylayout.compose.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+
+// Copied from https://github.com/androidx/androidx/blob/a733905d282ecdba574bc5e35d6b0ebf83c82dcd/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/layout/LazyLayoutItemProvider.kt
+// Removed support for content types.
+
+/**
+ * Provides all the needed info about the items which could be later composed and displayed as
+ * children or [LazyLayout].
+ */
+@Stable
+internal interface LazyLayoutItemProvider {
+
+  /**
+   * The total number of items in the lazy layout (visible or not).
+   */
+  val itemCount: Int
+
+  /**
+   * The item for the given [index].
+   */
+  @Composable
+  fun Item(index: Int)
+}


### PR DESCRIPTION
The guest side of Lazy List previously used Paging purely for its prefetching mechanism (e.g., when loading item 100, make sure the items between 100±20 are also loaded). The actual pagination mechanism of Paging is unnecessary.

Removing this dependency _greatly_ simplifies the logic here, and gives us some performance gains. Notably, we are no longer caching a bunch of Compose lambdas within the internal Paging cache, all of which get invalidated any time the item count of the list changes. We also don't need to cache Compose lambdas by some arbitrary page size, meaning previously we were always holding onto more Compose lambdas than strictly necessary.