### PR TITLE
Fix infinite recursion when measuring an empty YogaUIView.

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -64,12 +64,8 @@ internal class YogaUIView : UIView(cValue { CGRectZero }) {
     val subviews = typedSubviews
     if (subviews.isEmpty()) {
       rootNode.children.clear()
-      rootNode.measureCallback = UIViewMeasureCallback(this)
       return
     }
-
-    // Nodes with children cannot have measure functions.
-    rootNode.measureCallback = null
 
     val currentViews = rootNode.children.map { it.view }
     if (currentViews != subviews) {


### PR DESCRIPTION
Similar fix to: https://github.com/cashapp/redwood/pull/1237

Verified this issue doesn't exist for Compose UI.