### PR TITLE
Remove default parameters from `RefreshableLazyList` and `LazyList`

### DIFF
--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -34,7 +34,7 @@ internal fun LazyList(
   isVertical: Boolean,
   width: Constraint,
   height: Constraint,
-  modifier: Modifier = Modifier,
+  modifier: Modifier,
   placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {
@@ -79,7 +79,7 @@ internal fun RefreshableLazyList(
   onRefresh: (() -> Unit)? = null,
   width: Constraint,
   height: Constraint,
-  modifier: Modifier = Modifier,
+  modifier: Modifier,
   placeholder: @Composable () -> Unit,
   content: LazyListScope.() -> Unit,
 ) {


### PR DESCRIPTION
`LazyList` should only be invoked via `LazyColumn` or `LazyRow`. Those functions MUST pass in a value for `modifer`. The same sentiment holds for the `Refreshable*` counterparts.