### PR TITLE
Test empty `LazyColumn` composable

### DIFF
--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.layout.widget.RedwoodLayoutTestingWidgetFactory
+import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutTestingWidgetFactory
 import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.testing.TestRedwoodComposition
 import app.cash.redwood.testing.WidgetValue
@@ -82,6 +83,7 @@ abstract class AbstractChangeListenerTest {
         override fun Button() = button
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+      RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val c = backgroundScope.launchComposition(factories, button::changes)
 
@@ -102,6 +104,7 @@ abstract class AbstractChangeListenerTest {
         override fun Button() = button
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+      RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val c = backgroundScope.launchComposition(factories, button::changes)
 
@@ -123,6 +126,7 @@ abstract class AbstractChangeListenerTest {
         override fun Button() = button
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+      RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val c = backgroundScope.launchComposition(factories, button::changes)
 
@@ -145,6 +149,7 @@ abstract class AbstractChangeListenerTest {
         override fun Button() = button
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+      RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val c = backgroundScope.launchComposition(factories, button::changes)
 
@@ -169,6 +174,7 @@ abstract class AbstractChangeListenerTest {
         override fun Row() = row
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+      RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val c = backgroundScope.launchComposition(factories, row::changes)
 
@@ -195,6 +201,7 @@ abstract class AbstractChangeListenerTest {
         override fun Row() = row
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+      RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val c = backgroundScope.launchComposition(factories, row::changes)
 

--- a/redwood-lazylayout-compose/build.gradle
+++ b/redwood-lazylayout-compose/build.gradle
@@ -16,6 +16,15 @@ kotlin {
         api projects.redwoodLazylayoutWidget
       }
     }
+    commonTest {
+      dependencies {
+        implementation libs.kotlin.test
+        implementation libs.assertk
+        implementation libs.kotlinx.coroutines.test
+        implementation projects.testSchema.composeProtocol
+        implementation projects.testSchema.testing
+      }
+    }
   }
 }
 

--- a/redwood-lazylayout-compose/src/commonTest/kotlin/app/cash/redwood/lazylayout/compose/LazyListTest.kt
+++ b/redwood-lazylayout-compose/src/commonTest/kotlin/app/cash/redwood/lazylayout/compose/LazyListTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.lazylayout.compose
+
+import app.cash.redwood.Modifier
+import app.cash.redwood.layout.api.Constraint
+import app.cash.redwood.layout.api.CrossAxisAlignment
+import app.cash.redwood.lazylayout.widget.LazyListValue
+import app.cash.redwood.ui.Margin
+import app.cash.redwood.ui.dp
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import example.redwood.compose.Text
+import example.redwood.widget.ExampleSchemaTester
+import example.redwood.widget.TextValue
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class LazyListTest {
+  @Test
+  fun emptyLazyColumn() = runTest {
+    val snapshot = ExampleSchemaTester {
+      setContent {
+        LazyColumn(placeholder = { Text("Placeholder") }) {
+        }
+      }
+      awaitSnapshot()
+    }
+
+    assertThat(snapshot)
+      .containsExactly(
+        LazyListValue(
+          Modifier,
+          isVertical = true,
+          onViewportChanged = { _, _ -> },
+          itemsBefore = 0,
+          itemsAfter = 0,
+          width = Constraint.Wrap,
+          height = Constraint.Wrap,
+          margin = Margin(0.0.dp),
+          crossAxisAlignment = CrossAxisAlignment.Start,
+          placeholder = List(20) { TextValue(Modifier, "Placeholder") },
+          items = emptyList(),
+        ),
+      )
+  }
+}

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyRedwoodLazyLayoutWidgetFactory.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyRedwoodLazyLayoutWidgetFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory
+
+class EmptyRedwoodLazyLayoutWidgetFactory : RedwoodLazyLayoutWidgetFactory<Nothing> {
+  override fun LazyList() = TODO()
+  override fun RefreshableLazyList() = TODO()
+}

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolBridgeTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolBridgeTest.kt
@@ -39,6 +39,7 @@ class ProtocolBridgeTest {
         provider = ExampleSchemaWidgetFactories(
           ExampleSchema = EmptyExampleSchemaWidgetFactory(),
           RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+          RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
         ),
       ),
       eventSink = ::error,
@@ -62,6 +63,7 @@ class ProtocolBridgeTest {
         provider = ExampleSchemaWidgetFactories(
           ExampleSchema = EmptyExampleSchemaWidgetFactory(),
           RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+          RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
         ),
       ),
       eventSink = ::error,
@@ -86,6 +88,7 @@ class ProtocolBridgeTest {
         provider = ExampleSchemaWidgetFactories(
           ExampleSchema = EmptyExampleSchemaWidgetFactory(),
           RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+          RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
         ),
       ),
       eventSink = ::error,

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactoryTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactoryTest.kt
@@ -51,6 +51,7 @@ class ProtocolNodeFactoryTest {
       ExampleSchemaWidgetFactories(
         ExampleSchema = EmptyExampleSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
     )
 
@@ -66,6 +67,7 @@ class ProtocolNodeFactoryTest {
       provider = ExampleSchemaWidgetFactories(
         ExampleSchema = EmptyExampleSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       mismatchHandler = handler,
     )
@@ -88,6 +90,7 @@ class ProtocolNodeFactoryTest {
           override fun TextInput() = recordingTextInput
         },
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       json = json,
     )
@@ -122,6 +125,7 @@ class ProtocolNodeFactoryTest {
           override fun TextInput() = recordingTextInput
         },
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       json = json,
     )
@@ -153,6 +157,7 @@ class ProtocolNodeFactoryTest {
       provider = ExampleSchemaWidgetFactories(
         ExampleSchema = EmptyExampleSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
     )
     val button = factory.create(WidgetTag(4))!!
@@ -184,6 +189,7 @@ class ProtocolNodeFactoryTest {
           override fun TextInput() = recordingTextInput
         },
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       json = json,
       mismatchHandler = handler,
@@ -223,6 +229,7 @@ class ProtocolNodeFactoryTest {
       provider = ExampleSchemaWidgetFactories(
         ExampleSchema = EmptyExampleSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
     )
     val button = factory.create(WidgetTag(4))!!
@@ -239,6 +246,7 @@ class ProtocolNodeFactoryTest {
       provider = ExampleSchemaWidgetFactories(
         ExampleSchema = EmptyExampleSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       mismatchHandler = handler,
     )
@@ -262,6 +270,7 @@ class ProtocolNodeFactoryTest {
           override fun TextInput() = recordingTextInput
         },
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       json = json,
     )
@@ -278,6 +287,7 @@ class ProtocolNodeFactoryTest {
       provider = ExampleSchemaWidgetFactories(
         ExampleSchema = EmptyExampleSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
     )
     val button = factory.create(WidgetTag(4))!!
@@ -296,6 +306,7 @@ class ProtocolNodeFactoryTest {
       provider = ExampleSchemaWidgetFactories(
         ExampleSchema = EmptyExampleSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       mismatchHandler = handler,
     )
@@ -319,6 +330,7 @@ class ProtocolNodeFactoryTest {
           override fun TextInput() = recordingTextInput
         },
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
+        RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
       json = json,
     )

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.layout.widget.RedwoodLayoutTestingWidgetFactory
+import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutTestingWidgetFactory
 import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.ChildrenChange.Add
 import app.cash.redwood.protocol.ChildrenTag
@@ -117,6 +118,7 @@ class ViewTreesTest {
     val mutableFactories = ExampleSchemaWidgetFactories(
       ExampleSchema = ExampleSchemaTestingWidgetFactory(),
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+      RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val protocolNodes = ExampleSchemaProtocolNodeFactory(mutableFactories)
     val widgetContainer = MutableListChildren<WidgetValue>()

--- a/test-schema/build.gradle
+++ b/test-schema/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'app.cash.redwood.schema'
 
 dependencies {
   api projects.redwoodLayoutSchema
+  api projects.redwoodLazylayoutSchema
 }
 
 redwoodSchema {

--- a/test-schema/src/main/kotlin/example/redwood/schema.kt
+++ b/test-schema/src/main/kotlin/example/redwood/schema.kt
@@ -16,6 +16,7 @@
 package example.redwood
 
 import app.cash.redwood.layout.RedwoodLayout
+import app.cash.redwood.lazylayout.RedwoodLazyLayout
 import app.cash.redwood.schema.Children
 import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Modifier
@@ -43,6 +44,7 @@ import kotlin.time.Duration
   ],
   dependencies = [
     Dependency(1, RedwoodLayout::class),
+    Dependency(2, RedwoodLazyLayout::class),
   ],
 )
 public interface ExampleSchema

--- a/test-schema/testing/build.gradle
+++ b/test-schema/testing/build.gradle
@@ -10,7 +10,9 @@ kotlin {
     commonMain {
       dependencies {
         api projects.redwoodLayoutWidget
+        api projects.redwoodLazylayoutWidget
         api projects.redwoodLayoutTesting
+        api projects.redwoodLazylayoutTesting
         api projects.testSchema.widget
       }
     }

--- a/test-schema/widget/build.gradle
+++ b/test-schema/widget/build.gradle
@@ -10,6 +10,7 @@ kotlin {
     commonMain {
       dependencies {
         api projects.redwoodLayoutWidget
+        api projects.redwoodLazylayoutWidget
       }
     }
   }


### PR DESCRIPTION
This is to set up the groundwork for testing that the correct properties are emitted from `LazyList` as scrolling and data swapping occurs.