### PR TITLE
Widen Kotlin Spotless glob

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -63,7 +63,9 @@ class RedwoodBuildPlugin : Plugin<Project> {
         if (target.path == ":") {
           it.target("build-support/src/**/*.kt")
         } else {
-          it.target("src/*/kotlin/**/*.kt")
+          it.target("src/**/*.kt")
+          // Avoid 'build' folders within test fixture projects which may contain generated sources.
+          it.targetExclude("src/test/fixture/**/build/**")
         }
         it.ktlint(libs.ktlint.get().version).editorConfigOverride(
           mapOf("ktlint_standard_filename" to "disabled"),

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/src/main/kotlin/example/counter/schema.kt
@@ -16,15 +16,13 @@
 package example.counter
 
 import app.cash.redwood.schema.Children
-import app.cash.redwood.schema.Default
-import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
 
 @Schema(
   [
     CounterBox::class,
-  ]
+  ],
 )
 interface Counter
 

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/schema/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/schema/src/main/kotlin/example/counter/schema.kt
@@ -26,7 +26,7 @@ import app.cash.redwood.schema.Widget
     CounterBox::class,
     CounterText::class,
     CounterButton::class,
-  ]
+  ],
 )
 interface Counter
 

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-reference/schema/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-reference/schema/src/main/kotlin/example/counter/schema.kt
@@ -26,7 +26,7 @@ import app.cash.redwood.schema.Widget
     CounterBox::class,
     CounterText::class,
     CounterButton::class,
-  ]
+  ],
 )
 interface Counter
 


### PR DESCRIPTION
This catches the source files within the test fixtures. The old pattern was designed to avoid these projects completely. Instead, add a targeted exclude which avoids the 'build' directories of the test fixtures.