### PR TITLE
Remove ability for custom `LazyList` implementations

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -44,16 +44,7 @@ import platform.darwin.NSObject
 
 private const val reuseIdentifier = "cell"
 
-/**
- * Public function to allow downstream factories to create their own ViewLazyList
- */
-public fun UIViewLazyList(): LazyList<UIView> = UIViewLazyListImpl()
-
-public fun UIViewRefreshableLazyList(
-  refreshControlFactory: () -> UIRefreshControl,
-): RefreshableLazyList<UIView> = UIViewRefreshableLazyListImpl(refreshControlFactory)
-
-internal open class UIViewLazyListImpl() : LazyList<UIView> {
+internal open class UIViewLazyList() : LazyList<UIView> {
 
   private val itemsList = mutableListOf<Widget<UIView>>()
 
@@ -155,14 +146,12 @@ internal open class UIViewLazyListImpl() : LazyList<UIView> {
   override val value: UIView get() = tableView
 }
 
-internal class UIViewRefreshableLazyListImpl(
-  private val refreshControlFactory: () -> UIRefreshControl,
-) : UIViewLazyListImpl(), RefreshableLazyList<UIView> {
+internal class UIViewRefreshableLazyList : UIViewLazyList(), RefreshableLazyList<UIView> {
 
   private var onRefresh: (() -> Unit)? = null
 
   private val refreshControl by lazy {
-    refreshControlFactory().apply {
+    UIRefreshControl().apply {
       setEventHandler(UIControlEventValueChanged) {
         onRefresh?.invoke()
       }

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewRedwoodLayoutWidgetFactory.kt
@@ -18,14 +18,11 @@ package app.cash.redwood.lazylayout.uiview
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory
 import app.cash.redwood.lazylayout.widget.RefreshableLazyList
-import platform.UIKit.UIRefreshControl
 import platform.UIKit.UIView
 
 @ObjCName("UIViewRedwoodLazyLayoutWidgetFactory", exact = true)
 public class UIViewRedwoodLazyLayoutWidgetFactory : RedwoodLazyLayoutWidgetFactory<UIView> {
   override fun LazyList(): LazyList<UIView> = UIViewLazyList()
 
-  override fun RefreshableLazyList(): RefreshableLazyList<UIView> = UIViewRefreshableLazyList(
-    refreshControlFactory = { UIRefreshControl() },
-  )
+  override fun RefreshableLazyList(): RefreshableLazyList<UIView> = UIViewRefreshableLazyList()
 }

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -18,6 +18,7 @@
 package app.cash.redwood.lazylayout.view
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
@@ -89,27 +90,10 @@ internal class Items<VH : RecyclerView.ViewHolder>(
   }
 }
 
-/**
- * Public function to allow downstream factories to create their own LazyList
- */
-public fun ViewLazyList(
-  recyclerViewFactory: () -> RecyclerView,
-): LazyList<View> = ViewLazyListImpl(recyclerViewFactory)
-
-/**
- * Public function to allow downstream factories to create their own RefreshableLazyList
- */
-public fun ViewRefreshableLazyList(
-  recyclerViewFactory: () -> RecyclerView,
-  swipeRefreshLayoutFactory: () -> SwipeRefreshLayout,
-): RefreshableLazyList<View> = RefreshableViewLazyListImpl(recyclerViewFactory, swipeRefreshLayoutFactory)
-
-internal open class ViewLazyListImpl(
-  recyclerViewFactory: () -> RecyclerView,
-) : LazyList<View> {
+internal open class ViewLazyList(context: Context) : LazyList<View> {
   private val scope = MainScope()
 
-  internal val recyclerView: RecyclerView by lazy { recyclerViewFactory() }
+  internal val recyclerView: RecyclerView = RecyclerView(context)
 
   override var modifier: Modifier = Modifier
 
@@ -275,12 +259,11 @@ internal open class ViewLazyListImpl(
   }
 }
 
-internal class RefreshableViewLazyListImpl(
-  recyclerViewFactory: () -> RecyclerView,
-  swipeRefreshLayoutFactory: () -> SwipeRefreshLayout,
-) : ViewLazyListImpl(recyclerViewFactory), RefreshableLazyList<View> {
+internal class ViewRefreshableLazyList(
+  context: Context,
+) : ViewLazyList(context), RefreshableLazyList<View> {
 
-  private val swipeRefreshLayout by lazy { swipeRefreshLayoutFactory() }
+  private val swipeRefreshLayout = SwipeRefreshLayout(context)
 
   override val value: View get() = swipeRefreshLayout
 

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewRedwoodTreehouseLazyLayoutWidgetFactory.kt
@@ -17,8 +17,6 @@ package app.cash.redwood.lazylayout.view
 
 import android.content.Context
 import android.view.View
-import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory
 import app.cash.redwood.lazylayout.widget.RefreshableLazyList
@@ -26,12 +24,8 @@ import app.cash.redwood.lazylayout.widget.RefreshableLazyList
 public class ViewRedwoodLazyLayoutWidgetFactory(
   private val context: Context,
 ) : RedwoodLazyLayoutWidgetFactory<View> {
-  public override fun LazyList(): LazyList<View> = ViewLazyList(
-    recyclerViewFactory = { RecyclerView(context) },
-  )
+  public override fun LazyList(): LazyList<View> = ViewLazyList(context)
 
-  public override fun RefreshableLazyList(): RefreshableLazyList<View> = ViewRefreshableLazyList(
-    recyclerViewFactory = { RecyclerView(context) },
-    swipeRefreshLayoutFactory = { SwipeRefreshLayout(context) },
-  )
+  public override fun RefreshableLazyList(): RefreshableLazyList<View> =
+    ViewRefreshableLazyList(context)
 }


### PR DESCRIPTION
I want to remove it because I don't want downstream consumers of `LazyList` to be passing in weird `RecyclerView` instances that have to be considered if the implementation of `ViewLazyList` ever changes. It's not a crazy likely scenario, but neither is needing to pass in your own instance of `ReyclerView` to `LazyList` (imo).