### PR TITLE
Remove explicit `public` modifier usage in codegen

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
@@ -29,7 +29,6 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
@@ -71,7 +70,6 @@ internal fun generateComposable(
   return FileSpec.builder(schema.composePackage(), flatName)
     .addFunction(
       FunSpec.builder(flatName)
-        .addModifiers(PUBLIC)
         .addAnnotation(ComposeRuntime.Composable)
         .addAnnotation(Redwood.OptInToRedwoodCodegenApi)
         .apply {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
@@ -34,7 +34,6 @@ import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.NOTHING
@@ -322,12 +321,12 @@ internal fun generateProtocolWidget(
             .build(),
         )
         .addProperty(
-          PropertySpec.builder("id", Protocol.Id, PUBLIC, OVERRIDE)
+          PropertySpec.builder("id", Protocol.Id, OVERRIDE)
             .initializer("state.nextId()")
             .build(),
         )
         .addProperty(
-          PropertySpec.builder("tag", Protocol.WidgetTag, PUBLIC, OVERRIDE)
+          PropertySpec.builder("tag", Protocol.WidgetTag, OVERRIDE)
             .getter(
               FunSpec.getterBuilder()
                 .addStatement("return %T(%L)", Protocol.WidgetTag, widget.tag)
@@ -707,7 +706,7 @@ internal fun generateComposeProtocolModifierSerialization(
         .build(),
     )
     .addFunction(
-      FunSpec.builder(schema.modifierToProtocol.simpleName)
+      FunSpec.builder(schema.modifierToProtocol)
         .addModifiers(PRIVATE)
         .receiver(Redwood.ModifierElement)
         .addParameter("json", KotlinxSerialization.Json)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -30,7 +30,6 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.KModifier.SUSPEND
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.LambdaTypeName
@@ -72,7 +71,7 @@ internal fun generateTester(schemaSet: SchemaSet): FileSpec {
   ).copy(suspending = true)
   return FileSpec.builder(testerFunction.packageName, testerFunction.simpleName)
     .addFunction(
-      FunSpec.builder(testerFunction.simpleName)
+      FunSpec.builder(testerFunction)
         .addAnnotation(Redwood.OptInToRedwoodCodegenApi)
         .addModifiers(SUSPEND)
         .addParameter("body", bodyType)
@@ -193,7 +192,7 @@ internal fun generateMutableWidget(schema: Schema, widget: Widget): FileSpec {
         )
         .addProperty(
           PropertySpec.builder("modifier", Redwood.Modifier)
-            .addModifiers(PUBLIC, OVERRIDE)
+            .addModifiers(OVERRIDE)
             .mutable(true)
             .initializer("%T", Redwood.Modifier)
             .build(),
@@ -216,7 +215,7 @@ internal fun generateMutableWidget(schema: Schema, widget: Widget): FileSpec {
                 )
                 addFunction(
                   FunSpec.builder(trait.name)
-                    .addModifiers(PUBLIC, OVERRIDE)
+                    .addModifiers(OVERRIDE)
                     .addParameter(trait.name, type)
                     .addCode("this.%N = %N", trait.name, trait.name)
                     .build(),
@@ -227,7 +226,7 @@ internal fun generateMutableWidget(schema: Schema, widget: Widget): FileSpec {
                   .parameterizedBy(RedwoodTesting.WidgetValue)
                 addProperty(
                   PropertySpec.builder(trait.name, mutableChildrenOfMutableWidget)
-                    .addModifiers(PUBLIC, OVERRIDE)
+                    .addModifiers(OVERRIDE)
                     .initializer("%T()", RedwoodWidget.MutableListChildren)
                     .build(),
                 )
@@ -267,11 +266,10 @@ internal fun generateWidgetValue(schema: Schema, widget: Widget): FileSpec {
   val widgetValueType = schema.widgetValueType(widget)
 
   val classBuilder = TypeSpec.classBuilder(widgetValueType)
-    .addModifiers(PUBLIC)
     .addSuperinterface(RedwoodTesting.WidgetValue)
     .addProperty(
       PropertySpec.builder("modifier", Redwood.Modifier)
-        .addModifiers(PUBLIC, OVERRIDE)
+        .addModifiers(OVERRIDE)
         .initializer("modifier")
         .build(),
     )
@@ -353,7 +351,7 @@ internal fun generateWidgetValue(schema: Schema, widget: Widget): FileSpec {
             "childrenLists",
             LIST.parameterizedBy(LIST.parameterizedBy(RedwoodTesting.WidgetValue)),
           )
-            .addModifiers(PUBLIC, OVERRIDE)
+            .addModifiers(OVERRIDE)
             .getter(
               FunSpec.getterBuilder()
                 .addStatement("return %M(%L)", Stdlib.listOf, childrenLists.joinToCode())
@@ -363,7 +361,7 @@ internal fun generateWidgetValue(schema: Schema, widget: Widget): FileSpec {
         )
         .addFunction(
           FunSpec.builder("equals")
-            .addModifiers(PUBLIC, OVERRIDE)
+            .addModifiers(OVERRIDE)
             .addParameter("other", ANY.copy(nullable = true))
             .returns(BOOLEAN)
             .addStatement("return %L", equalsComparisons.joinToCode(" &&\n"))
@@ -371,14 +369,14 @@ internal fun generateWidgetValue(schema: Schema, widget: Widget): FileSpec {
         )
         .addFunction(
           FunSpec.builder("hashCode")
-            .addModifiers(PUBLIC, OVERRIDE)
+            .addModifiers(OVERRIDE)
             .returns(Int::class)
             .addStatement("return %M(%L).hashCode()", Stdlib.listOf, hashCodeProperties.joinToCode())
             .build(),
         )
         .addFunction(
           FunSpec.builder("toString")
-            .addModifiers(PUBLIC, OVERRIDE)
+            .addModifiers(OVERRIDE)
             .returns(String::class)
             .addStatement(
               "return %P",
@@ -391,7 +389,7 @@ internal fun generateWidgetValue(schema: Schema, widget: Widget): FileSpec {
         )
         .addFunction(
           FunSpec.builder("toWidget")
-            .addModifiers(PUBLIC, OVERRIDE)
+            .addModifiers(OVERRIDE)
             .addTypeVariable(typeVariableW)
             .addParameter("provider", RedwoodWidget.WidgetProvider.parameterizedBy(typeVariableW))
             .returns(RedwoodWidget.Widget.parameterizedBy(typeVariableW))

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
@@ -28,7 +28,6 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
@@ -129,7 +128,7 @@ internal fun generateWidgetFactory(schema: Schema): FileSpec {
           for (widget in schema.widgets) {
             addFunction(
               FunSpec.builder(widget.type.flatName)
-                .addModifiers(PUBLIC, ABSTRACT)
+                .addModifiers(ABSTRACT)
                 .returns(schema.widgetType(widget).parameterizedBy(typeVariableW))
                 .apply {
                   widget.deprecation?.let { deprecation ->
@@ -168,7 +167,6 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
   return FileSpec.builder(schema.widgetPackage(), flatName)
     .addType(
       TypeSpec.interfaceBuilder(flatName)
-        .addModifiers(PUBLIC)
         .addTypeVariable(typeVariableW)
         .addSuperinterface(RedwoodWidget.Widget.parameterizedBy(typeVariableW))
         .addAnnotation(
@@ -199,7 +197,7 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
               is Property -> {
                 addFunction(
                   FunSpec.builder(trait.name)
-                    .addModifiers(PUBLIC, ABSTRACT)
+                    .addModifiers(ABSTRACT)
                     .addParameter(trait.name, trait.type.asTypeName())
                     .apply {
                       trait.deprecation?.let { deprecation ->
@@ -218,7 +216,7 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
               is Event -> {
                 addFunction(
                   FunSpec.builder(trait.name)
-                    .addModifiers(PUBLIC, ABSTRACT)
+                    .addModifiers(ABSTRACT)
                     .addParameter(trait.name, trait.lambdaType)
                     .apply {
                       trait.deprecation?.let { deprecation ->
@@ -237,7 +235,7 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
               is Children -> {
                 addProperty(
                   PropertySpec.builder(trait.name, RedwoodWidget.WidgetChildrenOfW)
-                    .addModifiers(PUBLIC, ABSTRACT)
+                    .addModifiers(ABSTRACT)
                     .apply {
                       trait.deprecation?.let { deprecation ->
                         addAnnotation(deprecation.toAnnotationSpec())


### PR DESCRIPTION
Harmless for regular types and functions, but in the case of being paired with an `override` modifier this will actually cause a redundant emission in the codegen where one is not required to be explicit.