### PR TITLE
Disable Android resources by default in libraries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+android.library.defaults.buildfeatures.androidresources=false
 
 kotlin.mpp.enableCInteropCommonization=true
 

--- a/redwood-layout-composeui/build.gradle
+++ b/redwood-layout-composeui/build.gradle
@@ -36,4 +36,9 @@ kotlin {
 
 android {
   namespace 'app.cash.redwood.layout.composeui'
+
+  buildFeatures {
+    // TODO Remove once https://github.com/cashapp/paparazzi/issues/472 fixed.
+    androidResources = true
+  }
 }

--- a/redwood-layout-view/build.gradle
+++ b/redwood-layout-view/build.gradle
@@ -26,6 +26,11 @@ android {
   libraryVariants.all { variant ->
     variant.registerJavaGeneratingTask(helpers, helpers.outputDirectory.get().asFile)
   }
+
+  buildFeatures {
+    // TODO Remove once https://github.com/cashapp/paparazzi/issues/472 fixed.
+    androidResources = true
+  }
 }
 
 spotless {

--- a/redwood-lazylayout-composeui/build.gradle
+++ b/redwood-lazylayout-composeui/build.gradle
@@ -33,4 +33,9 @@ kotlin {
 
 android {
   namespace 'app.cash.redwood.lazylayout.composeui'
+
+  buildFeatures {
+    // TODO Remove once https://github.com/cashapp/paparazzi/issues/472 fixed.
+    androidResources = true
+  }
 }

--- a/redwood-lazylayout-view/build.gradle
+++ b/redwood-lazylayout-view/build.gradle
@@ -19,4 +19,9 @@ dependencies {
 
 android {
   namespace 'app.cash.redwood.lazylayout.view'
+
+  buildFeatures {
+    // TODO Remove once https://github.com/cashapp/paparazzi/issues/472 fixed.
+    androidResources = true
+  }
 }

--- a/redwood-treehouse-host/build.gradle
+++ b/redwood-treehouse-host/build.gradle
@@ -79,4 +79,9 @@ android {
   defaultConfig {
     testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }
+
+  buildFeatures {
+    // Needed for unit tests which use ViewCompat whose static fields reference `R.id`s.
+    androidResources = true
+  }
 }


### PR DESCRIPTION
Before:

    $ gw build --dry-run --console=plain | grep SKIPPED | wc -l
        6551

After:

    $ gw build --dry-run --console=plain | grep SKIPPED | wc -l
        6300