### PR TITLE
Remove call to `markDirtyAndPropogateDownwards()`

### DIFF
--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/Node.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/Node.kt
@@ -94,9 +94,6 @@ public class Node internal constructor(
     get() = Yoga.YGNodeLayoutGetHeight(native)
 
   public fun measure(parentWidth: Float, parentHeight: Float) {
-    // TODO: Figure out how to measure incrementally safely.
-    native.markDirtyAndPropogateDownwards()
-
     Yoga.YGNodeCalculateLayout(
       node = native,
       ownerWidth = parentWidth,


### PR DESCRIPTION
The motivation for this change is from https://github.com/cashapp/redwood/pull/1342#discussion_r1274914974, where performance drastically improves in Emoji Search for iOS if this function call is removed. I couldn't figure out the purpose of this call. I've outlined below what I _assumed_ would trigger it, but I could be completely off the mark.

I tried triggering it by replacing the `Item` composable in Emoji Search with a `Column` and a delayed `Text` widget being displayed. The full changes can be found [in this branch](https://github.com/cashapp/redwood/compare/veyndan/2023-07-26/rm-markDirtyAndPropogateDownwards...veyndan/2023-07-26/rm-markDirtyAndPropogateDownwards-test?expand=1).

Android View, Compose UI, and UIKit all handle the display of `Text` differently:

1. Android View never displays the text.
2. Compose UI displays the text after a 1s delay, and adjusts the item heights (as expected).
3. UIKit adds the text, but doesn't increase the item height.

The issue is is that having `markDirtyAndPropogateDownwards()` there or not doesn't change the above outcomes for each platform.

Happy to close the PR if this call turns out to be necessary!

Closes #1205.