### PR TITLE
Make `UIViewLazyList` placeholders self-sizing

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -82,7 +82,8 @@ internal open class UIViewLazyList : LazyList<UIView>, ChangeListener {
 
     // If we don't have a value, fallback to our pools of placeholders
     val placeholderIndex = index % placeholder.size
-    return ViewPortItem(placeholder[placeholderIndex], collectionView.size())
+    val widget = placeholder[placeholderIndex]
+    return ViewPortItem(widget, widget.value.sizeThatFits(collectionView.size()))
   }
 
   private var collectionViewFlowLayout: UICollectionViewFlowLayout =


### PR DESCRIPTION
Before this change, each placeholder is the height of the viewport. After this change, each placeholder is the height as defined by itself. This lines up with what `ViewLazyList` already does.