### PR TITLE
Rename Kotlin source generation task name

### DIFF
--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
@@ -83,9 +83,9 @@ public abstract class RedwoodGeneratorPlugin(
       isCanBeConsumed = false
       isVisible = false
     }
-    val generate = project.tasks.register("redwoodGenerate", RedwoodGeneratorTask::class.java) {
+    val generate = project.tasks.register("redwoodKotlinGenerate", RedwoodGeneratorTask::class.java) {
       it.group = BUILD_GROUP
-      it.description = "Generate Redwood sources"
+      it.description = "Generate Redwood Kotlin sources"
 
       it.toolClasspath.from(toolingConfiguration)
       it.outputDir.set(project.layout.buildDirectory.dir("generated/redwood"))


### PR DESCRIPTION
This matches the task name structure of the API generation and JSON generation tasks.

Closes #1312 