### PR TITLE
Upgrade to Zipline 0.9.20.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidxComposeCompiler = "1.4.5"
 androidx-activity = "1.7.2"
 jbCompose = "1.4.0"
 lint = "31.0.2"
-zipline = "0.9.18"
+zipline = "0.9.20"
 coil = "2.4.0"
 
 [libraries]

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
@@ -24,6 +24,7 @@ import app.cash.redwood.protocol.WidgetTag
 import app.cash.zipline.Call
 import app.cash.zipline.CallResult
 import app.cash.zipline.Zipline
+import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.ZiplineService
 import kotlin.native.ObjCName
 
@@ -70,6 +71,7 @@ public open class EventListener {
   public open fun codeLoadSuccess(
     app: TreehouseApp<*>,
     manifestUrl: String?,
+    manifest: ZiplineManifest,
     zipline: Zipline,
     startValue: Any?,
   ) {
@@ -202,6 +204,18 @@ public open class EventListener {
     url: String,
     exception: Exception,
     startValue: Any?,
+  ) {
+  }
+
+  /**
+   * Invoked when a the manifest verifier successfully verifies a key. Manifest verification
+   * failures are signaled with [codeLoadFailed].
+   */
+  public open fun manifestVerified(
+    app: TreehouseApp<*>,
+    manifestUrl: String?,
+    manifest: ZiplineManifest,
+    verifiedKey: String,
   ) {
   }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventPublisher.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventPublisher.kt
@@ -26,6 +26,7 @@ import app.cash.zipline.Call
 import app.cash.zipline.CallResult
 import app.cash.zipline.EventListener as ZiplineEventListener
 import app.cash.zipline.Zipline
+import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.ZiplineService
 
 internal class EventPublisher(
@@ -55,10 +56,11 @@ internal class EventPublisher(
       override fun applicationLoadSuccess(
         applicationName: String,
         manifestUrl: String?,
+        manifest: ZiplineManifest,
         zipline: Zipline,
         startValue: Any?,
       ) {
-        listener.codeLoadSuccess(app, manifestUrl, zipline, startValue)
+        listener.codeLoadSuccess(app, manifestUrl, manifest, zipline, startValue)
       }
 
       override fun applicationLoadSkipped(
@@ -112,6 +114,15 @@ internal class EventPublisher(
         startValue: Any?,
       ) {
         listener.downloadFailed(app, url, exception, startValue)
+      }
+
+      override fun manifestVerified(
+        applicationName: String,
+        manifestUrl: String?,
+        manifest: ZiplineManifest,
+        verifiedKey: String,
+      ) {
+        listener.manifestVerified(app, manifestUrl, manifest, verifiedKey)
       }
 
       override fun moduleLoadStart(zipline: Zipline, moduleId: String): Any? {


### PR DESCRIPTION
This update is neither forwards- nor backwards-compatible with the previous version of Zipline.