### PR TITLE
Better align `Row`/`Column` View screenshots with Compose UI

### DIFF
--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -58,6 +58,7 @@ class ViewFlexContainerTest(
     override val value = TextView(paparazzi.context).apply {
       background = ColorDrawable(Color.GREEN)
       textSize = 18f
+      textDirection = View.TEXT_DIRECTION_LOCALE
       setTextColor(Color.BLACK)
       this.text = text
     }

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContent[RTL,Center].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContent[RTL,Center].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3879dcbdbcf3c2b0c958bde865c1bd4edbc59110372ea5283b7302b26abcb2e4
-size 24049
+oid sha256:94009d86064e6802a2ad4a6624273e2ca673fa10a83c8ecf7815fd8939db1048
+size 24037

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContent[RTL,SpaceAround].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContent[RTL,SpaceAround].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f92dd0649ab544dc57b8b521af8a3cdc911ebe2da8774e969882e4ea3aacadaf
-size 24120
+oid sha256:74839e838444070b4a6758c9095f4431b8e4b2101c959a5b746748c4944770cb
+size 24147

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContent[RTL,SpaceBetween].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithJustifyContent[RTL,SpaceBetween].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a58ae927cf910efb7712dd9ff84ed2e7d3dec2c57781cb1ec426c46740da84a
-size 24291
+oid sha256:854011342d716349a7e1b522ab0aa7dd388f07ea829075708352b1a633874fc1
+size 24258

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_center.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_center.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ce0f63ff0ccdb904cd62ba42296218d04337c2964b82a172ed83007ad6e35eb
-size 24839
+oid sha256:a08cba31fee5ab4a6e14780d5c6071b6927743b3e3b09524e33bb8f16983ec18
+size 24868

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_flexend.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_columnWithUpdatedAlignItems[RTL]_flexend.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72c3e1cd1206a5b4ffe9a1565cd484a0cfb2d2419ea46ded616e1dc19d12803f
-size 23497
+oid sha256:915398091936d453d63d1f1961c8bdafe8ab1e665366c4ba5fc081b6a1c3c931
+size 23533

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,Center].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,Center].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ce0f63ff0ccdb904cd62ba42296218d04337c2964b82a172ed83007ad6e35eb
-size 24839
+oid sha256:a08cba31fee5ab4a6e14780d5c6071b6927743b3e3b09524e33bb8f16983ec18
+size 24868

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,FlexEnd].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,FlexEnd].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72c3e1cd1206a5b4ffe9a1565cd484a0cfb2d2419ea46ded616e1dc19d12803f
-size 23497
+oid sha256:915398091936d453d63d1f1961c8bdafe8ab1e665366c4ba5fc081b6a1c3c931
+size 23533

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,FlexStart].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,FlexStart].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b24455a227bd9ba3f61e7038761156ef0c913a64c36ff3f1c5d3be9b2ddb2b0
-size 24062
+oid sha256:c3a5b8545dfe93ba167e7a1c255f6d569d70ded7832b4bd42f277aff37e70823
+size 24058

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,Stretch].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Column,Stretch].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce3a6bfd00593ecfcdfef73c89b4acfa7ad4a18547a9107d2cf225b8dc33e597
-size 23341
+oid sha256:f82334eb9e0b32e004c262fa2f88f1ff2eff30933974599ed199f4036958e874
+size 23358

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,Center].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,Center].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:402f702b95deeb1c3a1ca3411b2ad72b3ee77d3fbd1a738100360bb379f9de58
-size 10388
+oid sha256:1895231a806b2a3206445a9d746645328f4cff96ad28f3bdf0e0b705d0fb961c
+size 10174

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,FlexEnd].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,FlexEnd].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f03aff8e086eb606a7d46f4a6b1c597ae0aff3d1b8e0a44e81b7cdd03825a7e
-size 10414
+oid sha256:ef85d1071b3b560cb1e2bd08dd036e2d41b4650ed8d4b26dc34590c7eaddcbbd
+size 10174

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,FlexStart].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,FlexStart].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b6a4a6c843519afe1c787cf716e903a574ada2262723a2fae4ccc20cc6ccb1f7
-size 10476
+oid sha256:22de53e28a04d89e8f5c3d9824da1bebabbce8951beb430ecd5c1819a4a6b44f
+size 10277

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,Stretch].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithAlignItems[RTL,Row,Stretch].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55037f8a401398ef9d8adb8999a26df01a5e4531e56eda987ddcf04f0e3770b5
-size 10346
+oid sha256:f410925b35be28bc7d65fa403ce8c779bedc5030fcb3ce352b57b3e5fe802597
+size 10139

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithConstraints[RTL,Column,Fill,Fill].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithConstraints[RTL,Column,Fill,Fill].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d8c5191a9fb3a12ef22d5fdee277a06a9b71349584d52213dfba9e93bf62c1c
-size 6020
+oid sha256:3444ce30101a50830f0c314e52fe74524fcff26ce751d573f59d1e79c6325faa
+size 6016

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithConstraints[RTL,Column,Fill,Wrap].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithConstraints[RTL,Column,Fill,Wrap].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53d595a8fcdc1ce2dde0a4f5c9708639b6af218bea5477d294bb8882e129e376
-size 6012
+oid sha256:292b125c575edfb8776d5c236139b48b3eb33d543812b6feed3152710a6951a6
+size 6004

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[RTL,Column].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[RTL,Column].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c8a0046f3508df1a236f3232f1b273386e98e7765014f1ede792f82a24522d2
-size 24452
+oid sha256:2da95413c7641aff2d36dcc11c6235fa7836a5abba96ca2a0173d5bc136637e4
+size 24461

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[RTL,Row].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_layoutWithMarginAndDifferentAlignments[RTL,Row].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2de3fdfb39db723b6280435a71031f3be3dcc596d62d04fccaf705f7bfa5202
-size 12052
+oid sha256:97255a44362495601ff74d4d0909c41758e44fd714148e558b02828e4f3c7e7d
+size 12018

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_longLayout[RTL,Column].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_longLayout[RTL,Column].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:084f4714a7bd675a59c0acdbaa5fd93652ff92d1142e77ec584fd0c58e59d45e
-size 24250
+oid sha256:68e431c06882fd86f1a32daf7ca40bbe27d745f4ecb9f7af614fc6abf8f23f3c
+size 24247

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_longLayout[RTL,Row].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_longLayout[RTL,Row].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e928d231ffcea9ab91c15f02ca110d8abaf946b4647974ce8346a9d066fa436
-size 10368
+oid sha256:088f163a4831daa69a013f4dfb57e8a84a0c463d2b9a49eeae22cf0ae287f67e
+size 10153

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_shortLayout[RTL,Column].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_shortLayout[RTL,Column].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2172c388137921cfdcf424dc7f13724198a1d86e22f46e42c9fe325f51a65ad
-size 13724
+oid sha256:c84a9179b42f67074cd0f33c6daefe2259be230155f03ccfc60405e5db896cdf
+size 13735

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_shortLayout[RTL,Row].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_shortLayout[RTL,Row].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e928d231ffcea9ab91c15f02ca110d8abaf946b4647974ce8346a9d066fa436
-size 10368
+oid sha256:088f163a4831daa69a013f4dfb57e8a84a0c463d2b9a49eeae22cf0ae287f67e
+size 10153


### PR DESCRIPTION
Most of the updated screenshots look the same, but 3 of them have the content switching sides in RTL. The motivation for this change is to eventually have the View and Compose UI screenshots share the same screenshots, so we make sure that the output of Android Views and Compose UI are identical. 