### PR TITLE
Fix `artifactId` for layout's modifiers

### DIFF
--- a/redwood-layout-modifiers/gradle.properties
+++ b/redwood-layout-modifiers/gradle.properties
@@ -1,2 +1,2 @@
-POM_ARTIFACT_ID=redwood-modifiers
-POM_NAME=Redwood: Modifiers
+POM_ARTIFACT_ID=redwood-layout-modifiers
+POM_NAME=Redwood Layout: Modifiers


### PR DESCRIPTION
This got caught in the rename and was too eagerly trimmed down. 'redwood-layout' is the artifact grouping and '-modifiers' is the specific name within the group.