### PR TITLE
Add screenshot test for updated `AlignItems`

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -65,8 +65,8 @@ class ComposeUiFlexContainerTest(
     override var modifier = modifier
   }
 
-  override fun verifySnapshot(container: TestFlexContainer<@Composable () -> Unit>) {
-    paparazzi.snapshot {
+  override fun verifySnapshot(container: TestFlexContainer<@Composable () -> Unit>, name: String?) {
+    paparazzi.snapshot(name) {
       container.value()
     }
   }

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[LTR]_center.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[LTR]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[LTR]_flexend.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[LTR]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[RTL]_center.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[RTL]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05398a992a058d0eb53ebd82598d5d357e93d1209f1191cf1163c318c9b1ab5c
+size 56509

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[RTL]_flexend.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_columnWithUpdatedAlignItems[RTL]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c2a07542154cfc9d36995407a78591c258f68f60883006ed94d64c1b239480c
+size 55210

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -34,7 +34,7 @@ import org.junit.Test
 abstract class AbstractFlexContainerTest<T : Any> {
   abstract fun flexContainer(direction: FlexDirection): TestFlexContainer<T>
   abstract fun widget(text: String, modifier: Modifier = Modifier): Widget<T>
-  abstract fun verifySnapshot(container: TestFlexContainer<T>)
+  abstract fun verifySnapshot(container: TestFlexContainer<T>, name: String? = null)
 
   @Test fun emptyRow() {
     val container = flexContainer(FlexDirection.Row)
@@ -115,6 +115,20 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(widget(movie))
     }
     verifySnapshot(container)
+  }
+
+  @Test
+  fun columnWithUpdatedAlignItems() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.alignItems(AlignItems.Center)
+    movies.forEach { movie ->
+      container.add(widget(movie))
+    }
+    verifySnapshot(container, "Center")
+    container.alignItems(AlignItems.FlexEnd)
+    verifySnapshot(container, "FlexEnd")
   }
 
   @Test fun columnWithJustifyContentCenter() {

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -64,8 +64,8 @@ class ViewFlexContainerTest(
     override var modifier = modifier
   }
 
-  override fun verifySnapshot(container: TestFlexContainer<View>) {
-    paparazzi.snapshot(container.value)
+  override fun verifySnapshot(container: TestFlexContainer<View>, name: String?) {
+    paparazzi.snapshot(container.value, name)
   }
 
   class ViewTestFlexContainer(context: Context, direction: FlexDirection) : TestFlexContainer<View> {

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[LTR]_center.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[LTR]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[LTR]_flexend.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[LTR]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_center.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_flexend.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5ff9c3492803d708d5e3251a080d56ea2891a5f00050640cfde5c318cac8f
+size 56168

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -66,8 +66,8 @@ class ComposeUiLazyListTest(
     override var modifier = modifier
   }
 
-  override fun verifySnapshot(container: TestFlexContainer<@Composable () -> Unit>) {
-    paparazzi.snapshot {
+  override fun verifySnapshot(container: TestFlexContainer<@Composable () -> Unit>, name: String?) {
+    paparazzi.snapshot(name) {
       container.value()
     }
   }

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[LTR]_center.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[LTR]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[LTR]_flexend.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[LTR]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[RTL]_center.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[RTL]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612880870579de43e0065500aa3d9d733f56ffbd3eac8c19bef1db9e7bc996c9
+size 55492

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[RTL]_flexend.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_columnWithUpdatedAlignItems[RTL]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612880870579de43e0065500aa3d9d733f56ffbd3eac8c19bef1db9e7bc996c9
+size 55492

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
@@ -62,8 +62,8 @@ class ViewLazyListTest(
     override var modifier = modifier
   }
 
-  override fun verifySnapshot(container: TestFlexContainer<View>) {
-    paparazzi.snapshot(container.value)
+  override fun verifySnapshot(container: TestFlexContainer<View>, name: String?) {
+    paparazzi.snapshot(container.value, name)
   }
 
   class ViewTestFlexContainer(context: Context, direction: FlexDirection) : TestFlexContainer<View> {

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[LTR]_center.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[LTR]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[LTR]_flexend.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[LTR]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84b8bdba6cbb2a84c8bcba44356c87dae452c405643e58367811249dd240fbc
+size 54913

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[RTL]_center.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[RTL]_center.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[RTL]_flexend.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_columnWithUpdatedAlignItems[RTL]_flexend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:686afb31ab505dbe2bc509c666682fcb8eaac91107112c7d754b092369165d72
+size 55324


### PR DESCRIPTION
This unsurprisingly fails for `LazyList` (it'll be fixed in https://github.com/cashapp/redwood/pull/1277).

For `Column`, this only works with Compose UI. I'll look at fixing it for Android Views in a follow-up PR.