### PR TITLE
Remove outdated `TODO`

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -102,7 +102,6 @@ internal open class UIViewLazyList() : LazyList<UIView>, ChangeListener {
     }
 
     override fun itemCount(): Int {
-      // TODO: replace with this with "ItemCounts"
       return max(itemsBefore - 1, 0) + viewPortList.count() + itemsAfter
     }
   }


### PR DESCRIPTION
There was a proposal to use https://github.com/cashapp/redwood/issues/1133#issuecomment-1561666108, but `ChangeListener` was opted for instead. The only benefit of `ItemCounts`/`ItemSnapshotList` was to batch change updates, therefore this comment is no longer relevant.

Closes #1253