### PR TITLE
Match `@Composable` annotation presence on actuals

### DIFF
--- a/redwood-treehouse-composeui-insets/src/iosMain/kotlin/app/cash/redwood/treehouse/composeui/insets.kt
+++ b/redwood-treehouse-composeui-insets/src/iosMain/kotlin/app/cash/redwood/treehouse/composeui/insets.kt
@@ -15,12 +15,14 @@
  */
 package app.cash.redwood.treehouse.composeui
 
+import androidx.compose.runtime.Composable
 import app.cash.redwood.ui.Default
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import kotlinx.cinterop.useContents
 import platform.UIKit.UIApplication
 
+@Composable
 public actual fun safeAreaInsets(): Margin {
   val keyWindow = UIApplication.sharedApplication.keyWindow ?: return Margin.Zero
   return keyWindow.safeAreaInsets.useContents {

--- a/redwood-treehouse-composeui-insets/src/macosMain/kotlin/app/cash/redwood/treehouse/composeui/insets.kt
+++ b/redwood-treehouse-composeui-insets/src/macosMain/kotlin/app/cash/redwood/treehouse/composeui/insets.kt
@@ -15,12 +15,14 @@
  */
 package app.cash.redwood.treehouse.composeui
 
+import androidx.compose.runtime.Composable
 import app.cash.redwood.ui.Default
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import kotlinx.cinterop.useContents
 import platform.AppKit.NSScreen
 
+@Composable
 public actual fun safeAreaInsets(): Margin {
   val mainScreen = NSScreen.mainScreen ?: return Margin.Zero
   return mainScreen.safeAreaInsets.useContents {


### PR DESCRIPTION
It is on the expect, it should be on the actual. A forthcoming Compose compiler plugin will validate this, so might as well do it now.

Extracted from #1369 