### PR TITLE
Send a real frame time for Redwood frame clocks

### DIFF
--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -26,6 +26,7 @@ kotlin {
       dependencies {
         implementation libs.kotlin.test
         implementation libs.kotlinx.coroutines.test
+        implementation libs.assertk
       }
     }
     androidMain {
@@ -36,8 +37,19 @@ kotlin {
   }
 }
 
+dependencies {
+  androidTestImplementation libs.junit
+  androidTestImplementation libs.androidx.test.runner
+  androidTestImplementation libs.kotlinx.coroutines.test
+  androidTestImplementation libs.assertk
+}
+
 android {
   namespace 'app.cash.redwood.compose'
+
+  defaultConfig {
+    testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+  }
 }
 
 spotless {

--- a/redwood-compose/src/androidInstrumentedTest/kotlin/app/cash/redwood/compose/AndroidUiFrameClockTest.kt
+++ b/redwood-compose/src/androidInstrumentedTest/kotlin/app/cash/redwood/compose/AndroidUiFrameClockTest.kt
@@ -15,17 +15,19 @@
  */
 package app.cash.redwood.compose
 
+import androidx.compose.runtime.MonotonicFrameClock
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isLessThan
 import assertk.assertions.isPositive
-import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
-class DisplayLinkClockTest {
+class AndroidUiFrameClockTest {
   @Test fun ticksWithTime() = runTest {
-    val frameTimeA = DisplayLinkClock.withFrameNanos { it }
-    val frameTimeB = DisplayLinkClock.withFrameNanos { it }
+    val frameClock = AndroidUiDispatcher.Main[MonotonicFrameClock]!!
+    val frameTimeA = frameClock.withFrameNanos { it }
+    val frameTimeB = frameClock.withFrameNanos { it }
     assertThat(frameTimeA).all {
       isPositive()
       isLessThan(frameTimeB)

--- a/redwood-compose/src/iosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
+++ b/redwood-compose/src/iosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
@@ -18,10 +18,13 @@ package app.cash.redwood.compose
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.MonotonicFrameClock
 import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.convert
 import platform.Foundation.NSRunLoop
 import platform.Foundation.NSSelectorFromString
 import platform.QuartzCore.CADisplayLink
 import platform.darwin.NSObject
+import platform.posix.CLOCK_MONOTONIC_RAW
+import platform.posix.clock_gettime_nsec_np
 
 public actual object DisplayLinkClock : MonotonicFrameClock {
 
@@ -41,7 +44,8 @@ public actual object DisplayLinkClock : MonotonicFrameClock {
   }
 
   private fun tickClock() {
-    clock.sendFrame(0L)
+    val nanos = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW).convert<Long>()
+    clock.sendFrame(nanos)
 
     // Detach from the run loop. We will re-attach if new frame awaiters appear.
     displayLink.removeFromRunLoop(NSRunLoop.currentRunLoop, NSRunLoop.currentRunLoop.currentMode)

--- a/redwood-compose/src/iosTest/kotlin/app/cash/redwood/compose/DisplayLinkClockTest.kt
+++ b/redwood-compose/src/iosTest/kotlin/app/cash/redwood/compose/DisplayLinkClockTest.kt
@@ -19,10 +19,12 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.isLessThan
 import assertk.assertions.isPositive
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
 class DisplayLinkClockTest {
+  @Ignore // TODO Does not work without linking XCTest and showing a XCUIApplication.
   @Test fun ticksWithTime() = runTest {
     val frameTimeA = DisplayLinkClock.withFrameNanos { it }
     val frameTimeB = DisplayLinkClock.withFrameNanos { it }

--- a/redwood-compose/src/jsTest/kotlin/app/cash/redwood/compose/WindowAnimationFrameClockTest.kt
+++ b/redwood-compose/src/jsTest/kotlin/app/cash/redwood/compose/WindowAnimationFrameClockTest.kt
@@ -15,16 +15,20 @@
  */
 package app.cash.redwood.compose
 
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isLessThan
+import assertk.assertions.isPositive
 import kotlin.test.Test
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 
 class WindowAnimationFrameClockTest {
-  @Test fun ticks() = runTest {
-    val job = Job()
-    WindowAnimationFrameClock.withFrameNanos {
-      job.complete()
+  @Test fun ticksWithTime() = runTest {
+    val frameTimeA = WindowAnimationFrameClock.withFrameNanos { it }
+    val frameTimeB = WindowAnimationFrameClock.withFrameNanos { it }
+    assertThat(frameTimeA).all {
+      isPositive()
+      isLessThan(frameTimeB)
     }
-    job.join()
   }
 }

--- a/redwood-compose/src/macosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
+++ b/redwood-compose/src/macosMain/kotlin/app/cash/redwood/compose/DisplayLinkClock.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.compose
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.MonotonicFrameClock
 import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.staticCFunction
@@ -28,6 +29,8 @@ import platform.CoreVideo.CVDisplayLinkSetOutputCallback
 import platform.CoreVideo.CVDisplayLinkStart
 import platform.CoreVideo.CVDisplayLinkStop
 import platform.CoreVideo.kCVReturnSuccess
+import platform.posix.CLOCK_MONOTONIC_RAW
+import platform.posix.clock_gettime_nsec_np
 
 public actual object DisplayLinkClock : MonotonicFrameClock {
 
@@ -47,7 +50,8 @@ public actual object DisplayLinkClock : MonotonicFrameClock {
       CVDisplayLinkSetOutputCallback(
         displayLink.value,
         staticCFunction { _, _, _, _, _, _ ->
-          clock.sendFrame(0L)
+          val nanos = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW).convert<Long>()
+          clock.sendFrame(nanos)
 
           // A frame was delivered. Stop the DisplayLink callback. It will get started again
           // when new frame awaiters appear.


### PR DESCRIPTION
Test it, too (except on iOS where we currently can't).

Redwood-side of #1130