### PR TITLE
Add screenshot tests for varying `AlignItems` value within `Column`

### DIFF
--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsCenter[LTR].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsCenter[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsCenter[RTL].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsCenter[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05398a992a058d0eb53ebd82598d5d357e93d1209f1191cf1163c318c9b1ab5c
+size 56509

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexEnd[LTR].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexEnd[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexEnd[RTL].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexEnd[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c2a07542154cfc9d36995407a78591c258f68f60883006ed94d64c1b239480c
+size 55210

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexStart[LTR].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexStart[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexStart[RTL].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsFlexStart[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612880870579de43e0065500aa3d9d733f56ffbd3eac8c19bef1db9e7bc996c9
+size 55492

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsStretch[LTR].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsStretch[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f80cce4e0ddaba73364be1f77dbac26573785c44c83fda2bd2c3256b42528ee
+size 53996

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsStretch[RTL].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithAlignItemsStretch[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b022cdf75398deafd899c82d1b1448e1080be4a6a20f38d568f8906d34af435
+size 54083

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -96,6 +96,50 @@ abstract class AbstractFlexContainerTest<T : Any> {
     verifySnapshot(container)
   }
 
+  @Test fun columnWithAlignItemsFlexStart() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.alignItems(AlignItems.FlexStart)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container)
+  }
+
+  @Test fun columnWithAlignItemsFlexEnd() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.alignItems(AlignItems.FlexEnd)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container)
+  }
+
+  @Test fun columnWithAlignItemsCenter() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.alignItems(AlignItems.Center)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container)
+  }
+
+  @Test fun columnWithAlignItemsStretch() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.alignItems(AlignItems.Stretch)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container)
+  }
+
   @Test fun columnWithJustifyContentCenter() {
     val container = flexContainer(FlexDirection.Column)
     container.width(Constraint.Fill)

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsCenter[LTR].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsCenter[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsCenter[RTL].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsCenter[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexEnd[LTR].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexEnd[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexEnd[RTL].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexEnd[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexStart[LTR].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexStart[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexStart[RTL].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsFlexStart[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsStretch[LTR].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsStretch[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f80cce4e0ddaba73364be1f77dbac26573785c44c83fda2bd2c3256b42528ee
+size 53996

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsStretch[RTL].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithAlignItemsStretch[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f80cce4e0ddaba73364be1f77dbac26573785c44c83fda2bd2c3256b42528ee
+size 53996

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsCenter[LTR].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsCenter[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsCenter[RTL].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsCenter[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612880870579de43e0065500aa3d9d733f56ffbd3eac8c19bef1db9e7bc996c9
+size 55492

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexEnd[LTR].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexEnd[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexEnd[RTL].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexEnd[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612880870579de43e0065500aa3d9d733f56ffbd3eac8c19bef1db9e7bc996c9
+size 55492

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexStart[LTR].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexStart[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexStart[RTL].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsFlexStart[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612880870579de43e0065500aa3d9d733f56ffbd3eac8c19bef1db9e7bc996c9
+size 55492

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsStretch[LTR].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsStretch[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsStretch[RTL].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithAlignItemsStretch[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612880870579de43e0065500aa3d9d733f56ffbd3eac8c19bef1db9e7bc996c9
+size 55492

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsCenter[LTR].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsCenter[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsCenter[RTL].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsCenter[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexEnd[LTR].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexEnd[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexEnd[RTL].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexEnd[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexStart[LTR].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexStart[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexStart[RTL].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsFlexStart[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsStretch[LTR].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsStretch[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsStretch[RTL].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithAlignItemsStretch[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324


### PR DESCRIPTION
The existing test `columnWithMarginAndDifferentAlignments` varies `align-self`, and not `align-items`.

It's expected that the `LazyList` tests aren't correct (see #1261).