### PR TITLE
Add a settings plugin to apply our build plugin everywhere

### DIFF
--- a/build-support/settings/README.md
+++ b/build-support/settings/README.md
@@ -1,0 +1,4 @@
+# Redwood Settings Plugin
+
+This is a Gradle plugin applied to the root `settings.gradle` via `includeBuild`
+which automatically adds the `build-support/` Gradle plugin to all projects.

--- a/build-support/settings/build.gradle
+++ b/build-support/settings/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'java-gradle-plugin'
+
+gradlePlugin {
+  plugins {
+    redwoodSettings {
+      id = "app.cash.redwood.settings"
+      displayName = "Redwood settings plugin"
+      description = "Gradle plugin for Redwood build settings"
+      implementationClass = "app.cash.redwood.buildsettings.RedwoodSettingsPlugin"
+    }
+  }
+}

--- a/build-support/settings/src/main/java/app/cash/redwood/buildsettings/RedwoodSettingsPlugin.java
+++ b/build-support/settings/src/main/java/app/cash/redwood/buildsettings/RedwoodSettingsPlugin.java
@@ -1,0 +1,17 @@
+package app.cash.redwood.buildsettings;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+
+@SuppressWarnings("unused") // Invoked reflectively by Gradle.
+public class RedwoodSettingsPlugin implements Plugin<Settings> {
+  @Override public void apply(Settings target) {
+    target.getGradle().allprojects(project -> {
+      if (!project.getPath().equals(":")) {
+        project.beforeEvaluate(ignored -> {
+          project.getPlugins().apply("app.cash.redwood.build");
+        });
+      }
+    });
+  }
+}

--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-composeui/build.gradle
+++ b/redwood-composeui/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-flexbox/build.gradle
+++ b/redwood-flexbox/build.gradle
@@ -1,7 +1,6 @@
 import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -11,8 +11,6 @@ apply plugin: 'com.github.gmazzo.buildconfig'
 //
 // We only want to publish when it's being built in the root project.
 if (rootProject.name == 'redwood') {
-  apply plugin: 'app.cash.redwood.build'
-
   redwoodBuild {
     publishing()
   }

--- a/redwood-layout-api/build.gradle
+++ b/redwood-layout-api/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-layout-compose/build.gradle
+++ b/redwood-layout-compose/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.compose'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-layout-composeui/build.gradle
+++ b/redwood-layout-composeui/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'app.cash.paparazzi'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-layout-dom/build.gradle
+++ b/redwood-layout-dom/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'org.jetbrains.kotlin.js'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-layout-modifiers/build.gradle
+++ b/redwood-layout-modifiers/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.modifiers'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-layout-schema/build.gradle
+++ b/redwood-layout-schema/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.redwood.schema'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -21,10 +21,10 @@ import app.cash.redwood.flexbox.FlexDirection
 import app.cash.redwood.flexbox.JustifyContent
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
-import app.cash.redwood.ui.Margin
-import app.cash.redwood.ui.dp
 import app.cash.redwood.layout.modifier.HorizontalAlignment
 import app.cash.redwood.layout.modifier.VerticalAlignment
+import app.cash.redwood.ui.Margin
+import app.cash.redwood.ui.dp
 import app.cash.redwood.widget.Widget
 import org.junit.Test
 

--- a/redwood-layout-testing/build.gradle
+++ b/redwood-layout-testing/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.testing'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-layout-uiview/build.gradle
+++ b/redwood-layout-uiview/build.gradle
@@ -1,7 +1,6 @@
 import app.cash.redwood.buildsupport.FlexboxHelpers
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-layout-view/build.gradle
+++ b/redwood-layout-view/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'app.cash.paparazzi'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-layout-widget/build.gradle
+++ b/redwood-layout-widget/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.widget'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-lazylayout-compose/build.gradle
+++ b/redwood-lazylayout-compose/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.compose'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-lazylayout-composeui/build.gradle
+++ b/redwood-lazylayout-composeui/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-lazylayout-schema/build.gradle
+++ b/redwood-lazylayout-schema/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.redwood.schema'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-lazylayout-testing/build.gradle
+++ b/redwood-lazylayout-testing/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.testing'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-lazylayout-uiview/build.gradle
+++ b/redwood-lazylayout-uiview/build.gradle
@@ -1,7 +1,6 @@
 import app.cash.redwood.buildsupport.ComposeHelpers
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-lazylayout-view/build.gradle
+++ b/redwood-lazylayout-view/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-lazylayout-widget/build.gradle
+++ b/redwood-lazylayout-widget/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.redwood.generator.widget'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-protocol-compose/build.gradle
+++ b/redwood-protocol-compose/build.gradle
@@ -3,7 +3,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-protocol-widget/build.gradle
+++ b/redwood-protocol-widget/build.gradle
@@ -3,7 +3,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-protocol/build.gradle
+++ b/redwood-protocol/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-runtime/build.gradle
+++ b/redwood-runtime/build.gradle
@@ -3,7 +3,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-schema/build.gradle
+++ b/redwood-schema/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-testing/build.gradle
+++ b/redwood-testing/build.gradle
@@ -3,7 +3,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-tooling-codegen/build.gradle
+++ b/redwood-tooling-codegen/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-tooling-lint/build.gradle
+++ b/redwood-tooling-lint/build.gradle
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-tooling-schema/build.gradle
+++ b/redwood-tooling-schema/build.gradle
@@ -3,7 +3,6 @@ import static org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.TEST_COMPILAT
 
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-treehouse-composeui-insets/build.gradle
+++ b/redwood-treehouse-composeui-insets/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-treehouse-composeui/build.gradle
+++ b/redwood-treehouse-composeui/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-treehouse-guest-compose/build.gradle
+++ b/redwood-treehouse-guest-compose/build.gradle
@@ -1,7 +1,6 @@
 import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-treehouse-guest/build.gradle
+++ b/redwood-treehouse-guest/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
 apply plugin: 'app.cash.zipline'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-treehouse-host/build.gradle
+++ b/redwood-treehouse-host/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
 apply plugin: 'app.cash.zipline'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-treehouse/build.gradle
+++ b/redwood-treehouse/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
 apply plugin: 'app.cash.zipline'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-widget-compose/build.gradle
+++ b/redwood-widget-compose/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.ComposeHelpers
 import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-widget-testing/build.gradle
+++ b/redwood-widget-testing/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-widget/build.gradle
+++ b/redwood-widget/build.gradle
@@ -3,7 +3,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.library'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/redwood-yoga/build.gradle
+++ b/redwood-yoga/build.gradle
@@ -2,7 +2,6 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'kotlinx-atomicfu'
-apply plugin: 'app.cash.redwood.build'
 
 redwoodBuild {
   publishing()

--- a/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/HTMLElementEmojiSearchWidgetFactory.kt
+++ b/samples/emoji-search/browser/src/main/kotlin/com/example/redwood/emojisearch/browser/HTMLElementEmojiSearchWidgetFactory.kt
@@ -26,7 +26,6 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLImageElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.HTMLSpanElement
-import org.w3c.dom.events.MouseEvent
 
 class HTMLElementEmojiSearchWidgetFactory(private val document: Document) : EmojiSearchWidgetFactory<HTMLElement> {
   override fun TextInput(): TextInput<HTMLElement> = HtmlTextInput(document.createElement("input") as HTMLInputElement)

--- a/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
+++ b/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
@@ -19,13 +19,13 @@ package com.example.redwood.emojisearch.ios
 
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
+import app.cash.redwood.lazylayout.uiview.UIViewRedwoodLazyLayoutWidgetFactory
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.Content
 import app.cash.redwood.treehouse.TreehouseUIKitView
 import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
-import app.cash.redwood.lazylayout.uiview.UIViewRedwoodLazyLayoutWidgetFactory
 import com.example.redwood.emojisearch.widget.EmojiSearchProtocolNodeFactory
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactory

--- a/samples/emoji-search/presenter/src/commonTest/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTest.kt
+++ b/samples/emoji-search/presenter/src/commonTest/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTest.kt
@@ -20,9 +20,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import app.cash.redwood.testing.flatten
 import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.layout.widget.ColumnValue
+import app.cash.redwood.testing.flatten
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import com.example.redwood.emojisearch.compose.Text

--- a/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
+++ b/samples/emoji-search/presenter/src/jsMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearchTreehouseUi.kt
@@ -19,9 +19,9 @@ import androidx.compose.runtime.Composable
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.lazylayout.compose.ExperimentalRedwoodLazyLayoutApi
-import app.cash.redwood.treehouse.TreehouseUi
 import app.cash.redwood.lazylayout.compose.LazyColumn
 import app.cash.redwood.lazylayout.compose.items
+import app.cash.redwood.treehouse.TreehouseUi
 
 class EmojiSearchTreehouseUi(
   private val httpClient: HttpClient,

--- a/samples/emoji-search/schema/src/main/kotlin/com/example/redwood/emojisearch/schema.kt
+++ b/samples/emoji-search/schema/src/main/kotlin/com/example/redwood/emojisearch/schema.kt
@@ -16,12 +16,12 @@
 package com.example.redwood.emojisearch
 
 import app.cash.redwood.layout.RedwoodLayout
+import app.cash.redwood.lazylayout.RedwoodLazyLayout
 import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Schema.Dependency
 import app.cash.redwood.schema.Widget
-import app.cash.redwood.lazylayout.RedwoodLazyLayout
 import example.values.TextFieldState
 
 @Schema(

--- a/samples/repo-search/presenter/src/commonMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearch.kt
+++ b/samples/repo-search/presenter/src/commonMain/kotlin/com/example/redwood/reposearch/presenter/RepoSearch.kt
@@ -16,9 +16,9 @@
 package com.example.redwood.reposearch.presenter
 
 import androidx.compose.runtime.Composable
+import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.dp
-import app.cash.redwood.layout.compose.Column
 import com.example.redwood.reposearch.compose.Text
 
 // TODO Switch to https://github.com/cashapp/zipline/issues/490 once available.

--- a/samples/repo-search/schema/src/main/kotlin/com/example/redwood/reposearch/schema.kt
+++ b/samples/repo-search/schema/src/main/kotlin/com/example/redwood/reposearch/schema.kt
@@ -16,11 +16,11 @@
 package com.example.redwood.reposearch
 
 import app.cash.redwood.layout.RedwoodLayout
+import app.cash.redwood.lazylayout.RedwoodLazyLayout
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Schema.Dependency
 import app.cash.redwood.schema.Widget
-import app.cash.redwood.lazylayout.RedwoodLazyLayout
 
 @Schema(
   members = [

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,6 @@
 pluginManagement {
+  includeBuild('build-support/settings')
+
   repositories {
     mavenCentral()
     google()
@@ -8,6 +10,7 @@ pluginManagement {
 
 plugins {
   id "com.gradle.enterprise" version "3.13.3"
+  id 'app.cash.redwood.settings'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
The primary effect of this is that Spotless once again runs on every project. It will also allow migrating more of the convention-based configuration in the root `build.gradle` moving forward since this effectively replicates `allprojects {}`.