### PR TITLE
Eliminate properties used for publishing artifacts

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-1. Update the `VERSION_NAME` in `gradle.properties` to the release version.
+1. Update `redwoodVersion` in `RedwoodBuildPlugin.kt` to the release version.
 
 2. Update the `CHANGELOG.md`:
    1. Change the `Unreleased` header to the release version.
@@ -22,7 +22,7 @@
    $ git tag -am "Version X.Y.Z" X.Y.Z
    ```
 
-6. Update the `VERSION_NAME` in `gradle.properties` to the next "SNAPSHOT" version.
+6. Update `redwoodVersion` in `RedwoodBuildPlugin.kt` to the next "SNAPSHOT" version.
 
 7. Commit
 

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildExtension.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildExtension.kt
@@ -18,8 +18,14 @@ package app.cash.redwood.buildsupport
 interface RedwoodBuildExtension {
   /** Add the Compose compiler plugin. */
   fun composeCompiler()
-  /** Enable artifact publishing and Dokka documentation generation. */
+
+  /**
+   * Enable artifact publishing and Dokka documentation generation.
+   *
+   * The published `artifactId` will be set to the project name.
+   */
   fun publishing()
+
   /** Bundle a zip with dependencies and startup scripts. */
   fun application(name: String, mainClass: String)
 }

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -24,9 +24,16 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.publish.PublishingExtension
 
+private const val redwoodGroupId = "app.cash.redwood"
+// HEY! If you change the major version update release.yaml doc folder.
+private const val redwoodVersion = "0.5.0-SNAPSHOT"
+
 @Suppress("unused") // Invoked reflectively by Gradle.
 class RedwoodBuildPlugin : Plugin<Project> {
   override fun apply(target: Project) {
+    target.group = redwoodGroupId
+    target.version = redwoodVersion
+
     val libs = target.extensions.getByName("libs") as LibrariesForLibs
 
     target.extensions.add(
@@ -95,6 +102,37 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
       if (project.providers.systemProperty("RELEASE_SIGNING_ENABLED").getOrElse("true").toBoolean()) {
         signAllPublications()
+      }
+
+      coordinates(redwoodGroupId, project.name, redwoodVersion)
+
+      pom { pom ->
+        pom.name.set(project.name)
+        pom.description.set("Multiplatform reactive UI using Kotlin and Jetpack Compose")
+        pom.inceptionYear.set("2020")
+        pom.url.set("https://github.com/cashapp/redwood/")
+
+        pom.licenses {
+          it.license { license ->
+            license.name.set("Apache-2.0")
+            license.url.set("https://www.apache.org/licenses/LICENSE-2.0")
+            license.distribution.set("repo")
+          }
+        }
+
+        pom.developers {
+          it.developer { developer ->
+            developer.id.set("cashapp")
+            developer.name.set("CashApp")
+            developer.url.set("https://github.com/cashapp")
+          }
+        }
+
+        pom.scm { scm ->
+          scm.url.set("https://github.com/cashapp/redwood/")
+          scm.connection.set("scm:git:git://github.com/cashapp/redwood.git")
+          scm.developerConnection.set("scm:git:ssh://git@github.com/cashapp/redwood.git")
+        }
       }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,6 @@ buildscript {
 apply plugin: 'org.jetbrains.dokka'
 
 allprojects {
-  group = project.property("GROUP") as String
-  version = project.property("VERSION_NAME") as String
-
   tasks.withType(AbstractTestTask).configureEach {
     testLogging {
       if (System.getenv("CI") == "true") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,24 +25,3 @@ kotlin.mpp.enableCInteropCommonization=true
 
 # Signals to our own plugin that we are building within the repo.
 app.cash.redwood.internal=true
-
-GROUP=app.cash.redwood
-# HEY! If you change major version update release.yaml doc folder.
-VERSION_NAME=0.5.0-SNAPSHOT
-
-POM_DESCRIPTION=Multiplatform reactive UI using Kotlin and Jetpack Compose
-
-POM_URL=https://github.com/cashapp/redwood/
-POM_SCM_URL=https://github.com/cashapp/redwood/
-POM_SCM_CONNECTION=scm:git:git://github.com/cashapp/redwood.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/cashapp/redwood.git
-
-POM_LICENCE_NAME=Apache-2.0
-POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0
-POM_LICENCE_DIST=repo
-
-POM_DEVELOPER_ID=cashapp
-POM_DEVELOPER_NAME=CashApp
-POM_DEVELOPER_URL=https://github.com/cashapp
-
-systemProp.org.gradle.internal.http.socketTimeout=120000

--- a/redwood-compose/gradle.properties
+++ b/redwood-compose/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-compose
-POM_NAME=Redwood Compose

--- a/redwood-composeui/gradle.properties
+++ b/redwood-composeui/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-composeui
-POM_NAME=Redwood for Compose UI

--- a/redwood-flexbox/gradle.properties
+++ b/redwood-flexbox/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-flexbox
-POM_NAME=Redwood Flex Container

--- a/redwood-gradle-plugin/gradle.properties
+++ b/redwood-gradle-plugin/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-gradle-plugin
-POM_NAME=Redwood Gradle plugin

--- a/redwood-layout-api/gradle.properties
+++ b/redwood-layout-api/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-api
-POM_NAME=Redwood Layout API

--- a/redwood-layout-compose/gradle.properties
+++ b/redwood-layout-compose/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-compose
-POM_NAME=Redwood Layout Compose

--- a/redwood-layout-composeui/gradle.properties
+++ b/redwood-layout-composeui/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-composeui
-POM_NAME=Redwood Layout for Compose UI

--- a/redwood-layout-dom/gradle.properties
+++ b/redwood-layout-dom/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-dom
-POM_NAME=Redwood Layout: Layout for HTML DOM

--- a/redwood-layout-modifiers/gradle.properties
+++ b/redwood-layout-modifiers/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-modifiers
-POM_NAME=Redwood Layout: Modifiers

--- a/redwood-layout-schema/gradle.properties
+++ b/redwood-layout-schema/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-schema
-POM_NAME=Redwood Layout Schema

--- a/redwood-layout-testing/gradle.properties
+++ b/redwood-layout-testing/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-testing
-POM_NAME=Redwood Layout Testing

--- a/redwood-layout-uiview/gradle.properties
+++ b/redwood-layout-uiview/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-uiview
-POM_NAME=Redwood Layout for UIView

--- a/redwood-layout-view/gradle.properties
+++ b/redwood-layout-view/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-view
-POM_NAME=Redwood Layout for Android Views

--- a/redwood-layout-widget/gradle.properties
+++ b/redwood-layout-widget/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-layout-widget
-POM_NAME=Redwood Layout Widgets

--- a/redwood-lazylayout-compose/gradle.properties
+++ b/redwood-lazylayout-compose/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-lazylayout-compose
-POM_NAME=Redwood Lazy Layout Compose

--- a/redwood-lazylayout-composeui/gradle.properties
+++ b/redwood-lazylayout-composeui/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-lazylayout-composeui
-POM_NAME=Redwood Lazy Layout for Compose UI

--- a/redwood-lazylayout-schema/gradle.properties
+++ b/redwood-lazylayout-schema/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-lazylayout-schema
-POM_NAME=Redwood Lazy Layout Schema

--- a/redwood-lazylayout-testing/gradle.properties
+++ b/redwood-lazylayout-testing/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-lazylayout-testing
-POM_NAME=Redwood Lazy Layout Testing

--- a/redwood-lazylayout-uiview/gradle.properties
+++ b/redwood-lazylayout-uiview/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-lazylayout-uiview
-POM_NAME=Redwood Lazy Layout for UIView

--- a/redwood-lazylayout-view/gradle.properties
+++ b/redwood-lazylayout-view/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-lazylayout-view
-POM_NAME=Redwood Lazy Layout for Android Views

--- a/redwood-lazylayout-widget/gradle.properties
+++ b/redwood-lazylayout-widget/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-lazylayout-widget
-POM_NAME=Redwood Lazy Layout Widgets

--- a/redwood-protocol-compose/gradle.properties
+++ b/redwood-protocol-compose/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-protocol-compose
-POM_NAME=Redwood protocol for Compose

--- a/redwood-protocol-widget/gradle.properties
+++ b/redwood-protocol-widget/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-protocol-widget
-POM_NAME=Redwood protocol for widgets

--- a/redwood-protocol/gradle.properties
+++ b/redwood-protocol/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-protocol
-POM_NAME=Redwood protocol

--- a/redwood-runtime/gradle.properties
+++ b/redwood-runtime/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-runtime
-POM_NAME=Redwood Runtime

--- a/redwood-schema/gradle.properties
+++ b/redwood-schema/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-schema
-POM_NAME=Redwood schema annotations

--- a/redwood-testing/gradle.properties
+++ b/redwood-testing/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-testing
-POM_NAME=Redwood Testing

--- a/redwood-tooling-codegen/gradle.properties
+++ b/redwood-tooling-codegen/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-tooling-codegen
-POM_NAME=Redwood tooling: code generation

--- a/redwood-tooling-lint/gradle.properties
+++ b/redwood-tooling-lint/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-tooling-lint
-POM_NAME=Redwood tooling: lint

--- a/redwood-tooling-schema/gradle.properties
+++ b/redwood-tooling-schema/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-tooling-schema
-POM_NAME=Redwood tooling: schema

--- a/redwood-treehouse-composeui-insets/gradle.properties
+++ b/redwood-treehouse-composeui-insets/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-treehouse-composeui-insets
-POM_NAME=Redwood Treehouse Compose UI Insets

--- a/redwood-treehouse-composeui/gradle.properties
+++ b/redwood-treehouse-composeui/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-treehouse-composeui
-POM_NAME=Redwood Treehouse Compose UI

--- a/redwood-treehouse-guest-compose/gradle.properties
+++ b/redwood-treehouse-guest-compose/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-treehouse-guest-compose
-POM_NAME=Redwood Treehouse Guest Compose

--- a/redwood-treehouse-guest/gradle.properties
+++ b/redwood-treehouse-guest/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-treehouse-guest
-POM_NAME=Redwood Treehouse Guest

--- a/redwood-treehouse-host/gradle.properties
+++ b/redwood-treehouse-host/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-treehouse-host
-POM_NAME=Redwood Treehouse Host

--- a/redwood-treehouse/gradle.properties
+++ b/redwood-treehouse/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-treehouse
-POM_NAME=Redwood Treehouse

--- a/redwood-widget-compose/gradle.properties
+++ b/redwood-widget-compose/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-widget-compose
-POM_NAME=Redwood widget for Compose

--- a/redwood-widget-testing/gradle.properties
+++ b/redwood-widget-testing/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-widget-testing
-POM_NAME=Redwood widget testing helpers

--- a/redwood-widget/gradle.properties
+++ b/redwood-widget/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-widget
-POM_NAME=Redwood widget

--- a/redwood-yoga/gradle.properties
+++ b/redwood-yoga/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=redwood-yoga
-POM_NAME=Redwood Yoga


### PR DESCRIPTION
The project name is now used as the `artifactId` automatically. These all matched the explicitly-specified ones from before.

I have eliminated the name which is now also set to the project name. Prior to this it was set to a more human-readable version of the `artifactId`.

This was tested by installing all artifacts to a local Maven repo both before and after this change and then diffing the directories. The only changes to the poms is the name change. For example:

    diff -r build/localMavenOld/app/cash/redwood/redwood-treehouse-js/0.5.0/redwood-treehouse-js-0.5.0.pom build/localMaven/app/cash/redwood/redwood-treehouse-js/0.5.0/redwood-treehouse-js-0.5.0.pom
    13c13
    <   <name>Redwood Treehouse</name>
    ---
    >   <name>redwood-treehouse</name>
    15a16