### PR TITLE
Remove redundant conditional

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -196,12 +196,10 @@ internal open class UIViewLazyList : LazyList<UIView>, ChangeListener {
   override fun isVertical(isVertical: Boolean) {
     this.isVertical = isVertical
 
-    if (!isVertical) {
-      collectionViewFlowLayout.scrollDirection = if (isVertical) {
-        UICollectionViewScrollDirection.UICollectionViewScrollDirectionVertical
-      } else {
-        UICollectionViewScrollDirection.UICollectionViewScrollDirectionHorizontal
-      }
+    collectionViewFlowLayout.scrollDirection = if (isVertical) {
+      UICollectionViewScrollDirection.UICollectionViewScrollDirectionVertical
+    } else {
+      UICollectionViewScrollDirection.UICollectionViewScrollDirectionHorizontal
     }
   }
 


### PR DESCRIPTION
Usually, this would be a bug. In this case though, the value of `isVertical` is baked into the "type"/name of the composable function (i.e., `LazyRow` or `LazyColumn`), thus the value of `isVertical` is only ever set once. The default value of `UICollectionViewFlowLayout` is vertical, so we previously just had an unused code path, which has now been removed.