### PR TITLE
Rollback serialization to 1.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.8.20"
 kotlinx-coroutines = "1.7.1"
-kotlinx-serialization = "1.5.1"
+kotlinx-serialization = "1.5.0"
 androidxComposeCompiler = "1.4.5"
 androidx-activity = "1.7.2"
 jbCompose = "1.4.0"

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -26,14 +26,15 @@ import androidx.compose.runtime.setValue
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
-import app.cash.redwood.ui.Margin
-import app.cash.redwood.ui.dp
 import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.layout.compose.Row
+import app.cash.redwood.ui.Margin
+import app.cash.redwood.ui.dp
 import com.example.redwood.emojisearch.compose.Image
 import com.example.redwood.emojisearch.compose.Text
 import com.example.redwood.emojisearch.compose.TextInput
 import example.values.TextFieldState
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 private data class EmojiImage(

--- a/samples/repo-search/presenter/src/commonMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
+++ b/samples/repo-search/presenter/src/commonMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearchTreehouseUi.kt
@@ -27,6 +27,7 @@ import app.cash.paging.compose.collectAsLazyPagingItems
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.lazylayout.compose.LazyColumn
 import app.cash.redwood.treehouse.TreehouseUi
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class RepoSearchTreehouseUi(


### PR DESCRIPTION
The 1.5.1 update requires Kotlin 1.8.21.