### PR TITLE
Naively extract placeholders from host to guest

### DIFF
--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyDsl.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyDsl.kt
@@ -71,11 +71,13 @@ public annotation class ExperimentalRedwoodLazyLayoutApi
 @Composable
 public fun LazyRow(
   modifier: Modifier = Modifier,
+  placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {
   LazyList(
     isVertical = false,
     modifier = modifier,
+    placeholder = placeholder,
     content = content,
   )
 }
@@ -86,6 +88,7 @@ public fun LazyRow(
   refreshing: Boolean,
   onRefresh: (() -> Unit)?,
   modifier: Modifier = Modifier,
+  placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {
   RefreshableLazyList(
@@ -93,6 +96,7 @@ public fun LazyRow(
     refreshing = refreshing,
     onRefresh = onRefresh,
     modifier = modifier,
+    placeholder = placeholder,
     content = content,
   )
 }
@@ -100,11 +104,13 @@ public fun LazyRow(
 @Composable
 public fun LazyColumn(
   modifier: Modifier = Modifier,
+  placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {
   LazyList(
     isVertical = true,
     modifier = modifier,
+    placeholder = placeholder,
     content = content,
   )
 }
@@ -115,6 +121,7 @@ public fun LazyColumn(
   refreshing: Boolean,
   onRefresh: (() -> Unit)?,
   modifier: Modifier = Modifier,
+  placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {
   RefreshableLazyList(
@@ -122,6 +129,7 @@ public fun LazyColumn(
     refreshing = refreshing,
     onRefresh = onRefresh,
     modifier = modifier,
+    placeholder = placeholder,
     content = content,
   )
 }

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -32,6 +32,7 @@ private const val OffscreenItemsBufferCount = 30
 internal fun LazyList(
   isVertical: Boolean,
   modifier: Modifier = Modifier,
+  placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {
   val itemProvider = rememberLazyListItemProvider(content)
@@ -48,6 +49,7 @@ internal fun LazyList(
       lastVisibleItemIndex = localLastVisibleItemIndex
     },
     modifier = modifier,
+    placeholder = { repeat(75) { placeholder() } },
     items = {
       for (index in itemsBefore until itemProvider.itemCount - itemsAfter) {
         key(index) {
@@ -64,6 +66,7 @@ internal fun RefreshableLazyList(
   refreshing: Boolean = false,
   onRefresh: (() -> Unit)? = null,
   modifier: Modifier = Modifier,
+  placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {
   val itemProvider = rememberLazyListItemProvider(content)
@@ -82,6 +85,7 @@ internal fun RefreshableLazyList(
     refreshing = refreshing,
     onRefresh = onRefresh,
     modifier = modifier,
+    placeholder = { repeat(75) { placeholder() } },
     items = {
       for (index in itemsBefore until itemProvider.itemCount - itemsAfter) {
         key(index) {

--- a/redwood-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/lazylayout/composeui/ComposeUiLazyList.kt
+++ b/redwood-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/lazylayout/composeui/ComposeUiLazyList.kt
@@ -54,6 +54,8 @@ internal class ComposeUiLazyList :
 
   override var modifier: RedwoodModifier = RedwoodModifier
 
+  override val placeholder = ComposeWidgetChildren()
+
   override val items = ComposeWidgetChildren()
 
   override fun isVertical(isVertical: Boolean) {

--- a/redwood-lazylayout-schema/src/main/kotlin/app/cash/redwood/lazylayout/widgets.kt
+++ b/redwood-lazylayout-schema/src/main/kotlin/app/cash/redwood/lazylayout/widgets.kt
@@ -25,7 +25,8 @@ public data class LazyList(
   @Property(2) val onViewportChanged: (firstVisibleItemIndex: Int, lastVisibleItemIndex: Int) -> Unit,
   @Property(3) val itemsBefore: Int,
   @Property(4) val itemsAfter: Int,
-  @Children(1) val items: () -> Unit,
+  @Children(1) val placeholder: () -> Unit,
+  @Children(2) val items: () -> Unit,
 )
 
 @Widget(2)
@@ -36,5 +37,6 @@ public data class RefreshableLazyList(
   @Property(4) val itemsAfter: Int,
   @Property(5) val refreshing: Boolean,
   @Property(6) val onRefresh: (() -> Unit)?,
-  @Children(1) val items: () -> Unit,
+  @Children(1) val placeholder: () -> Unit,
+  @Children(2) val items: () -> Unit,
 )

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -23,6 +23,7 @@ package app.cash.redwood.lazylayout.uiview
 import app.cash.redwood.Modifier
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.lazylayout.widget.RefreshableLazyList
+import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
 import kotlinx.cinterop.ObjCClass
 import platform.Foundation.NSIndexPath
@@ -54,6 +55,8 @@ public fun UIViewRefreshableLazyList(
 internal open class UIViewLazyListImpl() : LazyList<UIView> {
 
   private val itemsList = mutableListOf<Widget<UIView>>()
+
+  override val placeholder: Widget.Children<UIView> = MutableListChildren()
 
   override val items: Widget.Children<UIView> = object : Widget.Children<UIView> {
     override fun insert(index: Int, widget: Widget<UIView>) {

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -23,7 +23,6 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
-import android.widget.TextView
 import androidx.core.view.doOnDetach
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -35,6 +34,26 @@ import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
+
+private const val VIEW_TYPE_PLACEHOLDER = 1
+private const val VIEW_TYPE_ITEM = 2
+
+internal class Placeholders(
+  private val recycledViewPool: RecyclerView.RecycledViewPool,
+) : Widget.Children<View> {
+  private val pool = mutableListOf<Widget<View>>()
+
+  fun take(): Widget<View> = pool.removeFirst()
+
+  override fun insert(index: Int, widget: Widget<View>) {
+    pool += widget
+    recycledViewPool.setMaxRecycledViews(VIEW_TYPE_PLACEHOLDER, pool.size)
+  }
+
+  override fun move(fromIndex: Int, toIndex: Int, count: Int) {}
+  override fun remove(index: Int, count: Int) {}
+  override fun onModifierUpdated() {}
+}
 
 internal class Items<VH : RecyclerView.ViewHolder>(
   private val adapter: RecyclerView.Adapter<VH>,
@@ -90,8 +109,10 @@ internal open class ViewLazyListImpl(
 
   override var modifier: Modifier = Modifier
 
+  final override val placeholder = Placeholders(recyclerView.recycledViewPool)
+
   private val linearLayoutManager = LinearLayoutManager(recyclerView.context)
-  private val adapter = LazyContentItemListAdapter()
+  private val adapter = LazyContentItemListAdapter(placeholder)
   private var onViewportChanged: ((firstVisibleItemIndex: Int, lastVisibleItemIndex: Int) -> Unit)? = null
   private var viewport = IntRange.EMPTY
 
@@ -163,33 +184,49 @@ internal open class ViewLazyListImpl(
     }
   }
 
-  private class LazyContentItemListAdapter : RecyclerView.Adapter<ViewHolder>() {
+  private class LazyContentItemListAdapter(
+    val placeholders: Placeholders,
+  ) : RecyclerView.Adapter<ViewHolder>() {
     lateinit var items: Items<ViewHolder>
 
     override fun getItemCount(): Int = items.itemsBefore + items.widgets.size + items.itemsAfter
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder = ViewHolder(
-      FrameLayout(parent.context).apply {
-        layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
-      },
-    )
+    override fun getItemViewType(position: Int): Int {
+      val index = position - items.itemsBefore
+      return if (index in items.widgets.indices) VIEW_TYPE_ITEM else VIEW_TYPE_PLACEHOLDER
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+      return when (viewType) {
+        VIEW_TYPE_PLACEHOLDER -> ViewHolder.Placeholder(placeholders.take().value)
+        VIEW_TYPE_ITEM -> ViewHolder.Item(
+          FrameLayout(parent.context).apply {
+            layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+          },
+        )
+        else -> error("Unrecognized viewType: $viewType")
+      }
+    }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-      val index = position - items.itemsBefore
-      val view = if (index !in items.widgets.indices) {
-        TextView(holder.itemView.context).apply {
-          text = "Placeholder"
+      when (holder) {
+        is ViewHolder.Placeholder -> {
         }
-      } else {
-        items.widgets[index].value
+        is ViewHolder.Item -> {
+          val index = position - items.itemsBefore
+          val view = items.widgets[index].value
+          holder.container.removeAllViews()
+          (view.parent as? FrameLayout)?.removeAllViews()
+          holder.container.addView(view)
+        }
       }
-      holder.container.removeAllViews()
-      (view.parent as? FrameLayout)?.removeAllViews()
-      holder.container.addView(view)
     }
   }
 
-  class ViewHolder(val container: FrameLayout) : RecyclerView.ViewHolder(container)
+  sealed class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    class Placeholder(itemView: View) : ViewHolder(itemView)
+    class Item(val container: FrameLayout) : ViewHolder(container)
+  }
 }
 
 internal class RefreshableViewLazyListImpl(

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -83,6 +83,7 @@ private object TruncatingColumnProvider : ColumnProvider {
     refreshing: Boolean,
     onRefresh: (() -> Unit)?,
     modifier: Modifier,
+    placeholder: @Composable () -> Unit,
     itemContent: @Composable (item: T) -> Unit,
   ) {
     Column(modifier = modifier) {

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -59,6 +59,7 @@ interface ColumnProvider {
     refreshing: Boolean,
     onRefresh: (() -> Unit)?,
     modifier: Modifier,
+    placeholder: @Composable () -> Unit,
     itemContent: @Composable (item: T) -> Unit,
   )
 }
@@ -112,18 +113,31 @@ fun EmojiSearch(
       items = filteredEmojis,
       refreshing = refreshing,
       onRefresh = { refreshSignal++ },
-      modifier = Modifier.grow(1.0)
-    ) { image ->
-      Row(
-        width = Constraint.Fill,
-        verticalAlignment = CrossAxisAlignment.Center,
-      ) {
-        Image(
-          url = image.url,
-          modifier = Modifier.margin(Margin(8.dp)),
+      modifier = Modifier.grow(1.0),
+      placeholder = {
+        Item(
+          EmojiImage(
+            label = "loading…",
+            url = "https://github.githubassets.com/images/icons/emoji/unicode/231a.png?v8",
+          )
         )
-        Text(text = image.label)
-      }
+      },
+    ) { image ->
+      Item(image)
     }
+  }
+}
+
+@Composable
+private fun Item(emojiImage: EmojiImage) {
+  Row(
+    width = Constraint.Fill,
+    verticalAlignment = CrossAxisAlignment.Center,
+  ) {
+    Image(
+      url = emojiImage.url,
+      modifier = Modifier.margin(Margin(8.dp)),
+    )
+    Text(text = emojiImage.label)
   }
 }

--- a/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
+++ b/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
@@ -41,12 +41,14 @@ private class LazyColumnProvider : ColumnProvider {
     refreshing: Boolean,
     onRefresh: (() -> Unit)?,
     modifier: Modifier,
+    placeholder: @Composable () -> Unit,
     itemContent: @Composable (item: T) -> Unit,
   ) {
     LazyColumn(
       refreshing = refreshing,
       onRefresh = onRefresh,
       modifier = modifier,
+      placeholder = placeholder,
     ) {
       items(items, itemContent)
     }

--- a/samples/repo-search/presenter/src/commonMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
+++ b/samples/repo-search/presenter/src/commonMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
@@ -46,7 +46,7 @@ class RepoSearchTreehouseUi(
   @Composable
   override fun Show() {
     val lazyPagingItems = pager.flow.collectAsLazyPagingItems()
-    LazyColumn {
+    LazyColumn(placeholder = { RepoSearch(Repository(fullName = "Placeholder…", 0)) }) {
       items(lazyPagingItems.itemCount) { index ->
         RepoSearch(lazyPagingItems[index]!!)
       }


### PR DESCRIPTION
Closes #771.

This change allows callers to specify what sort of placeholder they want to display. The purpose of pooling is outlined in the opening paragraph of #771.

The pool of placeholders has been hardcoded to 75. It's important that this number always be at least the number of placeholders on screen, and I feel that 75 is sufficiently large in cases where items are very small. This mechanism should obviously be improved in follow up PRs.