### PR TITLE
Do not spend more than 5m trying to download caches on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,9 @@ jobs:
           java-version: 20
 
       - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
 
       - run: ./gradlew kotlinUpgradeYarnLock build -PredwoodNoSamples
 
@@ -37,6 +40,9 @@ jobs:
           java-version: 20
 
       - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
 
       - uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -54,6 +60,10 @@ jobs:
           java-version: 20
 
       - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
+
       - run: ./gradlew dokkaHtmlMultiModule
 
       # If we're on the integration branch, save the site to deploy from the publish job.
@@ -75,6 +85,9 @@ jobs:
           distribution: 'zulu'
           java-version: 20
       - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
 
       - run: ./gradlew verifyPaparazziDebug
 
@@ -88,6 +101,9 @@ jobs:
           java-version: 20
 
       - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
 
       - run: ./gradlew -p samples/counter build
 
@@ -113,6 +129,9 @@ jobs:
           java-version: 20
 
       - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
 
       - run: ./gradlew -p samples/emoji-search build
 
@@ -132,6 +151,9 @@ jobs:
           java-version: 20
 
       - uses: gradle/gradle-build-action@v2
+        # Don't spend more than 5m rehydrating the cache. Otherwise just move on.
+        timeout-minutes: 5
+        continue-on-error: true
 
       - run: ./gradlew -p samples/repo-search build
 


### PR DESCRIPTION
Otherwise we're just wasting time. The default timeout is 360(!!!) minutes.