### PR TITLE
Correctly set max recycled placeholder views

### DIFF
--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -43,13 +43,15 @@ private const val VIEW_TYPE_ITEM = 2
 internal class Placeholders(
   private val recycledViewPool: RecyclerView.RecycledViewPool,
 ) : Widget.Children<View> {
+  private var poolSize = 0
   private val pool = mutableListOf<Widget<View>>()
 
   fun take(): Widget<View> = pool.removeFirst()
 
   override fun insert(index: Int, widget: Widget<View>) {
+    poolSize++
     pool += widget
-    recycledViewPool.setMaxRecycledViews(VIEW_TYPE_PLACEHOLDER, pool.size)
+    recycledViewPool.setMaxRecycledViews(VIEW_TYPE_PLACEHOLDER, poolSize)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {}


### PR DESCRIPTION
The `pool` is removed from when the placeholder `Widget` is going to be displayed. We shouldn't decrement the max recycled views when this happens.