### PR TITLE
Fix Emoji Search cropping search bar

### DIFF
--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -111,6 +111,7 @@ fun EmojiSearch(
       state = searchTerm,
       hint = "Search",
       onChange = { searchTerm = it },
+      modifier = Modifier.shrink(0.0),
     )
     columnProvider.create(
       items = filteredEmojis,


### PR DESCRIPTION
Fixes https://github.com/cashapp/redwood/issues/964. Closes https://github.com/cashapp/redwood/issues/770 as not a bug.

<img src="https://github.com/cashapp/redwood/assets/6900601/c0e7945e-15ea-4ed1-99c8-3de9bfdc1389" width="250"/>
