### PR TITLE
Use queue for placeholder pool

### DIFF
--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -43,7 +43,7 @@ private const val VIEW_TYPE_ITEM = 2
 internal class Placeholders(
   private val recycledViewPool: RecyclerView.RecycledViewPool,
 ) : Widget.Children<View> {
-  private val pool = mutableListOf<Widget<View>>()
+  private val pool = ArrayDeque<Widget<View>>()
 
   fun take(): Widget<View> = pool.removeFirst()
 


### PR DESCRIPTION
Prevents shifting of backing `ArrayList` when removing from head. I could've instead just replaced `removeFirst` with `removeLast`, but using an `ArrayDeque` is more fitting for a pool and also prevents internal array shifting.