### PR TITLE
Verify `redwood-layout-view` and `redwood-lazylayout-view` parity with Paparazzi

### DIFF
--- a/redwood-lazylayout-view/build.gradle
+++ b/redwood-lazylayout-view/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
+apply plugin: 'app.cash.paparazzi'
 
 redwoodBuild {
   publishing()
@@ -12,6 +13,7 @@ dependencies {
   implementation libs.androidx.recyclerview
   implementation libs.androidx.swipeRefreshLayout
   implementation libs.kotlinx.coroutines.android
+  testImplementation projects.redwoodLayoutSharedTest
 }
 
 android {

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.lazylayout.view
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.View
+import android.widget.TextView
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import app.cash.redwood.Modifier
+import app.cash.redwood.layout.AbstractFlexContainerTest
+import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.api.Constraint
+import app.cash.redwood.ui.Margin
+import app.cash.redwood.widget.Widget
+import app.cash.redwood.yoga.AlignItems
+import app.cash.redwood.yoga.FlexDirection
+import app.cash.redwood.yoga.JustifyContent
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ViewLazyListTest : AbstractFlexContainerTest<View>() {
+
+  @get:Rule
+  val paparazzi = Paparazzi(
+    deviceConfig = DeviceConfig.PIXEL_6,
+    theme = "android:Theme.Material.Light.NoActionBar",
+    showSystemUi = false,
+  )
+
+  override fun flexContainer(direction: FlexDirection) = ViewTestFlexContainer(paparazzi.context, direction)
+
+  override fun widget(text: String, modifier: Modifier) = object : Widget<View> {
+    override val value = TextView(paparazzi.context).apply {
+      background = ColorDrawable(Color.GREEN)
+      textSize = 18f
+      setTextColor(Color.BLACK)
+      this.text = text
+    }
+    override var modifier = modifier
+  }
+
+  override fun verifySnapshot(container: TestFlexContainer<View>) {
+    paparazzi.snapshot(container.value)
+  }
+
+  class ViewTestFlexContainer(context: Context, direction: FlexDirection) : TestFlexContainer<View> {
+    private val delegate = ViewLazyList(context)
+      .apply { isVertical(direction == FlexDirection.Column) }
+    private var childCount = 0
+
+    override val value get() = delegate.value
+
+    override fun width(constraint: Constraint) {
+      delegate.width(constraint)
+    }
+
+    override fun height(constraint: Constraint) {
+      delegate.width(constraint)
+    }
+
+    override fun alignItems(alignItems: AlignItems) {
+    }
+
+    override fun justifyContent(justifyContent: JustifyContent) {
+    }
+
+    override fun margin(margin: Margin) {
+    }
+
+    override fun add(widget: Widget<View>) {
+      delegate.items.insert(childCount++, widget)
+    }
+  }
+}

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithJustifyContentCenter.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithJustifyContentCenter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f80cce4e0ddaba73364be1f77dbac26573785c44c83fda2bd2c3256b42528ee
+size 53996

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithJustifyContentSpaceAround.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithJustifyContentSpaceAround.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f80cce4e0ddaba73364be1f77dbac26573785c44c83fda2bd2c3256b42528ee
+size 53996

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithJustifyContentSpaceBetween.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithJustifyContentSpaceBetween.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f80cce4e0ddaba73364be1f77dbac26573785c44c83fda2bd2c3256b42528ee
+size 53996

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithMarginAndDifferentAlignments.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithMarginAndDifferentAlignments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc8c6641e7ea8d9c88fba7b0cdd607004c5adb4b4146175844bf98ecdfd901e6
+size 55330

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_longColumn.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_longColumn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc8c6641e7ea8d9c88fba7b0cdd607004c5adb4b4146175844bf98ecdfd901e6
+size 55330

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_longRow.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_longRow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e601cd4fc9c3c6bb0cbba2e702fed51ded69d4810890b53c7401c75eee1cd6e7
+size 7830

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_shortColumn.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_shortColumn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e782f6a530f32515d367765d094095e7fa1feeef1f56436d02b607fd93227b7d
+size 16411

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_shortRow.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_shortRow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e601cd4fc9c3c6bb0cbba2e702fed51ded69d4810890b53c7401c75eee1cd6e7
+size 7830


### PR DESCRIPTION
It should (for the most part) be possible to swap out `Column` with `LazyColumn` (or `Row` with `LazyRow`) and have the output be similar/identical. The only difference _should_ be that the `Lazy*` variations create items lazily instead of eagerly. With few items, the output should be identical.

At the moment, this isn't the case.

This PR brings this issue to the forefront. In subsequent PRs, I'll make the necessary fixes such that these snapshots match those of Flexbox/Yoga as close as makes sense.

Note that this doesn't test anything to do with the lazy creation of items. That shall be a completely separate endeavor.