### PR TITLE
`redwood-layout` not abiding wrap constraint

### DIFF
--- a/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainer.kt
+++ b/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainer.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
 import app.cash.redwood.Modifier as RedwoodModifier
+import androidx.compose.foundation.background
+import androidx.compose.ui.graphics.Color
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
@@ -129,7 +131,7 @@ internal class ComposeUiFlexContainer(
 
         children.render()
       },
-      modifier = computeModifier(),
+      modifier = computeModifier().background(Color.Blue),
       measurePolicy = ::measure,
     )
   }

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_shortColumn.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_shortColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df557299fb750f451225c24f2c524c35f1941010059eb03899919c0622cd4ade
-size 16327
+oid sha256:1017b652ef3e6b6a46fcefa7f80f846d872cd0d7b45a857d945ed81388ed4a36
+size 16550

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -44,6 +44,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun shortColumn() {
     val container = flexContainer(FlexDirection.Column)
+    container.height(Constraint.Wrap)
     container.alignItems(AlignItems.FlexStart)
     movies.take(5).forEach { movie ->
       container.add(widget(movie))

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.layout.view
 
 import android.content.Context
+import android.graphics.Color
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -133,6 +134,7 @@ internal class ViewFlexContainer(
       }
 
     init {
+      setBackgroundColor(Color.BLUE)
       updateViewHierarchy()
     }
 

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_shortColumn.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_shortColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df557299fb750f451225c24f2c524c35f1941010059eb03899919c0622cd4ade
-size 16327
+oid sha256:1017b652ef3e6b6a46fcefa7f80f846d872cd0d7b45a857d945ed81388ed4a36
+size 16550


### PR DESCRIPTION
@colinrtwhite This is more of a question with code than a PR!

For the test `shortColumn()`, I've set the height of the container to `Constraint.Wrap` (though I believe this is also the implicit value). I've also set the container background to blue.

With these changes, it doesn't appear that the flex container is abiding by the `Constraint.Wrap` constraint. Is this a bug?