### PR TITLE
Drop old `Mutable` adjective for testing API

### DIFF
--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
@@ -18,7 +18,7 @@ package app.cash.redwood.testing
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import app.cash.redwood.RedwoodCodegenApi
-import app.cash.redwood.layout.widget.RedwoodLayoutMutableWidgetFactory
+import app.cash.redwood.layout.widget.RedwoodLayoutTestingWidgetFactory
 import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.ChildrenChange.Add
 import app.cash.redwood.protocol.ChildrenTag
@@ -36,9 +36,9 @@ import assertk.assertions.isEqualTo
 import example.redwood.compose.ExampleSchemaProtocolBridge
 import example.redwood.compose.Row
 import example.redwood.compose.Text
-import example.redwood.widget.ExampleSchemaMutableWidgetFactory
 import example.redwood.widget.ExampleSchemaProtocolNodeFactory
 import example.redwood.widget.ExampleSchemaTester
+import example.redwood.widget.ExampleSchemaTestingWidgetFactory
 import example.redwood.widget.ExampleSchemaWidgetFactories
 import kotlin.test.Test
 import kotlinx.coroutines.plus
@@ -115,8 +115,8 @@ class ViewTreesTest {
 
     // Ensure when the changes are applied with the widget protocol we get equivalent values.
     val mutableFactories = ExampleSchemaWidgetFactories(
-      ExampleSchema = ExampleSchemaMutableWidgetFactory(),
-      RedwoodLayout = RedwoodLayoutMutableWidgetFactory(),
+      ExampleSchema = ExampleSchemaTestingWidgetFactory(),
+      RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
     )
     val protocolNodes = ExampleSchemaProtocolNodeFactory(mutableFactories)
     val widgetContainer = MutableListChildren<WidgetValue>()

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -95,8 +95,8 @@ internal fun Schema.getWidgetFactoryType(): ClassName {
   return ClassName(widgetPackage(), "${type.flatName}WidgetFactory")
 }
 
-internal fun Schema.getMutableWidgetFactoryType(): ClassName {
-  return ClassName(widgetPackage(), "${type.flatName}MutableWidgetFactory")
+internal fun Schema.getTestingWidgetFactoryType(): ClassName {
+  return ClassName(widgetPackage(), "${type.flatName}TestingWidgetFactory")
 }
 
 internal fun Schema.mutableWidgetType(widget: Widget): ClassName {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -47,8 +47,8 @@ suspend fun <R> ExampleTester(
   body: suspend TestRedwoodComposition<List<WidgetValue>>.() -> R,
 ): R = coroutineScope {
   val factories = ExampleWidgetFactories(
-    Sunspot = MutableExampleWidgetFactory(),
-    RedwoodLayout = MutableRedwoodLayoutWidgetFactory(),
+    ExampleSchema = ExampleSchemaTestingWidgetFactory(),
+    RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
   )
   val container = MutableListChildren<WidgetValue>()
   val tester = TestRedwoodComposition(this, factories, container) {
@@ -82,7 +82,7 @@ internal fun generateTester(schemaSet: SchemaSet): FileSpec {
         .addCode("val factories = %T(⇥\n", schema.getWidgetFactoriesType())
         .apply {
           for (dependency in schemaSet.all) {
-            addCode("%N = %T(),\n", dependency.type.flatName, dependency.getMutableWidgetFactoryType())
+            addCode("%N = %T(),\n", dependency.type.flatName, dependency.getTestingWidgetFactoryType())
           }
         }
         .addCode("⇤)\n")
@@ -103,13 +103,13 @@ internal fun generateTester(schemaSet: SchemaSet): FileSpec {
 
 /*
 @RedwoodCodegenApi
-public class EmojiSearchMutableWidgetFactory : EmojiSearchWidgetFactory<WidgetValue> {
+public class EmojiSearchTestingWidgetFactory : EmojiSearchWidgetFactory<WidgetValue> {
   public override fun Text(): Text<WidgetValue> = MutableText()
   public override fun Button(): Button<WidgetValue> = MutableButton()
 }
 */
 internal fun generateMutableWidgetFactory(schema: Schema): FileSpec {
-  val mutableWidgetFactoryType = schema.getMutableWidgetFactoryType()
+  val mutableWidgetFactoryType = schema.getTestingWidgetFactoryType()
   return FileSpec.builder(mutableWidgetFactoryType)
     .addType(
       TypeSpec.classBuilder(mutableWidgetFactoryType)


### PR DESCRIPTION
We no longer have the `MutableWidget` type in the public API.