### PR TITLE
UIViewFlexContainer ScrollView Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,8 @@ kotlin.native.ignoreIncorrectDependencies=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true
+# Specify a specific JAVA_HOME for gradle if needed
+# org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-17.0.3.jdk/Contents/Home
 
 android.useAndroidX=true
 android.enableJetifier=false

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -25,6 +25,7 @@ import app.cash.redwood.layout.widget.Row
 import app.cash.redwood.ui.Default
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
+import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.UIViewChildren
 import app.cash.redwood.yoga.AlignItems
 import app.cash.redwood.yoga.FlexDirection
@@ -35,10 +36,9 @@ import platform.UIKit.UIView
 import platform.darwin.NSInteger
 
 internal class UIViewFlexContainer(
-  direction: FlexDirection,
-) : Row<UIView>, Column<UIView> {
+  private val direction: FlexDirection,
+) : Row<UIView>, Column<UIView>, ChangeListener {
   private val yogaView = YogaUIView()
-
   override val value: UIView get() = yogaView
   override val children = UIViewChildren(
     value,
@@ -64,12 +64,10 @@ internal class UIViewFlexContainer(
 
   override fun width(width: Constraint) {
     yogaView.width = width
-    invalidate()
   }
 
   override fun height(height: Constraint) {
     yogaView.height = height
-    invalidate()
   }
 
   override fun margin(margin: Margin) {
@@ -81,11 +79,10 @@ internal class UIViewFlexContainer(
         marginBottom = margin.bottom.toPx().toFloat()
       }
     }
-    invalidate()
   }
 
   override fun overflow(overflow: Overflow) {
-    invalidate()
+    yogaView.scrollEnabled = overflow == Overflow.Scroll
   }
 
   override fun horizontalAlignment(horizontalAlignment: MainAxisAlignment) {
@@ -106,15 +103,13 @@ internal class UIViewFlexContainer(
 
   private fun alignItems(alignItems: AlignItems) {
     yogaView.rootNode.alignItems = alignItems
-    invalidate()
   }
 
   private fun justifyContent(justifyContent: JustifyContent) {
     yogaView.rootNode.justifyContent = justifyContent
-    invalidate()
   }
 
-  private fun invalidate() {
+  override fun onEndChanges() {
     value.setNeedsLayout()
   }
 }

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -68,7 +68,6 @@ public class UIViewChildren(
   }
 
   private fun invalidate() {
-    parent.setNeedsLayout()
-    parent.invalidateIntrinsicContentSize()
+    (parent.superview ?: parent).setNeedsLayout()
   }
 }

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp.xcodeproj/xcshareddata/xcschemes/EmojiSearchApp.xcscheme
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp.xcodeproj/xcshareddata/xcschemes/EmojiSearchApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "635661D021F12B7E00DD7240"
+               BuildableName = "EmojiSearchApp.app"
+               BlueprintName = "EmojiSearchApp"
+               ReferencedContainer = "container:EmojiSearchApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "635661D021F12B7E00DD7240"
+            BuildableName = "EmojiSearchApp.app"
+            BlueprintName = "EmojiSearchApp"
+            ReferencedContainer = "container:EmojiSearchApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "635661D021F12B7E00DD7240"
+            BuildableName = "EmojiSearchApp.app"
+            BlueprintName = "EmojiSearchApp"
+            ReferencedContainer = "container:EmojiSearchApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Making this a ScrollView eliminates the need to dynamically wrap the YogaView and deal with proxying sizing back and forth.

This works for a lot of complex nested use cases. For example:

https://github.com/cashapp/redwood/assets/465849/84cc4574-12f2-4e1b-a9f4-54bdcd3bdb7c

Remaining issues:
- [x] Wrapped sizing for Rows doesn't produce a height
- [x] Double Top Margins
- [x] Update width sizing when the data model changes (missing a layout pass for swapping shorter -> longer text)