### PR TITLE
Display placeholders when scrolling up in `UIViewLazyList`

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -32,7 +32,6 @@ import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
-import kotlin.math.max
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ObjCClass
 import kotlinx.cinterop.readValue
@@ -74,8 +73,7 @@ internal open class UIViewLazyList(
 
   // Fetch the item relative to the entire collection view
   private fun WindowedChildren<UIView>.itemForGlobalIndex(index: Int): Widget<UIView> {
-    return items.getOrNull(max(index - itemsBefore, 0))
-      ?: placeholder[index % placeholder.size]
+    return get(index) ?: placeholder[index % placeholder.size]
   }
 
   private val collectionViewDataSource: UICollectionViewDataSourceProtocol =


### PR DESCRIPTION
Funnily enough, this is just a reversion of [this reversion](https://github.com/cashapp/redwood/pull/1336), where the first reversion was fixing a bug, and now reverting it back fixes a different bug. The bug described in https://github.com/cashapp/redwood/pull/1336 no longer occurs with the use of `get`.