### PR TITLE
Migrate explicit API enabling to build plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,30 +39,6 @@ allprojects {
     outputs.upToDateWhen { false }
   }
 
-  // List of Redwood modules that aren't published.
-  def privateApiModules = [
-    ":redwood-layout-shared-test"
-  ]
-
-  if (project.path.startsWith(':redwood-') && !privateApiModules.contains(project.path)) {
-    plugins.withId('org.jetbrains.kotlin.multiplatform') {
-      kotlin {
-        explicitApi()
-      }
-    }
-
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { task ->
-      // Only enable strict mode for non-test sources.
-      if (!task.name.toLowerCase().contains('test')) {
-        compilerOptions {
-          freeCompilerArgs.addAll([
-            '-Xexplicit-api=strict',
-          ])
-        }
-      }
-    }
-  }
-
   plugins.withId('org.jetbrains.kotlin.multiplatform') {
     kotlin {
       sourceSets {

--- a/redwood-layout-dom/src/main/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
+++ b/redwood-layout-dom/src/main/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
@@ -31,7 +31,7 @@ import org.w3c.dom.Document
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
 
-class HTMLElementRedwoodLayoutWidgetFactory(
+public class HTMLElementRedwoodLayoutWidgetFactory(
   private val document: Document,
 ) : RedwoodLayoutWidgetFactory<HTMLElement> {
   override fun Column(): Column<HTMLElement> =


### PR DESCRIPTION
This enables it automatically for any published library, and it caught one library that was without it!