### PR TITLE
Insert and remove nodes with child modifications

### DIFF
--- a/redwood-layout-uiview/build.gradle
+++ b/redwood-layout-uiview/build.gradle
@@ -1,3 +1,4 @@
+import app.cash.redwood.buildsupport.ComposeHelpers
 import app.cash.redwood.buildsupport.FlexboxHelpers
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
@@ -13,6 +14,7 @@ kotlin {
 
   sourceSets {
     commonMain {
+      kotlin.srcDir(ComposeHelpers.get(tasks, 'app.cash.redwood.layout.uiview'))
       kotlin.srcDir(FlexboxHelpers.get(tasks, 'app.cash.redwood.layout.uiview'))
       dependencies {
         api projects.redwoodLayoutWidget

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewMeasureCallback.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewMeasureCallback.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.uiview
+
+import app.cash.redwood.yoga.MeasureCallback
+import app.cash.redwood.yoga.MeasureMode
+import app.cash.redwood.yoga.Node
+import app.cash.redwood.yoga.Size
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGSize
+import platform.CoreGraphics.CGSizeMake
+import platform.UIKit.UIView
+import platform.UIKit.UIViewNoIntrinsicMetric
+
+internal class UIViewMeasureCallback(val view: UIView) : MeasureCallback {
+  override fun measure(
+    node: Node,
+    width: Float,
+    widthMode: MeasureMode,
+    height: Float,
+    heightMode: MeasureMode,
+  ): Size {
+    val constrainedWidth = when (widthMode) {
+      MeasureMode.Undefined -> UIViewNoIntrinsicMetric
+      else -> width.toDouble()
+    }
+    val constrainedHeight = when (heightMode) {
+      MeasureMode.Undefined -> UIViewNoIntrinsicMetric
+      else -> height.toDouble()
+    }
+
+    // The default implementation of sizeThatFits: returns the existing size of
+    // the view. That means that if we want to layout an empty UIView, which
+    // already has a frame set, its measured size should be CGSizeZero, but
+    // UIKit returns the existing size. See https://github.com/facebook/yoga/issues/606
+    // for more information.
+    val sizeThatFits = if (view.isMemberOfClass(UIView.`class`()) && view.typedSubviews.isEmpty()) {
+      Size(0f, 0f)
+    } else {
+      view.sizeThatFits(CGSizeMake(constrainedWidth, constrainedHeight)).toSize()
+    }
+
+    return Size(
+      width = sanitizeMeasurement(constrainedWidth, sizeThatFits.width, widthMode),
+      height = sanitizeMeasurement(constrainedHeight, sizeThatFits.height, heightMode),
+    )
+  }
+
+  private fun sanitizeMeasurement(
+    constrainedSize: Double,
+    measuredSize: Float,
+    measureMode: MeasureMode,
+  ): Float = when (measureMode) {
+    MeasureMode.Exactly -> constrainedSize.toFloat()
+    MeasureMode.AtMost -> measuredSize
+    MeasureMode.Undefined -> measuredSize
+    else -> throw AssertionError()
+  }
+}
+
+private fun CValue<CGSize>.toSize() = useContents {
+  Size(width.toFloat(), height.toFloat())
+}

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -25,6 +25,11 @@ public class UIViewChildren(
   private val insert: (UIView, Int) -> Unit = { view, index ->
     parent.insertSubview(view, index.convert<NSInteger>())
   },
+  private val remove: (index: Int, count: Int) -> Array<UIView> = { index, count ->
+    Array(count) {
+      parent.typedSubviews[index].also(UIView::removeFromSuperview)
+    }
+  },
 ) : Widget.Children<UIView> {
   private val _widgets = ArrayList<Widget<UIView>>()
   public val widgets: List<Widget<UIView>> get() = _widgets
@@ -38,9 +43,7 @@ public class UIViewChildren(
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {
     _widgets.move(fromIndex, toIndex, count)
 
-    val subviews = Array(count) {
-      parent.typedSubviews[fromIndex].also(UIView::removeFromSuperview)
-    }
+    val subviews = remove.invoke(fromIndex, count)
 
     val newIndex = if (toIndex > fromIndex) {
       toIndex - count
@@ -56,9 +59,7 @@ public class UIViewChildren(
   override fun remove(index: Int, count: Int) {
     _widgets.remove(index, count)
 
-    repeat(count) {
-      parent.typedSubviews[index].removeFromSuperview()
-    }
+    remove.invoke(index, count)
     invalidate()
   }
 


### PR DESCRIPTION
Node insertion and deletion is solely managed by `UIViewChildren`. Instead of checking if the node children and the view children are in sync on every measure call (and if not, having to recreate all the node children), we can instead just update the node children as we update the view children, so we're certain that they are in sync, removing the need for the check.