### PR TITLE
Move `HostConfiguration` composition local into Redwood

### DIFF
--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/HostConfiguration.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/HostConfiguration.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.treehouse
+package app.cash.redwood.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
@@ -23,7 +23,7 @@ import app.cash.redwood.ui.HostConfiguration
 
 /**
  * Provide the configuration of the host display.
- * This value will be bound automatically when Treehouse is used.
+ * This value will be bound automatically.
  * Custom values should only be provided into a composition for testing purposes!
  *
  * @see HostConfiguration.Companion.current

--- a/redwood-treehouse-guest-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/composition.kt
+++ b/redwood-treehouse-guest-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/composition.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.treehouse
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import app.cash.redwood.compose.LocalHostConfiguration
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.ui.HostConfiguration
 import kotlinx.coroutines.flow.StateFlow


### PR DESCRIPTION
It is not hooked up yet, but at least it is there.

Refs #1054 