### PR TITLE
Reduce initial placeholder pool size and grow as needed

### DIFF
--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -43,18 +43,25 @@ internal fun LazyList(
   var lastVisibleItemIndex by remember { mutableStateOf(0) }
   val itemsBefore = remember(firstVisibleItemIndex) { (firstVisibleItemIndex - OffscreenItemsBufferCount / 2).coerceAtLeast(0) }
   val itemsAfter = remember(lastVisibleItemIndex, itemProvider.itemCount) { (itemProvider.itemCount - (lastVisibleItemIndex + OffscreenItemsBufferCount / 2).coerceAtMost(itemProvider.itemCount)).coerceAtLeast(0) }
+  var placeholderPoolSize by remember { mutableStateOf(20) }
   LazyList(
     isVertical,
     itemsBefore = itemsBefore,
     itemsAfter = itemsAfter,
     onViewportChanged = { localFirstVisibleItemIndex, localLastVisibleItemIndex ->
+      val visibleItemCount = localLastVisibleItemIndex - localFirstVisibleItemIndex
+      val proposedPlaceholderPoolSize = visibleItemCount + visibleItemCount / 2
+      // We only ever want to increase the pool size.
+      if (placeholderPoolSize < proposedPlaceholderPoolSize) {
+        placeholderPoolSize = proposedPlaceholderPoolSize
+      }
       firstVisibleItemIndex = localFirstVisibleItemIndex
       lastVisibleItemIndex = localLastVisibleItemIndex
     },
     width = width,
     height = height,
     modifier = modifier,
-    placeholder = { repeat(75) { placeholder() } },
+    placeholder = { repeat(placeholderPoolSize) { placeholder() } },
     items = {
       for (index in itemsBefore until itemProvider.itemCount - itemsAfter) {
         key(index) {
@@ -81,11 +88,18 @@ internal fun RefreshableLazyList(
   var lastVisibleItemIndex by remember { mutableStateOf(0) }
   val itemsBefore = remember(firstVisibleItemIndex) { (firstVisibleItemIndex - OffscreenItemsBufferCount / 2).coerceAtLeast(0) }
   val itemsAfter = remember(lastVisibleItemIndex, itemProvider.itemCount) { (itemProvider.itemCount - (lastVisibleItemIndex + OffscreenItemsBufferCount / 2).coerceAtMost(itemProvider.itemCount)).coerceAtLeast(0) }
+  var placeholderPoolSize by remember { mutableStateOf(20) }
   RefreshableLazyList(
     isVertical,
     itemsBefore = itemsBefore,
     itemsAfter = itemsAfter,
     onViewportChanged = { localFirstVisibleItemIndex, localLastVisibleItemIndex ->
+      val visibleItemCount = localLastVisibleItemIndex - localFirstVisibleItemIndex
+      val proposedPlaceholderPoolSize = visibleItemCount + visibleItemCount / 2
+      // We only ever want to increase the pool size.
+      if (placeholderPoolSize < proposedPlaceholderPoolSize) {
+        placeholderPoolSize = proposedPlaceholderPoolSize
+      }
       firstVisibleItemIndex = localFirstVisibleItemIndex
       lastVisibleItemIndex = localLastVisibleItemIndex
     },
@@ -94,7 +108,7 @@ internal fun RefreshableLazyList(
     width = width,
     height = height,
     modifier = modifier,
-    placeholder = { repeat(75) { placeholder() } },
+    placeholder = { repeat(placeholderPoolSize) { placeholder() } },
     items = {
       for (index in itemsBefore until itemProvider.itemCount - itemsAfter) {
         key(index) {

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -43,13 +43,15 @@ private const val VIEW_TYPE_ITEM = 2
 internal class Placeholders(
   private val recycledViewPool: RecyclerView.RecycledViewPool,
 ) : Widget.Children<View> {
+  private var poolSize = 0
   private val pool = mutableListOf<Widget<View>>()
 
   fun take(): Widget<View> = pool.removeFirst()
 
   override fun insert(index: Int, widget: Widget<View>) {
+    poolSize++
     pool += widget
-    recycledViewPool.setMaxRecycledViews(VIEW_TYPE_PLACEHOLDER, pool.size)
+    recycledViewPool.setMaxRecycledViews(VIEW_TYPE_PLACEHOLDER, poolSize)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {}

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -46,7 +46,7 @@ internal class Placeholders(
   private var poolSize = 0
   private val pool = mutableListOf<Widget<View>>()
 
-  fun take(): Widget<View> = pool.removeFirst()
+  fun takeOrNull(): Widget<View>? = pool.removeLastOrNull()
 
   override fun insert(index: Int, widget: Widget<View>) {
     poolSize++
@@ -204,6 +204,21 @@ internal open class ViewLazyListImpl(
   ) : RecyclerView.Adapter<ViewHolder>() {
     lateinit var items: Items<ViewHolder>
 
+    /**
+     * When we haven't loaded enough placeholders for the viewport height, we set a blank view while
+     * we load request more placeholders. This "meta" placeholder needs a non-zero height, so we
+     * don't load an infinite number of zero height meta placeholders.
+     *
+     * We set this height to the last available item height, or a hardcoded value in the case when
+     * no views have been laid out, but a meta placeholder has been requested.
+     */
+    private var lastItemHeight = 100
+      set(value) {
+        if (value > 0) {
+          field = value
+        }
+      }
+
     override fun getItemCount(): Int = items.itemsBefore + items.widgets.size + items.itemsAfter
 
     override fun getItemViewType(position: Int): Int {
@@ -213,7 +228,11 @@ internal open class ViewLazyListImpl(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
       return when (viewType) {
-        VIEW_TYPE_PLACEHOLDER -> ViewHolder.Placeholder(placeholders.take().value)
+        VIEW_TYPE_PLACEHOLDER -> ViewHolder.Placeholder(
+          FrameLayout(parent.context).apply {
+            layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+          },
+        )
         VIEW_TYPE_ITEM -> ViewHolder.Item(
           FrameLayout(parent.context).apply {
             layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
@@ -224,8 +243,20 @@ internal open class ViewLazyListImpl(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+      lastItemHeight = holder.itemView.height
       when (holder) {
         is ViewHolder.Placeholder -> {
+          if (holder.container.childCount == 0) {
+            val placeholder = placeholders.takeOrNull()
+            if (placeholder != null) {
+              holder.container.addView(placeholder.value)
+              holder.itemView.updateLayoutParams { height = WRAP_CONTENT }
+            } else if (holder.container.height == 0) {
+              // This occurs when the ViewHolder has been freshly created, so we set the container
+              // to a non-zero height so that it's visible.
+              holder.itemView.updateLayoutParams { height = lastItemHeight }
+            }
+          }
         }
         is ViewHolder.Item -> {
           val index = position - items.itemsBefore
@@ -239,7 +270,7 @@ internal open class ViewLazyListImpl(
   }
 
   sealed class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    class Placeholder(itemView: View) : ViewHolder(itemView)
+    class Placeholder(val container: FrameLayout) : ViewHolder(container)
     class Item(val container: FrameLayout) : ViewHolder(container)
   }
 }


### PR DESCRIPTION
Addresses the comments on https://github.com/cashapp/redwood/pull/1154#pullrequestreview-1454222047.

Here's a screen recording of the change. Note that the blank rows are places where we've exhausted the placeholder pool, and are in the midst of retrieving more.

Note that the retrieval of the "meta" placeholders occurred too fast for me to showcase it without modification. Therefore, I dropped the initial `placeholderPoolSize` to 5, and added a delay of `1000ms` in the `onViewportChanged` callback of `LazyList`. This was purely done to showcase the meta placeholders.

[after.webm](https://github.com/cashapp/redwood/assets/6900601/2afc662c-918f-4303-ad7b-3b1043af5451)
