### PR TITLE
Fill width in `align-self` screenshot tests

### DIFF
--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -82,6 +82,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     assumeTrue(flexDirectionEnum in listOf(FlexDirectionEnum.Row, FlexDirectionEnum.Column))
     val flexDirection = flexDirectionEnum.toFlexDirection()
     val container = flexContainer(flexDirection)
+    container.width(Constraint.Fill)
     container.margin(Margin(start = 5.dp, end = 10.dp, top = 20.dp, bottom = 20.dp))
     movies.forEachIndexed { index, movie ->
       val modifier = when (index % 4) {

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[LTR,Column].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[LTR,Column].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8dd618e0d88124898cfbf5d4d53eed9879668ed8f6197e06323db020ea51574
-size 24160
+oid sha256:f33f28c5458ee429c6fd8f20bafe1d25689511e5acccdd83157c2dca3e322fce
+size 24204

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[RTL,Column].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[RTL,Column].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82aafbc9976312d628a128634bbbbcf6ea27d16e2bb96671194de9bef1c9fa1f
-size 24271
+oid sha256:423a7b5e01b18bebacac5b111537d3d39047f1db54baa3e4f91dd5375ff68a36
+size 24148


### PR DESCRIPTION
It's hard to tell what's going on with the `align-self` properties when the width is wrapped.