### PR TITLE
Add automatic API tracking for schemas

### DIFF
--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaApiTasks.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaApiTasks.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.gradle
+
+import java.io.File
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+import org.gradle.process.ExecOperations
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+
+@CacheableTask
+internal abstract class RedwoodSchemaApiCheckTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+  @get:Classpath
+  abstract val toolClasspath: ConfigurableFileCollection
+
+  @get:Classpath
+  abstract val classpath: ConfigurableFileCollection
+
+  @get:Input
+  abstract val schemaType: Property<String>
+
+  @get:InputFiles
+  @get:PathSensitive(RELATIVE)
+  abstract val apiFile: RegularFileProperty
+
+  /**
+   * A dummy file inside the project's build directory which will be created as empty when this
+   * task runs. Gradle requires at least one output in order to skip a task as up-to-date if no
+   * inputs have changed.
+   */
+  @get:OutputFile
+  abstract val dummyOutputFile: RegularFileProperty
+
+  @TaskAction
+  fun run() {
+    dummyOutputFile.get().asFile.apply {
+      parentFile.mkdirs()
+      writeBytes(byteArrayOf())
+    }
+
+    val queue = workerExecutor.noIsolation()
+    queue.submit(RedwoodSchemaApiWorker::class.java) {
+      it.toolClasspath.from(toolClasspath)
+      it.classpath.setFrom(classpath)
+      it.schemaType.set(schemaType)
+      it.apiFile.set(apiFile)
+      it.mode.set("check")
+    }
+  }
+}
+
+@UntrackedTask(because = "it is explicitly run and not part of a lifecycle task")
+internal abstract class RedwoodSchemaApiGenerateTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+  @get:Internal // Despite being untracked, Gradle requires we annotate properties.
+  abstract val toolClasspath: ConfigurableFileCollection
+
+  @get:Internal // Despite being untracked, Gradle requires we annotate properties.
+  abstract val classpath: ConfigurableFileCollection
+
+  @get:Internal // Despite being untracked, Gradle requires we annotate properties.
+  abstract val schemaType: Property<String>
+
+  @get:Internal // Despite being untracked, Gradle requires we annotate properties.
+  abstract val apiFile: RegularFileProperty
+
+  @TaskAction
+  fun run() {
+    val queue = workerExecutor.noIsolation()
+    queue.submit(RedwoodSchemaApiWorker::class.java) {
+      it.toolClasspath.from(toolClasspath)
+      it.classpath.setFrom(classpath)
+      it.schemaType.set(schemaType)
+      it.apiFile.set(apiFile)
+      it.mode.set("generate")
+    }
+  }
+}
+
+private interface RedwoodSchemaApiParameters : WorkParameters {
+  val toolClasspath: ConfigurableFileCollection
+  val classpath: ConfigurableFileCollection
+  val schemaType: Property<String>
+  val mode: Property<String>
+  val apiFile: RegularFileProperty
+}
+
+private abstract class RedwoodSchemaApiWorker @Inject constructor(
+  private val execOperations: ExecOperations,
+) : WorkAction<RedwoodSchemaApiParameters> {
+  override fun execute() {
+    execOperations.javaexec { exec ->
+      exec.classpath = parameters.toolClasspath
+      exec.mainClass.set("app.cash.redwood.tooling.schema.Main")
+
+      exec.args = listOf(
+        "api",
+        "--mode",
+        parameters.mode.get(),
+        "--file",
+        parameters.apiFile.get().asFile.absolutePath,
+        "--fix-with",
+        RedwoodApiGenerateTaskName,
+        "--class-path",
+        parameters.classpath.files.joinToString(File.pathSeparator),
+        parameters.schemaType.get(),
+      )
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaExtension.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaExtension.kt
@@ -20,4 +20,10 @@ import org.gradle.api.provider.Property
 public abstract class RedwoodSchemaExtension {
   /** The fully-qualified name of the `@Schema`-annotated interface. */
   public abstract val type: Property<String>
+
+  /**
+   * Control whether an API file is generated for tracking schema compatibility.
+   * The default is true.
+   */
+  public abstract val apiTracking: Property<Boolean>
 }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaJsonTask.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodSchemaJsonTask.kt
@@ -32,7 +32,7 @@ import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
 
 @CacheableTask
-internal abstract class RedwoodSchemaTask @Inject constructor(
+internal abstract class RedwoodSchemaJsonTask @Inject constructor(
   private val workerExecutor: WorkerExecutor,
 ) : DefaultTask() {
   @get:Classpath
@@ -50,7 +50,7 @@ internal abstract class RedwoodSchemaTask @Inject constructor(
   @TaskAction
   fun run() {
     val queue = workerExecutor.noIsolation()
-    queue.submit(RedwoodSchemaWorker::class.java) {
+    queue.submit(RedwoodSchemaJsonWorker::class.java) {
       it.toolClasspath.from(toolClasspath)
       it.classpath.setFrom(classpath)
       it.schemaType.set(schemaType)
@@ -59,16 +59,16 @@ internal abstract class RedwoodSchemaTask @Inject constructor(
   }
 }
 
-private interface RedwoodSchemaParameters : WorkParameters {
+private interface RedwoodSchemaJsonParameters : WorkParameters {
   val toolClasspath: ConfigurableFileCollection
   val classpath: ConfigurableFileCollection
   val schemaType: Property<String>
   val outputDir: DirectoryProperty
 }
 
-private abstract class RedwoodSchemaWorker @Inject constructor(
+private abstract class RedwoodSchemaJsonWorker @Inject constructor(
   private val execOperations: ExecOperations,
-) : WorkAction<RedwoodSchemaParameters> {
+) : WorkAction<RedwoodSchemaJsonParameters> {
   override fun execute() {
     parameters.outputDir.get().asFile.deleteRecursively()
 

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-clean/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-clean/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
     classpath libs.androidGradlePlugin
     classpath libs.kotlin.gradlePlugin
-    classpath libs.kotlin.serializationPlugin
   }
 
   repositories {
@@ -15,25 +14,6 @@ buildscript {
     }
     mavenCentral()
     google()
-  }
-}
-
-allprojects {
-  repositories {
-    maven {
-      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
-    }
-    mavenCentral()
-    google()
-  }
-
-  tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
-  }
-
-  tasks.withType(KotlinJvmCompile).configureEach {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
   }
 }
 
@@ -46,7 +26,21 @@ dependencies {
 
 redwoodSchema {
   type = 'example.counter.Counter'
+}
 
-  // Test fixture. It does not need to be stable.
-  apiTracking = false
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+  targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.withType(KotlinJvmCompile).configureEach {
+  compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
 }

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-clean/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-clean/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.js.compiler=ir
+kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-clean/redwood-api.xml
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-clean/redwood-api.xml
@@ -1,0 +1,14 @@
+<schema version="1" type="example.counter.Counter">
+  <widget tag="1" type="example.counter.CounterBox">
+    <children tag="1" name="children"/>
+  </widget>
+  <widget tag="2" type="example.counter.CounterText">
+    <property tag="1" name="text" type="kotlin.String?"/>
+    <property tag="2" name="color" type="kotlin.String"/>
+  </widget>
+  <widget tag="3" type="example.counter.CounterButton">
+    <property tag="1" name="text" type="kotlin.String?"/>
+    <property tag="2" name="enabled" type="kotlin.Boolean"/>
+    <event tag="3" name="onClick"/>
+  </widget>
+</schema>

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-clean/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-clean/settings.gradle
@@ -1,0 +1,9 @@
+include ':'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-clean/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-clean/src/main/kotlin/example/counter/schema.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.counter
+
+import app.cash.redwood.schema.Children
+import app.cash.redwood.schema.Default
+import app.cash.redwood.schema.Property
+import app.cash.redwood.schema.Schema
+import app.cash.redwood.schema.Widget
+
+@Schema(
+  [
+    CounterBox::class,
+    CounterText::class,
+    CounterButton::class,
+  ],
+)
+interface Counter
+
+@Widget(1)
+data class CounterBox(
+  @Children(1) val children: () -> Unit,
+)
+
+@Widget(2)
+data class CounterText(
+  @Property(1) val text: String?,
+  @Property(2) @Default("\"black\"") val color: String,
+)
+
+@Widget(3)
+data class CounterButton(
+  @Property(1) val text: String?,
+  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(3) val onClick: () -> Unit,
+)

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/.gitignore
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/.gitignore
@@ -1,0 +1,1 @@
+redwood-api.xml

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
     classpath libs.androidGradlePlugin
     classpath libs.kotlin.gradlePlugin
-    classpath libs.kotlin.serializationPlugin
   }
 
   repositories {
@@ -15,25 +14,6 @@ buildscript {
     }
     mavenCentral()
     google()
-  }
-}
-
-allprojects {
-  repositories {
-    maven {
-      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
-    }
-    mavenCentral()
-    google()
-  }
-
-  tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
-  }
-
-  tasks.withType(KotlinJvmCompile).configureEach {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
   }
 }
 
@@ -46,7 +26,21 @@ dependencies {
 
 redwoodSchema {
   type = 'example.counter.Counter'
+}
 
-  // Test fixture. It does not need to be stable.
-  apiTracking = false
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+  targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.withType(KotlinJvmCompile).configureEach {
+  compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
 }

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.js.compiler=ir
+kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/redwood-api.xml.original
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/redwood-api.xml.original
@@ -1,0 +1,12 @@
+<schema version="1" type="example.counter.Counter">
+  <widget tag="1" type="example.counter.CounterBox">
+    <children tag="1" name="children"/>
+  </widget>
+  <widget tag="2" type="example.counter.CounterText">
+    <property tag="1" name="text" type="kotlin.String?"/>
+  </widget>
+  <widget tag="3" type="example.counter.CounterButton">
+    <property tag="1" name="text" type="kotlin.String?"/>
+    <event tag="3" name="onClick"/>
+  </widget>
+</schema>

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/settings.gradle
@@ -1,0 +1,9 @@
+include ':'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/src/main/kotlin/example/counter/schema.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.counter
+
+import app.cash.redwood.schema.Children
+import app.cash.redwood.schema.Default
+import app.cash.redwood.schema.Property
+import app.cash.redwood.schema.Schema
+import app.cash.redwood.schema.Widget
+
+@Schema(
+  [
+    CounterBox::class,
+    CounterText::class,
+    CounterButton::class,
+  ],
+)
+interface Counter
+
+@Widget(1)
+data class CounterBox(
+  @Children(1) val children: () -> Unit,
+)
+
+@Widget(2)
+data class CounterText(
+  @Property(1) val text: String?,
+  @Property(2) @Default("\"black\"") val color: String,
+)
+
+@Widget(3)
+data class CounterButton(
+  @Property(1) val text: String?,
+  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(3) val onClick: () -> Unit,
+)

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-missing/.gitignore
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-missing/.gitignore
@@ -1,0 +1,1 @@
+redwood-api.xml

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-missing/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-missing/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
     classpath libs.androidGradlePlugin
     classpath libs.kotlin.gradlePlugin
-    classpath libs.kotlin.serializationPlugin
   }
 
   repositories {
@@ -15,25 +14,6 @@ buildscript {
     }
     mavenCentral()
     google()
-  }
-}
-
-allprojects {
-  repositories {
-    maven {
-      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
-    }
-    mavenCentral()
-    google()
-  }
-
-  tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
-  }
-
-  tasks.withType(KotlinJvmCompile).configureEach {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
   }
 }
 
@@ -46,7 +26,21 @@ dependencies {
 
 redwoodSchema {
   type = 'example.counter.Counter'
+}
 
-  // Test fixture. It does not need to be stable.
-  apiTracking = false
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+  targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.withType(KotlinJvmCompile).configureEach {
+  compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
 }

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-missing/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-missing/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.js.compiler=ir
+kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-missing/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-missing/settings.gradle
@@ -1,0 +1,9 @@
+include ':'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-missing/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-missing/src/main/kotlin/example/counter/schema.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.counter
+
+import app.cash.redwood.schema.Children
+import app.cash.redwood.schema.Default
+import app.cash.redwood.schema.Property
+import app.cash.redwood.schema.Schema
+import app.cash.redwood.schema.Widget
+
+@Schema(
+  [
+    CounterBox::class,
+    CounterText::class,
+    CounterButton::class,
+  ],
+)
+interface Counter
+
+@Widget(1)
+data class CounterBox(
+  @Children(1) val children: () -> Unit,
+)
+
+@Widget(2)
+data class CounterText(
+  @Property(1) val text: String?,
+  @Property(2) @Default("\"black\"") val color: String,
+)
+
+@Widget(3)
+data class CounterButton(
+  @Property(1) val text: String?,
+  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(3) val onClick: () -> Unit,
+)

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/schema/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/schema/build.gradle
@@ -7,4 +7,7 @@ dependencies {
 
 redwoodSchema {
   type = 'example.counter.Counter'
+
+  // Test fixture. It does not need to be stable.
+  apiTracking = false
 }

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-reference/schema/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-reference/schema/build.gradle
@@ -7,4 +7,7 @@ dependencies {
 
 redwoodSchema {
   type = 'example.counter.Counter'
+
+  // Test fixture. It does not need to be stable.
+  apiTracking = false
 }

--- a/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
+++ b/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
@@ -18,22 +18,90 @@ package app.cash.redwood.gradle
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
+import assertk.assertions.prop
 import java.io.File
+import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.junit.Test
 
 class FixtureTest {
   @Test fun schemaProjectAccessor() {
     val fixtureDir = File("src/test/fixture/schema-project-accessor")
-    fixtureGradleRunner(fixtureDir, "assemble").build()
+    fixtureGradleRunner(fixtureDir, "clean", "assemble").build()
     assertThat(fixtureDir.resolve("widget/build/generated/redwood").walk().toList()).isNotEmpty()
   }
 
   @Test fun schemaProjectReference() {
     val fixtureDir = File("src/test/fixture/schema-project-reference")
-    fixtureGradleRunner(fixtureDir, "assemble").build()
+    fixtureGradleRunner(fixtureDir, "clean", "assemble").build()
     assertThat(fixtureDir.resolve("widget/build/generated/redwood").walk().toList()).isNotEmpty()
+  }
+
+  @Test fun schemaApiClean() {
+    val fixtureDir = File("src/test/fixture/schema-api-clean")
+    fixtureGradleRunner(fixtureDir, "clean", "check").build().let { result ->
+      val redwoodApiCheck = result.task(":redwoodApiCheck")!!
+      assertThat(redwoodApiCheck).prop(BuildTask::getOutcome).isEqualTo(SUCCESS)
+    }
+    // Ensure the task is properly incremental.
+    fixtureGradleRunner(fixtureDir, "redwoodApiCheck").build().let { result ->
+      val redwoodApiCheck = result.task(":redwoodApiCheck")!!
+      assertThat(redwoodApiCheck).prop(BuildTask::getOutcome).isEqualTo(UP_TO_DATE)
+    }
+  }
+
+  @Test fun schemaApiDirty() {
+    val fixtureDir = File("src/test/fixture/schema-api-dirty")
+
+    // Ensure we have the original dirty file as the test will overwrite it.
+    fixtureDir.resolve("redwood-api.xml.original")
+      .copyTo(fixtureDir.resolve("redwood-api.xml"), overwrite = true)
+
+    fixtureGradleRunner(fixtureDir, "clean", "check").buildAndFail().let { result ->
+      val redwoodApiCheck = result.task(":redwoodApiCheck")!!
+      assertThat(redwoodApiCheck).prop(BuildTask::getOutcome).isEqualTo(FAILED)
+      assertThat(result.output).contains(
+        """
+        |API file does not match!
+        |
+        |Differences:
+        | - Widget(tag=2) is missing property(tag=2) which is part of the Kotlin schema (fixable)
+        | - Widget(tag=3) is missing property(tag=2) which is part of the Kotlin schema (fixable)
+        |
+        |Run 'redwoodApiGenerate' to automatically update the file.
+        |
+        """.trimMargin(),
+      )
+    }
+    fixtureGradleRunner(fixtureDir, "redwoodApiGenerate").build()
+    fixtureGradleRunner(fixtureDir, "redwoodApiCheck").build()
+  }
+
+  @Test fun schemaApiMissing() {
+    val fixtureDir = File("src/test/fixture/schema-api-missing")
+
+    // Ensure we do not have this file. It may be left over from a previous run/failure.
+    fixtureDir.resolve("redwood-api.xml").delete()
+
+    fixtureGradleRunner(fixtureDir, "clean", "check").buildAndFail().let { result ->
+      val redwoodApiCheck = result.task(":redwoodApiCheck")!!
+      assertThat(redwoodApiCheck).prop(BuildTask::getOutcome).isEqualTo(FAILED)
+      assertThat(result.output).contains(
+        """
+        |API file redwood-api.xml missing!
+        |
+        |Run 'redwoodApiGenerate' to generate this file.
+        |
+        """.trimMargin(),
+      )
+    }
+    fixtureGradleRunner(fixtureDir, "redwoodApiGenerate").build()
+    fixtureGradleRunner(fixtureDir, "redwoodApiCheck").build()
   }
 
   @Test fun lintNoKotlinFails() {
@@ -113,14 +181,14 @@ class FixtureTest {
 
   private fun fixtureGradleRunner(
     fixtureDir: File,
-    task: String = "build",
+    vararg tasks: String = arrayOf("clean", "build"),
   ): GradleRunner {
     val gradleRoot = File(fixtureDir, "gradle").also { it.mkdir() }
     File("../gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
 
     return GradleRunner.create()
       .withProjectDir(fixtureDir)
-      .withArguments("clean", task, "--stacktrace", "-PredwoodVersion=$redwoodVersion")
+      .withArguments(*tasks, "--no-build-cache", "--stacktrace", "-PredwoodVersion=$redwoodVersion")
       .withDebug(true) // Do not use a daemon.
   }
 }

--- a/redwood-layout-schema/redwood-api.xml
+++ b/redwood-layout-schema/redwood-api.xml
@@ -1,0 +1,46 @@
+<schema version="1" type="app.cash.redwood.layout.RedwoodLayout">
+  <widget tag="1" type="app.cash.redwood.layout.Row">
+    <property tag="1" name="width" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="2" name="height" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="3" name="margin" type="app.cash.redwood.ui.Margin"/>
+    <property tag="4" name="overflow" type="app.cash.redwood.layout.api.Overflow"/>
+    <property tag="5" name="horizontalAlignment" type="app.cash.redwood.layout.api.MainAxisAlignment"/>
+    <property tag="6" name="verticalAlignment" type="app.cash.redwood.layout.api.CrossAxisAlignment"/>
+    <children tag="1" name="children"/>
+  </widget>
+  <widget tag="2" type="app.cash.redwood.layout.Column">
+    <property tag="1" name="width" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="2" name="height" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="3" name="margin" type="app.cash.redwood.ui.Margin"/>
+    <property tag="4" name="overflow" type="app.cash.redwood.layout.api.Overflow"/>
+    <property tag="5" name="horizontalAlignment" type="app.cash.redwood.layout.api.CrossAxisAlignment"/>
+    <property tag="6" name="verticalAlignment" type="app.cash.redwood.layout.api.MainAxisAlignment"/>
+    <children tag="1" name="children"/>
+  </widget>
+  <widget tag="3" type="app.cash.redwood.layout.Spacer">
+    <property tag="1" name="width" type="app.cash.redwood.ui.Dp"/>
+    <property tag="2" name="height" type="app.cash.redwood.ui.Dp"/>
+  </widget>
+  <modifier tag="1" type="app.cash.redwood.layout.Grow">
+    <property name="value" type="kotlin.Double"/>
+  </modifier>
+  <modifier tag="2" type="app.cash.redwood.layout.Shrink">
+    <property name="value" type="kotlin.Double"/>
+  </modifier>
+  <modifier tag="3" type="app.cash.redwood.layout.Margin">
+    <property name="margin" type="app.cash.redwood.ui.Margin"/>
+  </modifier>
+  <modifier tag="4" type="app.cash.redwood.layout.Alignment">
+    <property name="alignment" type="app.cash.redwood.layout.api.CrossAxisAlignment"/>
+  </modifier>
+  <modifier tag="6" type="app.cash.redwood.layout.Width">
+    <property name="width" type="app.cash.redwood.ui.Dp"/>
+  </modifier>
+  <modifier tag="7" type="app.cash.redwood.layout.Height">
+    <property name="height" type="app.cash.redwood.ui.Dp"/>
+  </modifier>
+  <modifier tag="8" type="app.cash.redwood.layout.Size">
+    <property name="height" type="app.cash.redwood.ui.Dp"/>
+    <property name="width" type="app.cash.redwood.ui.Dp"/>
+  </modifier>
+</schema>

--- a/redwood-lazylayout-schema/redwood-api.xml
+++ b/redwood-lazylayout-schema/redwood-api.xml
@@ -1,0 +1,28 @@
+<schema version="1" type="app.cash.redwood.lazylayout.RedwoodLazyLayout">
+  <widget tag="1" type="app.cash.redwood.lazylayout.LazyList">
+    <property tag="1" name="isVertical" type="kotlin.Boolean"/>
+    <property tag="3" name="itemsBefore" type="kotlin.Int"/>
+    <property tag="4" name="itemsAfter" type="kotlin.Int"/>
+    <property tag="5" name="width" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="6" name="height" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="7" name="margin" type="app.cash.redwood.ui.Margin"/>
+    <property tag="8" name="crossAxisAlignment" type="app.cash.redwood.layout.api.CrossAxisAlignment"/>
+    <event tag="2" name="onViewportChanged" params="kotlin.Int,kotlin.Int"/>
+    <children tag="1" name="placeholder"/>
+    <children tag="2" name="items"/>
+  </widget>
+  <widget tag="2" type="app.cash.redwood.lazylayout.RefreshableLazyList">
+    <property tag="1" name="isVertical" type="kotlin.Boolean"/>
+    <property tag="3" name="itemsBefore" type="kotlin.Int"/>
+    <property tag="4" name="itemsAfter" type="kotlin.Int"/>
+    <property tag="5" name="refreshing" type="kotlin.Boolean"/>
+    <property tag="7" name="width" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="8" name="height" type="app.cash.redwood.layout.api.Constraint"/>
+    <property tag="9" name="margin" type="app.cash.redwood.ui.Margin"/>
+    <property tag="10" name="crossAxisAlignment" type="app.cash.redwood.layout.api.CrossAxisAlignment"/>
+    <event tag="2" name="onViewportChanged" params="kotlin.Int,kotlin.Int"/>
+    <event tag="6" name="onRefresh" nullable="true"/>
+    <children tag="1" name="placeholder"/>
+    <children tag="2" name="items"/>
+  </widget>
+</schema>

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/GenerateCommand.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/GenerateCommand.kt
@@ -21,11 +21,12 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.arguments.help
-import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.options.switch
+import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.path
 import java.io.File
 import java.net.URLClassLoader
@@ -47,7 +48,8 @@ internal class GenerateCommand : CliktCommand(name = "generate") {
     .help("Directory into which generated files are written")
 
   private val classpath by option("-cp", "--class-path")
-    .convert { it.split(File.pathSeparator).map(::File) }
+    .file()
+    .split(File.pathSeparator)
     .required()
 
   private val schemaType by argument("schema")

--- a/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/LintCommand.kt
+++ b/redwood-tooling-lint/src/main/kotlin/app/cash/redwood/tooling/lint/LintCommand.kt
@@ -42,10 +42,10 @@ import com.android.tools.lint.helpers.DefaultUastParser
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.arguments.argument
-import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.types.file
 import com.intellij.pom.java.LanguageLevel
 import com.intellij.pom.java.LanguageLevel.JDK_1_7
@@ -63,7 +63,8 @@ internal class LintCommand : CliktCommand(name = "check") {
     .file()
     .multiple(required = true)
   private val classpath by option("-cp", "--class-path")
-    .convert { it.split(File.pathSeparator).map(::File) }
+    .file()
+    .split(File.pathSeparator)
     .default(emptyList())
 
   override fun run() {

--- a/redwood-tooling-schema/build.gradle
+++ b/redwood-tooling-schema/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   api projects.redwoodSchema
   api libs.kotlin.reflect
   implementation libs.kotlinx.serialization.json
+  implementation libs.xmlutil.serialization
   implementation libs.kotlin.compilerEmbeddable
   implementation libs.clikt
 
@@ -20,6 +21,7 @@ dependencies {
   testImplementation libs.junit
   testImplementation libs.assertk
   testImplementation libs.testParameterInjector
+  testImplementation libs.jimfs
 }
 
 // In order to simplify writing test schemas, inject the test sources and

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/apiModel.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/apiModel.kt
@@ -1,0 +1,352 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.tooling.schema
+
+import app.cash.redwood.tooling.schema.ApiSchema.Difference.Type.Fatal
+import app.cash.redwood.tooling.schema.ApiSchema.Difference.Type.Fixable
+import app.cash.redwood.tooling.schema.ApiSchema.Difference.Type.Warning
+import app.cash.redwood.tooling.schema.ProtocolWidget.ProtocolChildren
+import app.cash.redwood.tooling.schema.ProtocolWidget.ProtocolEvent
+import app.cash.redwood.tooling.schema.ProtocolWidget.ProtocolProperty
+import app.cash.redwood.tooling.schema.ValidationMode.Check
+import app.cash.redwood.tooling.schema.ValidationMode.Generate
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode.ALWAYS
+import kotlinx.serialization.EncodeDefault.Mode.NEVER
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XML
+
+internal enum class ValidationMode {
+  Check,
+  Generate,
+}
+
+internal sealed interface ValidationResult {
+  object Success : ValidationResult
+  data class Failure(val message: String) : ValidationResult
+}
+
+@Serializable
+@SerialName("schema")
+internal data class ApiSchema(
+  /** The format version of this XML. */
+  @OptIn(ExperimentalSerializationApi::class) // Easier than second constructor setting fixed value.
+  @EncodeDefault(ALWAYS)
+  val version: UInt = 1U,
+  val type: String,
+  val widgets: List<ApiWidget> = emptyList(),
+  val modifiers: List<ApiModifier> = emptyList(),
+) {
+  init {
+    require(version == 1U) {
+      "Only version 1 is supported"
+    }
+  }
+
+  constructor(schema: ProtocolSchema) : this(
+    type = schema.type.toString(),
+    widgets = schema.widgets.map(::ApiWidget).sortedBy(ApiWidget::tag),
+    modifiers = schema.modifiers.map(::ApiModifier).sortedBy(ApiModifier::tag),
+  )
+
+  fun validateAgainst(file: Path, mode: ValidationMode, fixCommand: String): ValidationResult {
+    val fileApi = if (file.exists()) {
+      xml.decodeFromString(serializer(), file.readText())
+    } else {
+      null
+    }
+
+    fun failure(differences: List<Difference>, message: String) = ValidationResult.Failure(
+      buildString {
+        appendLine(message)
+        appendLine()
+        appendLine("Differences:")
+        for (difference in differences) {
+          append(" - ")
+          append(difference.message)
+          append(" (")
+          append(difference.type.name.lowercase())
+          appendLine(')')
+        }
+        appendLine()
+        append(
+          if (differences.any { it.type == Fatal }) {
+            """
+            The API file cannot be updated automatically due to the presence of fatal
+            differences. Either revert the fatal differences to the schema, or delete the
+            file and run '$fixCommand' to regenerate. Note that regenerating the file
+            means the new schema is fundamentally incompatible with the old one and will
+            produce errors if both the host and guest code are not updated together.
+            """.trimIndent()
+          } else {
+            "Run '$fixCommand' to automatically update the file."
+          },
+        )
+      },
+    )
+
+    when (mode) {
+      Check -> {
+        if (fileApi == null) {
+          val relativePath = file.fileSystem.getPath("").toAbsolutePath().relativize(file)
+          return ValidationResult.Failure(
+            """
+            |API file $relativePath missing!
+            |
+            |Run '$fixCommand' to generate this file.
+            """.trimMargin(),
+          )
+        }
+        val differences = diffFrom(fileApi)
+        if (differences.isNotEmpty()) {
+          return failure(differences, "API file does not match!")
+        }
+      }
+      Generate -> {
+        if (fileApi != null) {
+          val differences = diffFrom(fileApi).filter { it.type == Fatal }
+          if (differences.isNotEmpty()) {
+            return failure(differences, "Schema contains incompatible changes with current API!")
+          }
+        }
+        file.writeText(xml.encodeToString(serializer(), this) + "\n")
+      }
+    }
+    return ValidationResult.Success
+  }
+
+  private data class Difference(
+    val message: String,
+    val type: Type,
+  ) {
+    enum class Type { Fatal, Fixable, Warning }
+  }
+
+  private fun diffFrom(file: ApiSchema): List<Difference> {
+    val diffs = mutableListOf<Difference>()
+
+    if (type != file.type) {
+      diffs += Difference("Schema type changed from ${file.type} to $type", Warning)
+    }
+
+    val (matchedWidgets, missingWidgets, extraWidgets) = widgets.diffFrom(file.widgets) { it.tag }
+    for (widget in missingWidgets) {
+      diffs += Difference("Widget(tag=${widget.tag}) is missing from the file, but it is a part of the Kotlin schema", Fixable)
+    }
+    for (widget in extraWidgets) {
+      diffs += Difference("Widget(tag=${widget.tag}) is tracked in the file, but it is not part of the Kotlin schema", Fatal)
+    }
+    for ((widget, fileWidget) in matchedWidgets) {
+      if (widget.type != fileWidget.type) {
+        diffs += Difference("Widget(tag=${widget.tag}) type changed from ${fileWidget.type} to ${widget.type} in the Kotlin schema", Warning)
+      }
+      val (matchedTraits, missingTraits, extraTraits) = widget.traits.diffFrom(fileWidget.traits) { it.tag to it.javaClass }
+      fun ApiWidgetTrait.humanType() = when (this) {
+        is ApiWidgetChildren -> "children"
+        is ApiWidgetEvent -> "event"
+        is ApiWidgetProperty -> "property"
+      }
+      for (trait in missingTraits) {
+        diffs += Difference("Widget(tag=${widget.tag}) is missing ${trait.humanType()}(tag=${trait.tag}) which is part of the Kotlin schema", Fixable)
+      }
+      for (trait in extraTraits) {
+        diffs += Difference("Widget(tag=${widget.tag}) contains unknown ${trait.humanType()}(tag=${trait.tag}) which is not part of the Kotlin schema", Fatal)
+      }
+      for ((trait, fileTrait) in matchedTraits) {
+        if (trait.name != fileTrait.name) {
+          diffs += Difference("Widget(tag=${widget.tag}) ${trait.humanType()}(tag=${trait.tag}) name changed from ${fileTrait.name} to ${trait.name}", Fixable)
+        }
+        when (trait) {
+          is ApiWidgetChildren -> Unit // Nothing else to verify for this type.
+          is ApiWidgetEvent -> {
+            val fileEvent = fileTrait as ApiWidgetEvent
+            if (trait.params != fileEvent.params) {
+              diffs += Difference("Widget(tag=${widget.tag}) event(tag=${trait.tag}) type changed from ${fileEvent.params} to ${trait.params}", Fatal)
+            }
+            if (trait.nullable != fileEvent.nullable) {
+              val type = if (trait.nullable) Fatal else Fixable
+              diffs += Difference("Widget(tag=${widget.tag}) event(tag=${trait.tag}) nullability changed from ${fileEvent.nullable} to ${trait.nullable}", type)
+            }
+          }
+          is ApiWidgetProperty -> {
+            val fileProperty = fileTrait as ApiWidgetProperty
+            if (trait.type != fileProperty.type) {
+              diffs += Difference("Widget(tag=${widget.tag}) property(tag=${trait.tag}) type changed from ${fileProperty.type} to ${trait.type}", Fatal)
+            }
+          }
+        }
+      }
+    }
+
+    val (matchedModifiers, missingModifiers, extraModifiers) = modifiers.diffFrom(file.modifiers) { it.tag }
+    for (modifier in missingModifiers) {
+      diffs += Difference("Modifier(tag=${modifier.tag}) is missing from the file, but it is part of the Kotlin schema", Fixable)
+    }
+    for (modifier in extraModifiers) {
+      diffs += Difference("Modifier(tag=${modifier.tag}) is tracked in the file, but is not part of the Kotlin schema", Fatal)
+    }
+    for ((modifier, fileWidget) in matchedModifiers) {
+      val (matchedProperties, missingProperties, extraProperties) = modifier.properties.diffFrom(fileWidget.properties) { it.name }
+      for (property in missingProperties) {
+        diffs += Difference("Modifier(tag=${modifier.tag}) is missing property(name=${property.name}) which is part of the Kotlin schema", Fixable)
+      }
+      for (property in extraProperties) {
+        diffs += Difference("Modifier(tag=${modifier.tag}) contains unknown property(name=${property.name}) which is not part of the Kotlin schema", Fatal)
+      }
+      for ((property, oldProperty) in matchedProperties) {
+        if (property.type != oldProperty.type) {
+          diffs += Difference("Modifier(tag=${modifier.tag}) property(name=${property.name}) type changed from ${oldProperty.type} to ${property.type} in the Kotlin schema", Fatal)
+        }
+      }
+    }
+
+    return diffs
+  }
+
+  companion object {
+    private val xml = XML {
+      indent = 2
+      autoPolymorphic = true
+    }
+
+    /**
+     * Compute the difference between [this] and [previous] collections by [key].
+     * Returns a triple of matching pairs, added items, and removed items.
+     */
+    private fun <T, K> Collection<T>.diffFrom(
+      previous: Collection<T>,
+      key: (T) -> K,
+    ): Triple<List<Pair<T, T>>, List<T>, List<T>> {
+      val currentsByTag = associateBy(key)
+      val previousByTag = previous.associateBy(key)
+
+      val matched = mapNotNull { item -> previousByTag[key(item)]?.let { item to it } }
+      val added = filter { key(it) !in previousByTag }
+      val removed = previous.filter { key(it) !in currentsByTag }
+
+      return Triple(matched, added, removed)
+    }
+  }
+}
+
+@Serializable
+@SerialName("widget")
+internal data class ApiWidget(
+  val tag: Int,
+  val type: String,
+  val traits: List<ApiWidgetTrait> = emptyList(),
+) {
+  constructor(widget: ProtocolWidget) : this(
+    type = widget.type.toString(),
+    tag = widget.tag,
+    traits = widget.traits
+      .map {
+        when (it) {
+          is ProtocolEvent -> ApiWidgetEvent(it)
+          is ProtocolProperty -> ApiWidgetProperty(it)
+          is ProtocolChildren -> ApiWidgetChildren(it)
+        }
+      }
+      .sortedWith(ApiWidgetTrait.comparator),
+  )
+}
+
+@Serializable
+internal sealed interface ApiWidgetTrait {
+  val tag: Int
+  val name: String
+
+  companion object {
+    val comparator = compareByDescending<ApiWidgetTrait> { it.javaClass.name }.thenBy { it.tag }
+  }
+}
+
+@Serializable
+@SerialName("property")
+internal data class ApiWidgetProperty(
+  override val tag: Int,
+  override val name: String,
+  val type: String,
+) : ApiWidgetTrait {
+  constructor(property: ProtocolProperty) : this(
+    tag = property.tag,
+    name = property.name,
+    type = property.type.toString(),
+  )
+}
+
+@Serializable
+@SerialName("event")
+@OptIn(ExperimentalSerializationApi::class) // Easier than second constructor setting fixed value.
+internal data class ApiWidgetEvent(
+  override val tag: Int,
+  override val name: String,
+  @EncodeDefault(NEVER)
+  val params: String = "",
+  @EncodeDefault(NEVER)
+  val nullable: Boolean = false,
+) : ApiWidgetTrait {
+  constructor(event: ProtocolEvent) : this(
+    tag = event.tag,
+    name = event.name,
+    params = event.parameterTypes.joinToString(","),
+    nullable = event.isNullable,
+  )
+}
+
+@Serializable
+@SerialName("children")
+internal data class ApiWidgetChildren(
+  override val tag: Int,
+  override val name: String,
+) : ApiWidgetTrait {
+  constructor(children: ProtocolChildren) : this(
+    tag = children.tag,
+    name = children.name,
+  )
+}
+
+@Serializable
+@SerialName("modifier")
+internal data class ApiModifier(
+  val tag: Int,
+  val type: String,
+  val properties: List<ApiModifierProperty> = emptyList(),
+) {
+  constructor(modifier: ProtocolModifier) : this(
+    tag = modifier.tag,
+    type = modifier.type.toString(),
+    properties = modifier.properties.map(::ApiModifierProperty).sortedBy(ApiModifierProperty::name),
+  )
+}
+
+@Serializable
+@SerialName("property")
+internal data class ApiModifierProperty(
+  val name: String,
+  val type: String,
+) {
+  constructor(property: Modifier.Property) : this(
+    name = property.name,
+    type = property.type.toString(),
+  )
+}

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/main.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/main.kt
@@ -23,6 +23,7 @@ import com.github.ajalt.clikt.core.subcommands
 public fun main(vararg args: String) {
   NoOpCliktCommand()
     .subcommands(
+      ApiCommand(),
       JsonCommand(),
     )
     .main(args)

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/ApiTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/ApiTest.kt
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.tooling.schema
+
+import app.cash.redwood.tooling.schema.ValidationMode.Check
+import app.cash.redwood.tooling.schema.ValidationMode.Generate
+import app.cash.redwood.tooling.schema.ValidationResult.Failure
+import assertk.Assert
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import com.google.common.jimfs.Configuration.unix
+import com.google.common.jimfs.Jimfs
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import org.junit.Test
+
+class ApiTest {
+  private val fsRoot = Jimfs.newFileSystem(unix()).rootDirectories.single()
+
+  // JimFs working directory is work/ so let's pretend that's our project directory.
+  private val apiFile = fsRoot.resolve("work/api.xml")
+
+  @Test fun checkNoFile() {
+    val api = ApiSchema(type = "com.example.Schema")
+    val result = api.validateAgainst(apiFile, Check, "COMMAND")
+    assertThat(result).isFailureWithMessage(
+      """
+      |API file api.xml missing!
+      |
+      |Run 'COMMAND' to generate this file.
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun checkFileUpToDate() {
+    apiFile.writeText(
+      """
+      |<schema version="1" type="com.example.TestSchema">
+      |  <widget tag="1" type="com.example.Widget">
+      |    <property tag="1" name="first" type="kotlin.String"/>
+      |    <property tag="2" name="second" type="kotlin.Double"/>
+      |    <event tag="3" name="event" params="kotlin.String"/>
+      |    <event tag="4" name="none"/>
+      |    <event tag="5" name="eventOpt" params="kotlin.String" nullable="true"/>
+      |    <event tag="6" name="noneOpt" nullable="true"/>
+      |    <children tag="1" name="left"/>
+      |    <children tag="2" name="right"/>
+      |  </widget>
+      |  <modifier tag="1" type="com.example.Modifier">
+      |    <property name="first" type="kotlin.String"/>
+      |    <property name="second" type="kotlin.Double"/>
+      |  </modifier>
+      |</schema>
+      |
+      """.trimMargin(),
+    )
+    val api = ApiSchema(
+      type = "com.example.TestSchema",
+      widgets = listOf(
+        ApiWidget(
+          tag = 1,
+          type = "com.example.Widget",
+          traits = listOf(
+            ApiWidgetProperty(tag = 1, "first", "kotlin.String"),
+            ApiWidgetProperty(tag = 2, "second", "kotlin.Double"),
+            ApiWidgetEvent(tag = 3, "event", "kotlin.String", nullable = false),
+            ApiWidgetEvent(tag = 4, "none", nullable = false),
+            ApiWidgetEvent(tag = 5, "eventOpt", "kotlin.String", nullable = true),
+            ApiWidgetEvent(tag = 6, "noneOpt", params = "", nullable = true),
+            ApiWidgetChildren(tag = 1, "left"),
+            ApiWidgetChildren(tag = 2, "right"),
+          ),
+        ),
+      ),
+      modifiers = listOf(
+        ApiModifier(
+          tag = 1,
+          type = "com.example.Modifier",
+          properties = listOf(
+            ApiModifierProperty("first", "kotlin.String"),
+            ApiModifierProperty("second", "kotlin.Double"),
+          ),
+        ),
+      ),
+    )
+    val result = api.validateAgainst(apiFile, Check, "UNUSED")
+    assertThat(result).isSuccess()
+  }
+
+  @Test fun checkFileOutOfDateNonFatal() {
+    apiFile.writeText(
+      """
+      |<schema version="1" type="com.example.TestSchema">
+      |  <widget tag="1" type="com.example.Widget">
+      |    <property tag="1" name="first" type="kotlin.String"/>
+      |    <property tag="2" name="second" type="kotlin.Double"/>
+      |    <event tag="4" name="event" params="kotlin.String"/>
+      |    <event tag="5" name="nullableChange" nullable="true"/>
+      |    <children tag="1" name="left"/>
+      |    <children tag="2" name="right"/>
+      |  </widget>
+      |  <modifier tag="1" type="com.example.Modifier">
+      |    <property name="first" type="kotlin.String"/>
+      |    <property name="second" type="kotlin.Double"/>
+      |  </modifier>
+      |</schema>
+      |
+      """.trimMargin(),
+    )
+    val api = ApiSchema(
+      type = "com.example.TestSchemaTypeChange",
+      widgets = listOf(
+        ApiWidget(
+          tag = 1,
+          type = "com.example.WidgetTypeChange",
+          traits = listOf(
+            ApiWidgetProperty(tag = 1, "firstNameChange", "kotlin.String"),
+            ApiWidgetProperty(tag = 2, "second", "kotlin.Double"),
+            ApiWidgetProperty(tag = 3, "missingFromFile", "kotlin.Long"),
+            ApiWidgetEvent(tag = 4, "eventNameChange", "kotlin.String"),
+            ApiWidgetEvent(tag = 5, "nullableChange"),
+            ApiWidgetEvent(tag = 6, "missingFromFile"),
+            ApiWidgetChildren(tag = 1, "leftNameChange"),
+            ApiWidgetChildren(tag = 2, "right"),
+            ApiWidgetChildren(tag = 3, "missingFromFile"),
+          ),
+        ),
+        ApiWidget(
+          tag = 2,
+          type = "com.example.WidgetMissingFromFile",
+        ),
+      ),
+      modifiers = listOf(
+        ApiModifier(
+          tag = 1,
+          type = "com.example.ModifierTypeChange",
+          properties = listOf(
+            ApiModifierProperty("first", "kotlin.String"),
+            ApiModifierProperty("second", "kotlin.Double"),
+          ),
+        ),
+        ApiModifier(
+          tag = 2,
+          type = "com.example.ModifierMissingFromFile",
+        ),
+      ),
+    )
+    val result = api.validateAgainst(apiFile, Check, "COMMAND")
+    assertThat(result).isFailureWithMessage(
+      """
+      |API file does not match!
+      |
+      |Differences:
+      | - Schema type changed from com.example.TestSchema to com.example.TestSchemaTypeChange (warning)
+      | - Widget(tag=2) is missing from the file, but it is a part of the Kotlin schema (fixable)
+      | - Widget(tag=1) type changed from com.example.Widget to com.example.WidgetTypeChange in the Kotlin schema (warning)
+      | - Widget(tag=1) is missing property(tag=3) which is part of the Kotlin schema (fixable)
+      | - Widget(tag=1) is missing event(tag=6) which is part of the Kotlin schema (fixable)
+      | - Widget(tag=1) is missing children(tag=3) which is part of the Kotlin schema (fixable)
+      | - Widget(tag=1) property(tag=1) name changed from first to firstNameChange (fixable)
+      | - Widget(tag=1) event(tag=4) name changed from event to eventNameChange (fixable)
+      | - Widget(tag=1) event(tag=5) nullability changed from true to false (fixable)
+      | - Widget(tag=1) children(tag=1) name changed from left to leftNameChange (fixable)
+      | - Modifier(tag=2) is missing from the file, but it is part of the Kotlin schema (fixable)
+      |
+      |Run 'COMMAND' to automatically update the file.
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun checkFileOutOfDateFatal() {
+    apiFile.writeText(
+      """
+      |<schema version="1" type="com.example.TestSchema">
+      |  <widget tag="1" type="com.example.Widget">
+      |    <property tag="1" name="typeChange" type="kotlin.String"/>
+      |    <property tag="2" name="extraInFile" type="kotlin.Int"/>
+      |    <event tag="3" name="paramChange" params="kotlin.String"/>
+      |    <event tag="4" name="nullableChange"/>
+      |    <event tag="5" name="extraInFile" nullable="true"/>
+      |    <children tag="1" name="extraInFile"/>
+      |  </widget>
+      |  <widget tag="2" type="com.example.WidgetExtraInFile"/>
+      |  <modifier tag="1" type="com.example.Modifier">
+      |    <property name="first" type="kotlin.String"/>
+      |    <property name="extraInFile" type="kotlin.String"/>
+      |  </modifier>
+      |  <modifier tag="2" type="com.example.ModifierExtraInFile"/>
+      |</schema>
+      |
+      """.trimMargin(),
+    )
+    val api = ApiSchema(
+      type = "com.example.TestSchema",
+      widgets = listOf(
+        ApiWidget(
+          tag = 1,
+          type = "com.example.Widget",
+          traits = listOf(
+            ApiWidgetProperty(tag = 1, "typeChange", "kotlin.Double"),
+            ApiWidgetEvent(tag = 3, "paramChange", "kotlin.Double"),
+            ApiWidgetEvent(tag = 4, "nullableChange", nullable = true),
+          ),
+        ),
+      ),
+      modifiers = listOf(
+        ApiModifier(
+          tag = 1,
+          type = "com.example.ModifierTypeChange",
+          properties = listOf(
+            ApiModifierProperty("first", "kotlin.StringTypeChange"),
+          ),
+        ),
+      ),
+    )
+    val result = api.validateAgainst(apiFile, Check, "COMMAND")
+    assertThat(result).isFailureWithMessage(
+      """
+      |API file does not match!
+      |
+      |Differences:
+      | - Widget(tag=2) is tracked in the file, but it is not part of the Kotlin schema (fatal)
+      | - Widget(tag=1) contains unknown property(tag=2) which is not part of the Kotlin schema (fatal)
+      | - Widget(tag=1) contains unknown event(tag=5) which is not part of the Kotlin schema (fatal)
+      | - Widget(tag=1) contains unknown children(tag=1) which is not part of the Kotlin schema (fatal)
+      | - Widget(tag=1) property(tag=1) type changed from kotlin.String to kotlin.Double (fatal)
+      | - Widget(tag=1) event(tag=3) type changed from kotlin.String to kotlin.Double (fatal)
+      | - Widget(tag=1) event(tag=4) nullability changed from false to true (fatal)
+      | - Modifier(tag=2) is tracked in the file, but is not part of the Kotlin schema (fatal)
+      | - Modifier(tag=1) contains unknown property(name=extraInFile) which is not part of the Kotlin schema (fatal)
+      | - Modifier(tag=1) property(name=first) type changed from kotlin.String to kotlin.StringTypeChange in the Kotlin schema (fatal)
+      |
+      |The API file cannot be updated automatically due to the presence of fatal
+      |differences. Either revert the fatal differences to the schema, or delete the
+      |file and run 'COMMAND' to regenerate. Note that regenerating the file
+      |means the new schema is fundamentally incompatible with the old one and will
+      |produce errors if both the host and guest code are not updated together.
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun generateNoFile() {
+    assertThat(apiFile).prop("exists", Path::exists).isFalse()
+    val api = ApiSchema(type = "com.example.Schema")
+    val result = api.validateAgainst(apiFile, Generate, "UNUSED")
+    assertThat(result).isSuccess()
+    assertThat(apiFile.readText()).isEqualTo(
+      """
+      |<schema version="1" type="com.example.Schema"/>
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun generateFileUpToDate() {
+    apiFile.writeText(
+      """
+      |<schema version="1" type="com.example.Schema"/>
+      |
+      """.trimMargin(),
+    )
+    val api = ApiSchema(type = "com.example.Schema")
+    val result = api.validateAgainst(apiFile, Generate, "UNUSED")
+    assertThat(result).isSuccess()
+    assertThat(apiFile.readText()).isEqualTo(
+      """
+      |<schema version="1" type="com.example.Schema"/>
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun generateFileOutOfDateWarning() {
+    apiFile.writeText(
+      """
+      |<schema version="1" type="com.example.Schema"/>
+      |
+      """.trimMargin(),
+    )
+    val api = ApiSchema(type = "com.example.SchemaNew")
+    val result = api.validateAgainst(apiFile, Generate, "UNUSED")
+    assertThat(result).isSuccess()
+    assertThat(apiFile.readText()).isEqualTo(
+      """
+      |<schema version="1" type="com.example.SchemaNew"/>
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun generateFileOutOfDateFixable() {
+    apiFile.writeText(
+      """
+      |<schema version="1" type="com.example.Schema"/>
+      |
+      """.trimMargin(),
+    )
+    val api = ApiSchema(
+      type = "com.example.Schema",
+      widgets = listOf(
+        ApiWidget(tag = 1, type = "com.example.Widget"),
+      ),
+    )
+    val result = api.validateAgainst(apiFile, Generate, "UNUSED")
+    assertThat(result).isSuccess()
+    assertThat(apiFile.readText()).isEqualTo(
+      """
+      |<schema version="1" type="com.example.Schema">
+      |  <widget tag="1" type="com.example.Widget"/>
+      |</schema>
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun generateFileOutOfDateFatal() {
+    val xml = """
+      |<schema version="1" type="com.example.Schema">
+      |  <widget tag="1" type="com.example.Widget"/>
+      |</schema>
+      |
+    """.trimMargin()
+
+    apiFile.writeText(xml)
+    val api = ApiSchema(
+      type = "com.example.Schema",
+      widgets = listOf(
+        // The presence of this widget will produce a fixable difference.
+        ApiWidget(tag = 2, type = "com.example.OtherWidget"),
+      ),
+    )
+    val result = api.validateAgainst(apiFile, Generate, "COMMAND")
+
+    // Ensure only the fatal problems are reported as problematic when trying to generate.
+    assertThat(result).isFailureWithMessage(
+      """
+      |Schema contains incompatible changes with current API!
+      |
+      |Differences:
+      | - Widget(tag=1) is tracked in the file, but it is not part of the Kotlin schema (fatal)
+      |
+      |The API file cannot be updated automatically due to the presence of fatal
+      |differences. Either revert the fatal differences to the schema, or delete the
+      |file and run 'COMMAND' to regenerate. Note that regenerating the file
+      |means the new schema is fundamentally incompatible with the old one and will
+      |produce errors if both the host and guest code are not updated together.
+      """.trimMargin(),
+    )
+    // Ensure the file was not changed in any way.
+    assertThat(apiFile.readText()).isEqualTo(xml)
+  }
+
+  private fun Assert<ValidationResult>.isFailureWithMessage(message: String) {
+    isInstanceOf<Failure>().prop(Failure::message).isEqualTo(message)
+  }
+  private fun Assert<ValidationResult>.isSuccess() {
+    isEqualTo(ValidationResult.Success)
+  }
+}

--- a/samples/counter/schema/redwood-api.xml
+++ b/samples/counter/schema/redwood-api.xml
@@ -1,0 +1,10 @@
+<schema version="1" type="com.example.redwood.counter.Schema">
+  <widget tag="2" type="com.example.redwood.counter.Text">
+    <property tag="1" name="text" type="kotlin.String?"/>
+  </widget>
+  <widget tag="3" type="com.example.redwood.counter.Button">
+    <property tag="1" name="text" type="kotlin.String?"/>
+    <property tag="2" name="enabled" type="kotlin.Boolean"/>
+    <event tag="3" name="onClick" nullable="true"/>
+  </widget>
+</schema>

--- a/samples/emoji-search/schema/redwood-api.xml
+++ b/samples/emoji-search/schema/redwood-api.xml
@@ -1,0 +1,14 @@
+<schema version="1" type="com.example.redwood.emojisearch.EmojiSearch">
+  <widget tag="1" type="com.example.redwood.emojisearch.TextInput">
+    <property tag="1" name="state" type="example.values.TextFieldState"/>
+    <property tag="2" name="hint" type="kotlin.String"/>
+    <event tag="3" name="onChange" params="example.values.TextFieldState" nullable="true"/>
+  </widget>
+  <widget tag="2" type="com.example.redwood.emojisearch.Text">
+    <property tag="1" name="text" type="kotlin.String"/>
+  </widget>
+  <widget tag="3" type="com.example.redwood.emojisearch.Image">
+    <property tag="1" name="url" type="kotlin.String"/>
+    <event tag="2" name="onClick" nullable="true"/>
+  </widget>
+</schema>

--- a/samples/repo-search/schema/redwood-api.xml
+++ b/samples/repo-search/schema/redwood-api.xml
@@ -1,0 +1,5 @@
+<schema version="1" type="com.example.redwood.reposearch.RepoSearch">
+  <widget tag="1" type="com.example.redwood.reposearch.Text">
+    <property tag="1" name="text" type="kotlin.String"/>
+  </widget>
+</schema>

--- a/test-schema/build.gradle
+++ b/test-schema/build.gradle
@@ -7,4 +7,7 @@ dependencies {
 
 redwoodSchema {
   type = 'example.redwood.ExampleSchema'
+
+  // Private, test-only module. It does not need to be stable.
+  apiTracking = false
 }


### PR DESCRIPTION
This adds a `redwoodApiCheck` task tied to the `check` lifecycle task, and a `redwoodApiGenerate` for updating the file.

Refs #37 