### PR TITLE
Test child widget property changes correctly

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -18,6 +18,9 @@ package app.cash.redwood.layout.composeui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -27,6 +30,7 @@ import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.Modifier as RedwoodModifier
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.Widget
@@ -53,15 +57,22 @@ class ComposeUiFlexContainerTest(
 
   override fun flexContainer(direction: FlexDirection) = ComposeTestFlexContainer(direction)
 
-  override fun widget(text: String, modifier: RedwoodModifier) = object : Widget<@Composable () -> Unit> {
+  override fun widget(text: String, modifier: RedwoodModifier) = object : Text<@Composable () -> Unit> {
+    private var text by mutableStateOf(text)
+
     override val value = @Composable {
       BasicText(
-        text = text,
+        text = this.text,
         style = TextStyle(fontSize = 18.sp, color = Color.Black),
         modifier = Modifier.background(Color.Green),
       )
     }
+
     override var modifier = modifier
+
+    override fun text(text: String) {
+      this.text = text
+    }
   }
 
   override fun verifySnapshot(container: TestFlexContainer<@Composable () -> Unit>, name: String?) {

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[LTR]_initial.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[LTR]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[LTR]_updated.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[LTR]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4028fb3dceb398db0c4d4737b31be4cf5e59f3aab1764df855d31c4b71114eb
+size 6031

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[RTL]_initial.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[RTL]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[RTL]_updated.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_childWithUpdatedProperty[RTL]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f4862c29b07f05b59d0e362f1ae23a8db2374932dac3249805067edda1bdfda
+size 6065

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -38,7 +38,7 @@ import org.junit.Test
 @Suppress("JUnitMalformedDeclaration")
 abstract class AbstractFlexContainerTest<T : Any> {
   abstract fun flexContainer(direction: FlexDirection): TestFlexContainer<T>
-  abstract fun widget(text: String, modifier: Modifier = Modifier): Widget<T>
+  abstract fun widget(text: String, modifier: Modifier = Modifier): Text<T>
   abstract fun verifySnapshot(container: TestFlexContainer<T>, name: String? = null)
 
   @Test fun emptyLayout(
@@ -194,6 +194,18 @@ abstract class AbstractFlexContainerTest<T : Any> {
     }
     verifySnapshot(container)
   }
+
+  @Test fun childWithUpdatedProperty() {
+    val container = flexContainer(FlexDirection.Column)
+    container.width(Constraint.Fill)
+    container.height(Constraint.Fill)
+    container.alignItems(AlignItems.FlexStart)
+    val widget = widget("")
+    container.add(widget)
+    verifySnapshot(container, "initial")
+    widget.text(movies.first())
+    verifySnapshot(container, "updated")
+  }
 }
 
 interface TestFlexContainer<T : Any> {
@@ -204,6 +216,10 @@ interface TestFlexContainer<T : Any> {
   fun justifyContent(justifyContent: JustifyContent)
   fun margin(margin: Margin)
   fun add(widget: Widget<T>)
+}
+
+interface Text<T : Any> : Widget<T> {
+  fun text(text: String)
 }
 
 private val movies = listOf(

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -25,6 +25,7 @@ import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.Widget
@@ -53,7 +54,7 @@ class ViewFlexContainerTest(
     return ViewTestFlexContainer(paparazzi.context, direction)
   }
 
-  override fun widget(text: String, modifier: Modifier) = object : Widget<View> {
+  override fun widget(text: String, modifier: Modifier) = object : Text<View> {
     override val value = TextView(paparazzi.context).apply {
       background = ColorDrawable(Color.GREEN)
       textSize = 18f
@@ -61,7 +62,12 @@ class ViewFlexContainerTest(
       setTextColor(Color.BLACK)
       this.text = text
     }
+
     override var modifier = modifier
+
+    override fun text(text: String) {
+      value.text = text
+    }
   }
 
   override fun verifySnapshot(container: TestFlexContainer<View>, name: String?) {

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[LTR]_initial.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[LTR]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[LTR]_updated.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[LTR]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4028fb3dceb398db0c4d4737b31be4cf5e59f3aab1764df855d31c4b71114eb
+size 6031

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[RTL]_initial.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[RTL]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[RTL]_updated.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_childWithUpdatedProperty[RTL]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f4862c29b07f05b59d0e362f1ae23a8db2374932dac3249805067edda1bdfda
+size 6065

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -18,6 +18,9 @@ package app.cash.redwood.layout.composeui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -27,6 +30,7 @@ import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.Modifier as RedwoodModifier
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.lazylayout.composeui.ComposeUiLazyList
@@ -55,15 +59,22 @@ class ComposeUiLazyListTest(
 
   override fun flexContainer(direction: FlexDirection) = ComposeTestFlexContainer(direction)
 
-  override fun widget(text: String, modifier: RedwoodModifier) = object : Widget<@Composable () -> Unit> {
+  override fun widget(text: String, modifier: RedwoodModifier) = object : Text<@Composable () -> Unit> {
+    private var text by mutableStateOf(text)
+
     override val value = @Composable {
       BasicText(
-        text = text,
+        text = this.text,
         style = TextStyle(fontSize = 18.sp, color = Color.Black),
         modifier = Modifier.background(Color.Green),
       )
     }
+
     override var modifier = modifier
+
+    override fun text(text: String) {
+      this.text = text
+    }
   }
 
   override fun verifySnapshot(container: TestFlexContainer<@Composable () -> Unit>, name: String?) {

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[LTR]_initial.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[LTR]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[LTR]_updated.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[LTR]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4028fb3dceb398db0c4d4737b31be4cf5e59f3aab1764df855d31c4b71114eb
+size 6031

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[RTL]_initial.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[RTL]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[RTL]_updated.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_childWithUpdatedProperty[RTL]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f4862c29b07f05b59d0e362f1ae23a8db2374932dac3249805067edda1bdfda
+size 6065

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
@@ -25,6 +25,7 @@ import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.ui.Margin
@@ -52,14 +53,19 @@ class ViewLazyListTest(
 
   override fun flexContainer(direction: FlexDirection) = ViewTestFlexContainer(paparazzi.context, direction)
 
-  override fun widget(text: String, modifier: Modifier) = object : Widget<View> {
+  override fun widget(text: String, modifier: Modifier) = object : Text<View> {
     override val value = TextView(paparazzi.context).apply {
       background = ColorDrawable(Color.GREEN)
       textSize = 18f
       setTextColor(Color.BLACK)
       this.text = text
     }
+
     override var modifier = modifier
+
+    override fun text(text: String) {
+      value.text = text
+    }
   }
 
   override fun verifySnapshot(container: TestFlexContainer<View>, name: String?) {

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[LTR]_initial.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[LTR]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[LTR]_updated.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[LTR]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4028fb3dceb398db0c4d4737b31be4cf5e59f3aab1764df855d31c4b71114eb
+size 6031

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[RTL]_initial.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[RTL]_initial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7b23860374332b0cf8faf7798618f3adef6ac515e807c88c53703d79b060f8
+size 3584

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[RTL]_updated.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_childWithUpdatedProperty[RTL]_updated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f4862c29b07f05b59d0e362f1ae23a8db2374932dac3249805067edda1bdfda
+size 6065


### PR DESCRIPTION
Follow up to https://github.com/cashapp/redwood/pull/1352#issuecomment-1652688440.

Interestingly, commenting out `markDirtyAndPropogateDownwards` as I did in the aforementioned PR only fails the `redwood-layout-view` tests, but not those of `redwood-layout-composeui`.