### PR TITLE
Store and restore state for widget view in compose (syntax)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ jetbrains-compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradl
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "jbCompose" }
 jetbrains-compose-material = { module = "org.jetbrains.compose.material:material", version.ref = "jbCompose" }
 jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jbCompose" }
+jetbrains-compose-runtime-saveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "jbCompose" }
 jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jbCompose" }
 jetbrains-compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "jbCompose" }
 jetbrains-compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "jbCompose" }

--- a/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -52,6 +52,8 @@ public fun <A : AppService> TreehouseContent(
       override val widgetSystem = widgetSystem
       override val readyForContent = true
       override var readyForContentChangeListener: ReadyForContentChangeListener? = null
+      override var saveCallback: TreehouseView.SaveCallback? = null
+      override val restoredId: String? = null
       override fun reset() = children.remove(0, children.widgets.size)
     }
   }

--- a/redwood-treehouse-guest-compose/build.gradle
+++ b/redwood-treehouse-guest-compose/build.gradle
@@ -15,6 +15,7 @@ kotlin {
       dependencies {
         api projects.redwoodProtocolCompose
         api libs.jetbrains.compose.runtime
+        api libs.jetbrains.compose.runtime.saveable
       }
     }
   }

--- a/redwood-treehouse-guest-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/composition.kt
+++ b/redwood-treehouse-guest-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/composition.kt
@@ -18,6 +18,8 @@ package app.cash.redwood.treehouse
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
 import app.cash.redwood.compose.LocalUiConfiguration
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.ui.UiConfiguration
@@ -27,10 +29,14 @@ import kotlinx.coroutines.flow.StateFlow
 public fun RedwoodComposition.bind(
   treehouseUi: TreehouseUi,
   uiConfigurations: StateFlow<UiConfiguration>,
+  saveableStateRegistry: SaveableStateRegistry,
 ) {
   setContent {
     val uiConfiguration by uiConfigurations.collectAsState()
-    CompositionLocalProvider(LocalUiConfiguration provides uiConfiguration) {
+    CompositionLocalProvider(
+      LocalUiConfiguration provides uiConfiguration,
+      LocalSaveableStateRegistry provides saveableStateRegistry,
+    ) {
       treehouseUi.Show()
     }
   }

--- a/redwood-treehouse-guest/build.gradle
+++ b/redwood-treehouse-guest/build.gradle
@@ -16,7 +16,9 @@ kotlin {
     commonMain {
       dependencies {
         api libs.jetbrains.compose.runtime
+        api libs.jetbrains.compose.runtime.saveable
         api libs.kotlinx.coroutines.core
+        api libs.okio
         api libs.zipline
         api projects.redwoodProtocol
         api projects.redwoodProtocolCompose

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -106,19 +106,6 @@ public class TreehouseWidgetView(
   }
 
   override fun onRestoreInstanceState(state: Parcelable?) {
-    // Hard problems to solve:
-    //   Do we get positive confirmation when no state is coming?
-    //   Ie. should we delay launching the Content until state is ready,
-    //   or will we never find out if state isn't ever coming?
-
-    // A good model for state is:
-    // showing pixels on screen currently requires 3 things to be ready:
-    //   - the code (downloaded and initialized)
-    //   - the content (setContent() is called)
-    //   - this view is attached to the screen
-    // Our plan here:
-    //   - just add one more thing that needs to be ready! The state
-
     state as SavedState
     this.restoredId = state.id
     super.onRestoreInstanceState(state.superState)
@@ -149,6 +136,8 @@ public class TreehouseWidgetView(
     }
 
     companion object {
+
+      // Android OS relies on CREATOR to restore SavedState
       @JvmField
       val CREATOR: Parcelable.Creator<SavedState> = object : Parcelable.Creator<SavedState> {
         override fun createFromParcel(parcel: Parcel): SavedState {

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -47,15 +47,17 @@ public class TreehouseWidgetView(
       field = value
     }
 
-  override var saveCallback: TreehouseView.SaveCallback? = null
-  override var restoredId: String? = null
-
   /**
    * Like [View.isAttachedToWindow]. We'd prefer that property but it's false until
    * [onAttachedToWindow] returns and true until [onDetachedFromWindow] returns.
    */
   override var readyForContent: Boolean = false
     private set
+
+  override var restoredId: String? = null
+    private set
+
+  override var saveCallback: TreehouseView.SaveCallback? = null
 
   private val _children = ViewGroupChildren(this)
   override val children: Widget.Children<View> get() = _children

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -18,6 +18,8 @@ package app.cash.redwood.treehouse
 import android.content.Context
 import android.os.Looper
 import android.util.Log
+import app.cash.zipline.Zipline
+import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.loader.ManifestVerifier
 import app.cash.zipline.loader.ZiplineCache
 import app.cash.zipline.loader.asZiplineHttpClient
@@ -34,12 +36,13 @@ public fun TreehouseAppFactory(
   context: Context,
   httpClient: OkHttpClient,
   manifestVerifier: ManifestVerifier,
-  eventListener: EventListener = EventListener(),
+  eventListener: EventListener = defaultEventListener,
   embeddedDir: Path? = null,
   embeddedFileSystem: FileSystem? = null,
   cacheName: String = "zipline",
   cacheMaxSizeInBytes: Long = 50L * 1024L * 1024L,
   concurrentDownloads: Int = 8,
+  stateStore: StateStore = MemoryStateStore(),
 ): TreehouseApp.Factory = TreehouseApp.Factory(
   platform = AndroidTreehousePlatform(context),
   dispatchers = AndroidTreehouseDispatchers(),
@@ -52,6 +55,7 @@ public fun TreehouseAppFactory(
   cacheName = cacheName,
   cacheMaxSizeInBytes = cacheMaxSizeInBytes,
   concurrentDownloads = concurrentDownloads,
+  stateStore = stateStore,
 )
 
 internal class AndroidTreehousePlatform(
@@ -95,5 +99,15 @@ internal class AndroidTreehouseDispatchers : TreehouseDispatchers {
 
   override fun checkZipline() {
     check(Thread.currentThread() == ziplineThread)
+  }
+}
+
+public val defaultEventListener: EventListener = object : EventListener() {
+  override fun codeLoadFailed(app: TreehouseApp<*>, manifestUrl: String?, exception: Exception, startValue: Any?) {
+    Log.w("Treehouse", "codeLoadFailed", exception)
+  }
+
+  override fun codeLoadSuccess(app: TreehouseApp<*>, manifestUrl: String?, manifest: ZiplineManifest, zipline: Zipline, startValue: Any?) {
+    Log.i("Treehouse", "codeLoadSuccess")
   }
 }

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -18,8 +18,6 @@ package app.cash.redwood.treehouse
 import android.content.Context
 import android.os.Looper
 import android.util.Log
-import app.cash.zipline.Zipline
-import app.cash.zipline.ZiplineManifest
 import app.cash.zipline.loader.ManifestVerifier
 import app.cash.zipline.loader.ZiplineCache
 import app.cash.zipline.loader.asZiplineHttpClient

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -36,7 +36,7 @@ public fun TreehouseAppFactory(
   context: Context,
   httpClient: OkHttpClient,
   manifestVerifier: ManifestVerifier,
-  eventListener: EventListener = defaultEventListener,
+  eventListener: EventListener = EventListener(),
   embeddedDir: Path? = null,
   embeddedFileSystem: FileSystem? = null,
   cacheName: String = "zipline",
@@ -99,15 +99,5 @@ internal class AndroidTreehouseDispatchers : TreehouseDispatchers {
 
   override fun checkZipline() {
     check(Thread.currentThread() == ziplineThread)
-  }
-}
-
-public val defaultEventListener: EventListener = object : EventListener() {
-  override fun codeLoadFailed(app: TreehouseApp<*>, manifestUrl: String?, exception: Exception, startValue: Any?) {
-    Log.w("Treehouse", "codeLoadFailed", exception)
-  }
-
-  override fun codeLoadSuccess(app: TreehouseApp<*>, manifestUrl: String?, manifest: ZiplineManifest, zipline: Zipline, startValue: Any?) {
-    Log.i("Treehouse", "codeLoadSuccess")
   }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/MemoryStateStore.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/MemoryStateStore.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+/** A simple in-memory state store. */
+public class MemoryStateStore : StateStore {
+  private val map = mutableMapOf<String, StateSnapshot>()
+
+  override suspend fun put(id: String, value: StateSnapshot) {
+    map[id] = value
+  }
+
+  override suspend fun get(id: String): StateSnapshot? {
+    return map[id]
+  }
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/StateStore.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/StateStore.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+/** All functions are invoked on the UI dispatcher. */
 public interface StateStore {
   public suspend fun put(id: String, value: StateSnapshot)
   public suspend fun get(id: String): StateSnapshot?

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/StateStore.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/StateStore.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+public interface StateStore {
+  public suspend fun put(id: String, value: StateSnapshot)
+  public suspend fun get(id: String): StateSnapshot?
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -62,6 +62,8 @@ public class TreehouseApp<A : AppService> private constructor(
    */
   internal val boundContents = mutableListOf<TreehouseAppContent<A>>()
 
+  internal val stateStore: StateStore = factory.stateStore
+
   /**
    * Returns the current zipline attached to this host, or null if Zipline hasn't loaded yet. The
    * returned value will be invalid when new code is loaded.
@@ -221,6 +223,7 @@ public class TreehouseApp<A : AppService> private constructor(
     private val cacheName: String,
     private val cacheMaxSizeInBytes: Long,
     internal val concurrentDownloads: Int,
+    internal val stateStore: StateStore,
   ) : Closeable {
     internal val eventPublisher = EventPublisher(eventListener)
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -383,7 +383,6 @@ private class ViewContentCodeBinding<A : AppService>(
       val state = treehouseUiOrNull?.snapshotState() ?: return@launch
       appScope.launch(app.dispatchers.ui) {
         app.stateStore.put(id, state)
-        println("=== id: $id, $state")
       }
     }
   }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -252,7 +252,7 @@ private class ViewContentCodeBinding<A : AppService>(
   private val isInitialLaunch: Boolean,
   session: ZiplineSession<A>,
   firstUiConfiguration: StateFlow<UiConfiguration>,
-) : EventSink, ChangesSinkService {
+) : EventSink, ChangesSinkService, TreehouseView.SaveCallback {
   private val uiConfigurationFlow = SequentialStateFlow(firstUiConfiguration)
 
   private val json = session.zipline.json
@@ -291,6 +291,9 @@ private class ViewContentCodeBinding<A : AppService>(
     if (canceled) return
 
     viewOrNull = view
+
+    view.saveCallback = this
+
     @Suppress("UNCHECKED_CAST") // We don't have a type parameter for the widget type.
     bridgeOrNull = ProtocolBridge(
       container = view.children as Widget.Children<Any>,
@@ -365,16 +368,30 @@ private class ViewContentCodeBinding<A : AppService>(
       val scopedAppService = session.appService.withScope(ziplineScope)
       val treehouseUi = contentSource.get(scopedAppService)
       treehouseUiOrNull = treehouseUi
+      val restoredId = viewOrNull?.restoredId
+      val restoredState = if (restoredId != null) app.stateStore.get(restoredId) else null
       treehouseUi.start(
         changesSink = this@ViewContentCodeBinding,
         uiConfigurations = uiConfigurationFlow,
+        stateSnapshot = restoredState,
       )
+    }
+  }
+
+  override fun performSave(id: String) {
+    appScope.launch(app.dispatchers.zipline) {
+      val state = treehouseUiOrNull?.snapshotState() ?: return@launch
+      appScope.launch(app.dispatchers.ui) {
+        app.stateStore.put(id, state)
+        println("=== id: $id, $state")
+      }
     }
   }
 
   fun cancel() {
     app.dispatchers.checkUi()
     canceled = true
+    viewOrNull?.saveCallback = null
     viewOrNull = null
     bridgeOrNull = null
     appScope.launch(app.dispatchers.zipline) {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -30,6 +30,8 @@ public interface TreehouseView {
   public val widgetSystem: WidgetSystem
   public val readyForContent: Boolean
   public var readyForContentChangeListener: ReadyForContentChangeListener?
+  public var saveCallback: SaveCallback?
+  public var restoredId: String?
 
   /** Invoked when new code is loaded. This should at minimum clear all [children]. */
   public fun reset()
@@ -38,6 +40,12 @@ public interface TreehouseView {
   public fun interface ReadyForContentChangeListener {
     /** Called when [TreehouseView.readyForContent] has changed. */
     public fun onReadyForContentChanged(view: TreehouseView)
+  }
+
+  @ObjCName("TreehouseViewSaveCallback", exact = true)
+  public interface SaveCallback {
+    /** Called on the UI dispatcher to save the state for the current content. */
+    public fun performSave(id: String)
   }
 
   @ObjCName("TreehouseViewWidgetSystem", exact = true)

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -31,7 +31,7 @@ public interface TreehouseView {
   public val readyForContent: Boolean
   public var readyForContentChangeListener: ReadyForContentChangeListener?
   public var saveCallback: SaveCallback?
-  public var restoredId: String?
+  public val restoredId: String?
 
   /** Invoked when new code is loaded. This should at minimum clear all [children]. */
   public fun reset()

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -38,6 +38,8 @@ public class TreehouseUIKitView(
   override val widgetSystem: WidgetSystem,
 ) : TreehouseView {
   public val view: UIView = RootUiView(this)
+  override var saveCallback: TreehouseView.SaveCallback? = null
+  override var restoredId: String? = null
 
   override var readyForContentChangeListener: ReadyForContentChangeListener? = null
     set(value) {

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
@@ -43,6 +43,7 @@ public fun TreehouseAppFactory(
   cacheName: String = "zipline",
   cacheMaxSizeInBytes: Long = 50L * 1024L * 1024L,
   concurrentDownloads: Int = 8,
+  stateStore: StateStore = MemoryStateStore(),
 ): TreehouseApp.Factory = TreehouseApp.Factory(
   platform = IosTreehousePlatform(),
   dispatchers = IosTreehouseDispatchers(),
@@ -55,6 +56,7 @@ public fun TreehouseAppFactory(
   cacheName = cacheName,
   cacheMaxSizeInBytes = cacheMaxSizeInBytes,
   concurrentDownloads = concurrentDownloads,
+  stateStore = stateStore,
 )
 
 internal class IosTreehousePlatform : TreehousePlatform {

--- a/redwood-treehouse/build.gradle
+++ b/redwood-treehouse/build.gradle
@@ -17,6 +17,7 @@ kotlin {
       dependencies {
         api projects.redwoodCompose
         api projects.redwoodProtocol
+        api libs.okio
         api libs.zipline
       }
     }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+
+@Serializable
+public class StateSnapshot(
+  public val content: Map<String, List<JsonElement?>>,
+) {
+  public fun toValuesMap(): Map<String, List<Any?>>? {
+    return content.mapValues { entry ->
+      entry.value.map { mutableStateOf(it.fromJsonElement()) }
+    }
+  }
+}
+
+/**
+ * Supported types:
+ * String, Boolean, Int, List (of supported primitive types), Map (of supported primitive types)
+ */
+public fun Map<String, List<Any?>>.toStateSnapshot(): StateSnapshot? {
+  val map = mutableMapOf<String, List<JsonElement?>>()
+  this.forEach { entry ->
+    val list = entry.value.map { element ->
+      when (element) {
+        is MutableState<*> -> {
+          element.value.toJsonElement()
+        }
+
+        else -> error("unexpected type: $this")
+      }
+    }
+    map[entry.key] = list
+  }
+  return StateSnapshot(map)
+}
+
+private fun Any?.toJsonElement(): JsonElement {
+  return when (this) {
+    is String -> JsonPrimitive(this)
+    is List<*> -> JsonArray(map { it.toJsonElement() })
+    is JsonElement -> this
+    else -> error("unexpected type: $this")
+    // TODO: add support to Map<*, *>
+  }
+}
+
+private fun JsonElement?.fromJsonElement(): Any {
+  return when (this) {
+    is JsonPrimitive -> {
+      if (this.isString) {
+        return content
+      }
+      if (isBoolean(this)) {
+        return this.boolean
+      }
+      if (isInt(this)) {
+        return this.int
+      } else {
+        error("unexpected type: $this")
+      }
+      // TODO add other primitive types (double, float, long) when needed
+    }
+
+    is JsonArray -> listOf({ this.forEach { it.toJsonElement() } })
+    // TODO: map, numbers
+    // is Map<*, *> -> JsonElement
+    else -> error("unexpected type: $this")
+  }
+}
+
+private fun isBoolean(jsonPrimitive: JsonPrimitive): Boolean {
+  return try {
+    jsonPrimitive.boolean
+    true
+  } catch (e: IllegalStateException) {
+    false
+  }
+}
+
+private fun isInt(jsonPrimitive: JsonPrimitive): Boolean {
+  return try {
+    jsonPrimitive.int
+    true
+  } catch (e: NumberFormatException) {
+    false
+  }
+}

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
-import kotlinx.serialization.json.int
+import kotlinx.serialization.json.double
 
 @Serializable
 public class StateSnapshot(
@@ -75,8 +75,8 @@ private fun JsonElement?.fromJsonElement(): Any {
       if (isBoolean(this)) {
         return this.boolean
       }
-      if (isInt(this)) {
-        return this.int
+      if (isDouble(this)) {
+        return this.double
       } else {
         error("unexpected type: $this")
       }
@@ -99,9 +99,9 @@ private fun isBoolean(jsonPrimitive: JsonPrimitive): Boolean {
   }
 }
 
-private fun isInt(jsonPrimitive: JsonPrimitive): Boolean {
+private fun isDouble(jsonPrimitive: JsonPrimitive): Boolean {
   return try {
-    jsonPrimitive.int
+    jsonPrimitive.double
     true
   } catch (e: NumberFormatException) {
     false

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineTreehouseUi.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineTreehouseUi.kt
@@ -31,5 +31,7 @@ public interface ZiplineTreehouseUi : ZiplineService, EventSink {
   public fun start(
     changesSink: ChangesSinkService,
     uiConfigurations: StateFlow<UiConfiguration>,
+    stateSnapshot: StateSnapshot?,
   )
+  public fun snapshotState(): StateSnapshot? = null
 }

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -15,6 +15,7 @@
  */
 package com.example.redwood.emojisearch.android.views
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -41,11 +42,15 @@ import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
 
 class EmojiSearchActivity : ComponentActivity() {
   private val scope: CoroutineScope = CoroutineScope(Main)
 
+  @SuppressLint("ResourceType")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -68,6 +73,8 @@ class EmojiSearchActivity : ComponentActivity() {
 
     setContentView(
       TreehouseWidgetView(this, widgetSystem).apply {
+        // The view needs to have an id for Android to populate saved data back
+        this.id = 9000
         treehouseContentSource.bindWhenReady(this, treehouseApp)
       },
     )
@@ -82,6 +89,11 @@ class EmojiSearchActivity : ComponentActivity() {
       httpClient = httpClient,
       manifestVerifier = ManifestVerifier.NO_SIGNATURE_CHECKS,
       eventListener = appEventListener,
+      stateStore = FileStateStore(
+        json = Json,
+        fileSystem = FileSystem.SYSTEM,
+        directory = applicationContext.getDir("TreehouseState", MODE_PRIVATE).toOkioPath(),
+      ),
     )
 
     val manifestUrlFlow = flowOf("http://10.0.2.2:8080/manifest.zipline.json")

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/FileStateStore.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/FileStateStore.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.redwood.emojisearch.android.views
+
+import app.cash.redwood.treehouse.StateSnapshot
+import app.cash.redwood.treehouse.StateStore
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okio.FileNotFoundException
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Limited state store that creates a new file for each snapshot.
+ *
+ * This doesn't implement eviction.
+ */
+class FileStateStore(
+  private val json: Json,
+  private val fileSystem: FileSystem,
+  private val directory: Path,
+) : StateStore {
+  init {
+    fileSystem.createDirectories(directory)
+    // TODO add a mechanism to delete files older than 24 hours
+  }
+
+  override suspend fun put(id: String, value: StateSnapshot) {
+    val path = directory / "$id.state"
+    val tmpPath = directory / "$id.state.tmp"
+    fileSystem.write(tmpPath) {
+      writeUtf8(json.encodeToString(value))
+    }
+    fileSystem.atomicMove(tmpPath, path)
+  }
+
+  override suspend fun get(id: String): StateSnapshot? {
+    return try {
+      val path = directory / "$id.state"
+      fileSystem.read(path) {
+        json.decodeFromString<StateSnapshot>(readUtf8())
+      }
+    } catch (e: FileNotFoundException) {
+      null
+    }
+  }
+}

--- a/samples/emoji-search/presenter-treehouse/build.gradle
+++ b/samples/emoji-search/presenter-treehouse/build.gradle
@@ -18,6 +18,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        api libs.okio
         api projects.redwoodTreehouse
       }
     }

--- a/samples/emoji-search/presenter/build.gradle
+++ b/samples/emoji-search/presenter/build.gradle
@@ -10,6 +10,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        api libs.okio
         api projects.samples.emojiSearch.schema.compose
         api projects.redwoodTreehouse
         api projects.redwoodTreehouseGuestCompose

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -22,6 +22,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.SaverScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import app.cash.redwood.Modifier
 import app.cash.redwood.compose.LocalUiConfiguration
@@ -87,6 +90,13 @@ fun EmojiSearch(
   var refreshSignal by remember { mutableStateOf(0) }
   var refreshing by remember { mutableStateOf(false) }
 
+  val searchTermSaver = object : Saver<TextFieldState, String> {
+    override fun restore(value: String) = TextFieldState(value)
+    override fun SaverScope.save(value: TextFieldState) = value.text
+  }
+
+  var searchTerm by rememberSaveable(stateSaver = searchTermSaver) { mutableStateOf(TextFieldState("")) }
+
   LaunchedEffect(refreshSignal) {
     try {
       refreshing = true
@@ -103,7 +113,6 @@ fun EmojiSearch(
     }
   }
 
-  var searchTerm by remember { mutableStateOf(TextFieldState()) }
   val filteredEmojis by derivedStateOf {
     val searchTerms = searchTerm.text.split(" ")
     allEmojis.filter { image ->
@@ -118,7 +127,7 @@ fun EmojiSearch(
     margin = LocalUiConfiguration.current.safeAreaInsets,
   ) {
     TextInput(
-      state = searchTerm,
+      state = TextFieldState(searchTerm.text),
       hint = "Search",
       onChange = { searchTerm = it },
       modifier = Modifier.shrink(0.0),


### PR DESCRIPTION
This PR introduces a mechanism to store and restore state for the Android view implementation as part of `onSaveInstanceState` and `onRestoreInstanceState`.

**Android view implementation: works as designed**

https://github.com/cashapp/redwood/assets/57155915/1b79da53-4626-4569-a50d-8df6d6324e90

**Android compose implementation: it's not the focus of this PR, and it's somewhat broken right now, will look into it**

https://github.com/cashapp/redwood/assets/57155915/ec739245-6ad2-4ffc-ab0b-2471860b68ec

**iOS implementation: it just works ... (no work is required)**


