### PR TITLE
Remove protocol dependency from widget

### DIFF
--- a/redwood-widget/build.gradle
+++ b/redwood-widget/build.gradle
@@ -15,7 +15,6 @@ kotlin {
     commonMain {
       kotlin.srcDir(ComposeHelpers.get(tasks, 'app.cash.redwood.widget'))
       dependencies {
-        api projects.redwoodProtocol
         api projects.redwoodRuntime
       }
     }


### PR DESCRIPTION
Not sure when this was added, but the base widget interface should know nothing about the protocol.