### PR TITLE
Add native frame clock for iOS and MacOS

### DIFF
--- a/redwood-compose/src/iosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
+++ b/redwood-compose/src/iosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.compose
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.MonotonicFrameClock
+import kotlinx.cinterop.ObjCAction
+import platform.Foundation.NSRunLoop
+import platform.Foundation.NSSelectorFromString
+import platform.QuartzCore.CADisplayLink
+import platform.darwin.NSObject
+
+public actual object DisplayLinkClock : MonotonicFrameClock {
+
+  private val target = SelectorTarget(this)
+  private val displayLink = CADisplayLink.displayLinkWithTarget(
+    target = target,
+    selector = NSSelectorFromString(SelectorTarget::tickClock.name),
+  )
+
+  private val clock = BroadcastFrameClock {
+    // We only want to listen to the DisplayLink run loop if we have frame awaiters.
+    displayLink.addToRunLoop(NSRunLoop.currentRunLoop, NSRunLoop.currentRunLoop.currentMode)
+  }
+
+  override suspend fun <R> withFrameNanos(onFrame: (frameTimeNanos: Long) -> R): R {
+    return clock.withFrameNanos(onFrame)
+  }
+
+  private fun tickClock() {
+    clock.sendFrame(0L)
+
+    // Detach from the run loop. We will re-attach if new frame awaiters appear.
+    displayLink.removeFromRunLoop(NSRunLoop.currentRunLoop, NSRunLoop.currentRunLoop.currentMode)
+  }
+
+  /**
+   * Selectors can only target subtypes of [NSObject] which is why this helper exists.
+   * We cannot subclass it on [DisplayLinkClock] directly because it implements a Kotlin
+   * interface, but we also don't want to leak it into public API. The contained function
+   * must be public for the selector to work.
+   */
+  private class SelectorTarget(private val target: DisplayLinkClock) : NSObject() {
+    @ObjCAction
+    fun tickClock() {
+      target.tickClock()
+    }
+  }
+}

--- a/redwood-compose/src/macosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
+++ b/redwood-compose/src/macosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.compose
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.MonotonicFrameClock
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.value
+import platform.CoreVideo.CVDisplayLinkCreateWithActiveCGDisplays
+import platform.CoreVideo.CVDisplayLinkRefVar
+import platform.CoreVideo.CVDisplayLinkSetOutputCallback
+import platform.CoreVideo.CVDisplayLinkStart
+import platform.CoreVideo.CVDisplayLinkStop
+import platform.CoreVideo.kCVReturnSuccess
+
+public actual object DisplayLinkClock : MonotonicFrameClock {
+
+  private val clock = BroadcastFrameClock {
+    // One or more awaiters have appeared. Start the DisplayLink clock callback so that awaiters
+    // get dispatched on the next available frame.
+    checkDisplayLink(CVDisplayLinkStart(displayLink.value))
+  }
+
+  // We alloc directly to nativeHeap because this singleton object lives for the duration of the
+  // process. We don't care about cleanup and therefore never free this.
+  private val displayLink = nativeHeap.alloc<CVDisplayLinkRefVar>()
+
+  init {
+    checkDisplayLink(CVDisplayLinkCreateWithActiveCGDisplays(displayLink.ptr))
+    checkDisplayLink(
+      CVDisplayLinkSetOutputCallback(
+        displayLink.value,
+        staticCFunction { _, _, _, _, _, _ ->
+          clock.sendFrame(0L)
+
+          // A frame was delivered. Stop the DisplayLink callback. It will get started again
+          // when new frame awaiters appear.
+          CVDisplayLinkStop(displayLink.value)
+        },
+        null,
+      ),
+    )
+  }
+
+  override suspend fun <R> withFrameNanos(onFrame: (frameTimeNanos: Long) -> R): R {
+    return clock.withFrameNanos(onFrame)
+  }
+
+  private fun checkDisplayLink(code: Int) {
+    check(code == kCVReturnSuccess) { "Could not initialize CVDisplayLink. Error code $code." }
+  }
+}

--- a/redwood-compose/src/macosTest/kotlin/app/cash/redwood/compose/DisplayLinkClockTest.kt
+++ b/redwood-compose/src/macosTest/kotlin/app/cash/redwood/compose/DisplayLinkClockTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.compose
+
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class DisplayLinkClockTest {
+
+  @Test fun `DisplayLinkClock delivers a single frame`() = runTest {
+    DisplayLinkClock.withFrameNanos {
+      // If this function does not time out the test passes.
+    }
+  }
+}

--- a/redwood-compose/src/nativeMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
+++ b/redwood-compose/src/nativeMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.compose
+
+import androidx.compose.runtime.MonotonicFrameClock
+
+public expect object DisplayLinkClock : MonotonicFrameClock

--- a/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
@@ -15,7 +15,7 @@
  */
 package com.example.redwood.counter.ios
 
-import androidx.compose.runtime.BroadcastFrameClock
+import app.cash.redwood.compose.DisplayLinkClock
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.widget.UIViewChildren
@@ -31,8 +31,7 @@ import platform.UIKit.UIStackView
 class CounterViewControllerDelegate(
   root: UIStackView,
 ) {
-  private val clock = BroadcastFrameClock()
-  private val scope = MainScope() + clock
+  private val scope = MainScope() + DisplayLinkClock
 
   init {
     val children = UIViewChildren(
@@ -50,10 +49,6 @@ class CounterViewControllerDelegate(
     composition.setContent {
       Counter()
     }
-  }
-
-  fun tickClock() {
-    clock.sendFrame(0L) // Compose does not use frame time.
   }
 
   fun dispose() {

--- a/samples/counter/ios-uikit/CounterApp/CounterViewController.swift
+++ b/samples/counter/ios-uikit/CounterApp/CounterViewController.swift
@@ -3,7 +3,6 @@ import UIKit
 import CounterKt
 
 class CounterViewController : UIViewController {
-    private var displayLink: CADisplayLink!
     private var delegate: CounterViewControllerDelegate!
 
     override func viewDidLoad() {
@@ -19,22 +18,7 @@ class CounterViewController : UIViewController {
         container.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
         container.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
 
-        let delegate = CounterViewControllerDelegate(root: container)
-        self.delegate = delegate
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        let displayLink = CADisplayLink.init(target: self, selector: #selector(tickClock))
-        displayLink.add(to: .current, forMode: .default)
-        self.displayLink = displayLink
-    }
-
-    @objc func tickClock() {
-        delegate.tickClock()
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        displayLink.invalidate()
+        self.delegate = CounterViewControllerDelegate(root: container)
     }
 
     deinit {


### PR DESCRIPTION
Update the iOS counter sample to use.

Closes #747