### PR TITLE
Send initial lambda absence in protocol

### DIFF
--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.Modifier
 import example.redwood.widget.Button
+import example.redwood.widget.Button2
 import example.redwood.widget.ExampleSchemaWidgetFactory
 import example.redwood.widget.Row
 import example.redwood.widget.ScopedRow
@@ -37,6 +38,7 @@ open class EmptyExampleSchemaWidgetFactory : ExampleSchemaWidgetFactory<Nothing>
     override fun text(text: String?) = TODO()
     override fun onClick(onClick: (() -> Unit)?) = TODO()
   }
+  override fun Button2(): Button2<Nothing> = TODO()
   override fun TextInput(): TextInput<Nothing> = TODO()
   override fun Space(): Space<Nothing> = TODO()
 }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeProtocolGeneration.kt
@@ -368,6 +368,14 @@ internal fun generateProtocolWidget(
                     .initializer("null")
                     .build(),
                 )
+                if (trait.isNullable) {
+                  addProperty(
+                    PropertySpec.builder(trait.name + "_firstSet", BOOLEAN, PRIVATE)
+                      .mutable()
+                      .initializer("true")
+                      .build(),
+                  )
+                }
                 addFunction(
                   FunSpec.builder(trait.name)
                     .addModifiers(OVERRIDE)
@@ -375,7 +383,8 @@ internal fun generateProtocolWidget(
                     .apply {
                       val newValue = if (trait.isNullable) {
                         addStatement("val %1NSet = %1N != null", trait.name)
-                        beginControlFlow("if (%1NSet != (this.%1N != null))", trait.name)
+                        beginControlFlow("if (%1NSet != (this.%1N != null) || %1N_firstSet)", trait.name)
+                        addStatement("%N_firstSet = false", trait.name)
                         trait.name + "Set"
                       } else {
                         beginControlFlow("if (this.%1N == null)", trait.name)

--- a/test-schema/src/main/kotlin/example/redwood/schema.kt
+++ b/test-schema/src/main/kotlin/example/redwood/schema.kt
@@ -37,6 +37,7 @@ import kotlin.time.Duration
     CustomTypeWithMultipleScopes::class,
     Text::class,
     Button::class,
+    Button2::class,
     TextInput::class,
     Space::class,
   ],
@@ -67,6 +68,13 @@ public data class Text(
 public data class Button(
   @Property(1) val text: String?,
   @Property(2) val onClick: (() -> Unit)?,
+)
+
+/** Like [Button] but with a required lambda. */
+@Widget(7)
+public data class Button2(
+  @Property(1) val text: String?,
+  @Property(2) val onClick: () -> Unit,
 )
 
 @Widget(5)


### PR DESCRIPTION
Expand testing to ensure we're covering both nullable and non-null lambdas in presence change tests.