### PR TITLE
Fix iOS `LazyList` bug where placeholder's aren't replaced with items

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -33,6 +33,7 @@ import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
+import kotlin.math.max
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ObjCClass
 import kotlinx.cinterop.readValue
@@ -85,7 +86,7 @@ internal class ViewPortItems(
 
   // Fetch the item relative to the entire collection view
   internal fun itemForGlobalIndex(index: Int): ViewPortItem {
-    get(index)?.let {
+    items.getOrNull(max(index - itemsBefore, 0))?.let {
       return it
     }
 


### PR DESCRIPTION
Reverts the item retrieval change in https://github.com/cashapp/redwood/pull/1335. `get(index`) _should_ work in this case, but I'll look into that in a follow up. This just fixes iOS so we're back to where we were before.