### PR TITLE
Stop creating so many Item ViewHolder's

### DIFF
--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -128,6 +128,8 @@ internal open class ViewLazyListImpl(
       layoutManager = linearLayoutManager
       layoutParams = ViewGroup.LayoutParams(WRAP_CONTENT, WRAP_CONTENT)
 
+      // TODO Dynamically set the max recycled views for VIEW_TYPE_ITEM
+      recycledViewPool.setMaxRecycledViews(VIEW_TYPE_ITEM, 30)
       addOnScrollListener(
         object : RecyclerView.OnScrollListener() {
           override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {


### PR DESCRIPTION
I noticed that `onCreateViewHolder` was being invoked a lot as I scrolled, as the pool size for `Item` (i.e., a non-placeholder) was smaller than the number of items that can fit in the viewport. This is because the default max recycled view count is 5, and on both the sample apps we're showing a few more than 5.

I've hard-coded it to 30 for now. I'll tackle an actual fix for this in a follow-up, where the number isn't hard-coded. Ironically, the addition of this magic number is to unblock me replacing the magic number of placeholders (set to 75) to something dynamic.