### PR TITLE
Move `RedwoodContent` to Compose UI-specific module

### DIFF
--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -18,7 +18,6 @@ kotlin {
         api libs.kotlinx.coroutines.core
         api projects.redwoodRuntime
         api projects.redwoodWidget
-        implementation projects.redwoodWidgetCompose
         api libs.jetbrains.compose.runtime
       }
     }

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
@@ -20,42 +20,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.DisallowComposableCalls
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.Updater
 import androidx.compose.runtime.currentComposer
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshots.Snapshot
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.widget.Widget
-import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-
-/**
- * Render a Redwood composition inside of a different composition such as Compose UI.
- */
-@Composable
-public fun RedwoodContent(
-  provider: Widget.Provider<@Composable () -> Unit>,
-  content: @Composable () -> Unit,
-) {
-  val scope = rememberCoroutineScope()
-  val children = remember(provider, content) { ComposeWidgetChildren() }
-  LaunchedEffect(provider, content) {
-    val composition = RedwoodComposition(
-      scope = scope,
-      container = children,
-      provider = provider,
-    )
-    composition.setContent(content)
-  }
-  children.render()
-}
 
 public interface RedwoodComposition {
   public fun setContent(content: @Composable () -> Unit)

--- a/redwood-composeui/build.gradle
+++ b/redwood-composeui/build.gradle
@@ -1,0 +1,36 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'app.cash.redwood.build'
+
+redwoodBuild {
+  composeCompiler()
+  publishing()
+}
+
+kotlin {
+  android {
+    publishLibraryVariants('release')
+  }
+
+  iosArm64()
+  iosX64()
+  iosSimulatorArm64()
+
+  jvm()
+
+  macosArm64()
+  macosX64()
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api projects.redwoodCompose
+        implementation projects.redwoodWidgetCompose
+      }
+    }
+  }
+}
+
+android {
+  namespace 'app.cash.redwood.composeui'
+}

--- a/redwood-composeui/gradle.properties
+++ b/redwood-composeui/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=redwood-composeui
+POM_NAME=Redwood for Compose UI

--- a/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/RedwoodContent.kt
+++ b/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/RedwoodContent.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.composeui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import app.cash.redwood.compose.RedwoodComposition
+import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.compose.ComposeWidgetChildren
+
+/** Render a Redwood composition inside of Compose UI. */
+@Composable
+public fun RedwoodContent(
+  provider: Widget.Provider<@Composable () -> Unit>,
+  content: @Composable () -> Unit,
+) {
+  val scope = rememberCoroutineScope()
+  val children = remember(provider, content) { ComposeWidgetChildren() }
+  LaunchedEffect(provider, content) {
+    val composition = RedwoodComposition(
+      scope = scope,
+      container = children,
+      provider = provider,
+    )
+    composition.setContent(content)
+  }
+  children.render()
+}

--- a/samples/counter/android-composeui/build.gradle
+++ b/samples/counter/android-composeui/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'app.cash.redwood'
 dependencies {
   implementation projects.samples.counter.presenter
   implementation projects.samples.counter.sharedComposeui
+  implementation projects.redwoodComposeui
   implementation projects.redwoodLayoutComposeui
   implementation libs.kotlinx.coroutines.android
   implementation libs.google.material

--- a/samples/counter/android-composeui/src/main/java/com/example/redwood/counter/android/composeui/MainActivity.kt
+++ b/samples/counter/android-composeui/src/main/java/com/example/redwood/counter/android/composeui/MainActivity.kt
@@ -18,7 +18,7 @@ package com.example.redwood.counter.android.composeui
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import app.cash.redwood.compose.RedwoodContent
+import app.cash.redwood.composeui.RedwoodContent
 import app.cash.redwood.layout.composeui.ComposeUiRedwoodLayoutWidgetFactory
 import com.example.redwood.counter.composeui.ComposeUiWidgetFactory
 import com.example.redwood.counter.composeui.CounterTheme

--- a/samples/counter/desktop-composeui/build.gradle
+++ b/samples/counter/desktop-composeui/build.gradle
@@ -13,5 +13,6 @@ dependencies {
   implementation compose.desktop.currentOs
   implementation projects.samples.counter.presenter
   implementation projects.samples.counter.sharedComposeui
+  implementation projects.redwoodComposeui
   implementation projects.redwoodLayoutComposeui
 }

--- a/samples/counter/desktop-composeui/src/main/kotlin/com/example/redwood/counter/desktop/main.kt
+++ b/samples/counter/desktop-composeui/src/main/kotlin/com/example/redwood/counter/desktop/main.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-import app.cash.redwood.compose.RedwoodContent
+import app.cash.redwood.composeui.RedwoodContent
 import app.cash.redwood.layout.composeui.ComposeUiRedwoodLayoutWidgetFactory
 import com.example.redwood.counter.composeui.ComposeUiWidgetFactory
 import com.example.redwood.counter.composeui.CounterTheme

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,7 @@ enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
 rootProject.name = 'redwood'
 
 include ':redwood-compose'
+include ':redwood-composeui'
 include ':redwood-flexbox'
 include ':redwood-gradle-plugin'
 include ':redwood-layout-api'


### PR DESCRIPTION
While it doesn't have a Compose UI dependency now, it will gain one soon as we pipe HostConfiguration into it and need to pull things like dark mode, insets, etc.

Refs #1116. Refs #1054.