### PR TITLE
Support custom version or coordinates for Compose compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ allprojects {
       }
     }
     android.composeOptions {
-      kotlinCompilerExtensionVersion libs.versions.androidxComposeCompiler.get()
+      kotlinCompilerExtensionVersion libs.androidx.compose.compiler.get().version
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 kotlin = "1.8.22"
 kotlinx-coroutines = "1.7.3"
 kotlinx-serialization = "1.5.1"
-androidxComposeCompiler = "1.4.5"
 androidx-activity = "1.7.2"
 jbCompose = "1.4.3"
 lint = "31.1.0"
@@ -35,6 +34,7 @@ buildConfigPlugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx.activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx.activity" }
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version = "1.6.1" }
+androidx-compose-compiler = "androidx.compose.compiler:compiler:1.4.5"
 androidx-core = { module = "androidx.core:core-ktx", version = "1.10.1" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.3.1" }
 androidx-swipeRefreshLayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -43,8 +43,8 @@ gradlePlugin {
     redwood {
       id = "app.cash.redwood"
       displayName = "Redwood"
-      description = "Redwood client Gradle plugin"
-      implementationClass = "app.cash.redwood.gradle.RedwoodPlugin"
+      description = "Redwood Compose Gradle plugin"
+      implementationClass = "app.cash.redwood.gradle.RedwoodComposePlugin"
     }
     redwoodLint {
       id = "app.cash.redwood.lint"
@@ -121,8 +121,6 @@ buildConfig {
   }
 
   packageName('app.cash.redwood.gradle')
-  buildConfigField("String", "composeCompilerGroupId", "\"${libs.jetbrains.compose.compiler.get().module.group}\"")
-  buildConfigField("String", "composeCompilerArtifactId", "\"${libs.jetbrains.compose.compiler.get().module.name}\"")
   buildConfigField("String", "composeCompilerVersion", "\"${libs.jetbrains.compose.compiler.get().version}\"")
   buildConfigField("String", "redwoodVersion", "\"${project.version}\"")
 }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodComposeExtension.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodComposeExtension.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.gradle
+
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+
+public abstract class RedwoodComposeExtension
+@Inject constructor(objectFactory: ObjectFactory) {
+  /**
+   * The version of the JetBrains Compose compiler to use, or a Maven coordinate triple of
+   * the custom Compose compiler to use.
+   *
+   * Example: using a custom version of the JetBrains Compose compiler
+   * ```kotlin
+   * redwood {
+   *   kotlinCompilerPlugin.set("1.4.8")
+   * }
+   * ```
+   *
+   * Example: using a custom Maven coordinate for the Compose compiler
+   * ```kotlin
+   * redwood {
+   *   kotlinCompilerPlugin.set("com.example:custom-compose-compiler:1.0.0")
+   * }
+   * ```
+   */
+  public val kotlinCompilerPlugin: Property<String> =
+    objectFactory.property(String::class.java)
+      .convention(composeCompilerVersion)
+}

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
@@ -62,7 +62,7 @@ public abstract class RedwoodGeneratorPlugin(
 
   override fun apply(project: Project) {
     if (strategy == Compose) {
-      project.plugins.apply(RedwoodPlugin::class.java)
+      project.plugins.apply(RedwoodComposePlugin::class.java)
     }
     if (strategy == ComposeProtocol || strategy == WidgetProtocol) {
       project.plugins.apply("org.jetbrains.kotlin.plugin.serialization")

--- a/redwood-gradle-plugin/src/test/fixture/custom-compiler-coordinates/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/custom-compiler-coordinates/build.gradle
@@ -1,0 +1,30 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
+    classpath libs.kotlin.gradlePlugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.redwood'
+
+redwood {
+  // Use the AndroidX Compose compiler instead of JetBrains Compose compiler.
+  kotlinCompilerPlugin = libs.androidx.compose.compiler.get().toString()
+}
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/redwood-gradle-plugin/src/test/fixture/custom-compiler-coordinates/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/custom-compiler-coordinates/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/fixture/custom-compiler-invalid/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/custom-compiler-invalid/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
+    classpath libs.kotlin.gradlePlugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.redwood'
+
+redwood {
+  kotlinCompilerPlugin = 'wrong:format'
+}
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/redwood-gradle-plugin/src/test/fixture/custom-compiler-invalid/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/custom-compiler-invalid/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/fixture/custom-compiler-version/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/custom-compiler-version/build.gradle
@@ -1,0 +1,36 @@
+buildscript {
+  ext.kotlinVersion = '1.8.20'
+
+  dependencies {
+    classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+if (kotlinVersion == libs.kotlin.gradlePlugin.get().version) {
+  throw RuntimeException("This test requires a different version of Kotlin then the Redwood build")
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.redwood'
+
+redwood {
+  // Use the JetBrains Compose compiler version for the version of Kotlin used by this project.
+  kotlinCompilerPlugin = '1.4.8'
+}
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/redwood-gradle-plugin/src/test/fixture/custom-compiler-version/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/custom-compiler-version/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
+++ b/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
@@ -179,6 +179,28 @@ class FixtureTest {
     fixtureGradleRunner(fixtureDir).build()
   }
 
+  @Test fun customCompilerCoordinates() {
+    val fixtureDir = File("src/test/fixture/custom-compiler-coordinates")
+    fixtureGradleRunner(fixtureDir).build()
+  }
+
+  @Test fun customCompilerInvalid() {
+    val fixtureDir = File("src/test/fixture/custom-compiler-invalid")
+    val result = fixtureGradleRunner(fixtureDir).buildAndFail()
+    assertThat(result.output).contains(
+      """
+      |Illegal format of 'redwood.kotlinCompilerPlugin' property.
+      |Expected format: either '<VERSION>' or '<GROUP_ID>:<ARTIFACT_ID>:<VERSION>'
+      |Actual value: 'wrong:format'
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun customCompilerVersion() {
+    val fixtureDir = File("src/test/fixture/custom-compiler-version")
+    fixtureGradleRunner(fixtureDir).build()
+  }
+
   private fun fixtureGradleRunner(
     fixtureDir: File,
     vararg tasks: String = arrayOf("clean", "build"),


### PR DESCRIPTION
Since this project does not build a Kotlin compiler plugin, we should not be forced to do a release for new versions of Kotlin. This property will allow consumers to upgrade thier Kotlin version by specifying a newer JetBrains Compose compiler version, or a totally different set of Maven coordiantes for a custom Compose compiler aritfact.

Closes #1364