### PR TITLE
Abstract away `Row` and `Column` child aligning behind `FlexContainer`

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -98,11 +98,11 @@ class ComposeUiFlexContainerTest(
     }
 
     override fun crossAxisAlignment(crossAxisAlignment: CrossAxisAlignment) {
-      delegate.alignItems(crossAxisAlignment.toAlignItems())
+      delegate.crossAxisAlignment(crossAxisAlignment)
     }
 
     override fun mainAxisAlignment(mainAxisAlignment: MainAxisAlignment) {
-      delegate.justifyContent(mainAxisAlignment.toJustifyContent())
+      delegate.mainAxisAlignment(mainAxisAlignment)
     }
 
     override fun margin(margin: Margin) {

--- a/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainer.kt
+++ b/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainer.kt
@@ -41,22 +41,19 @@ import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
-import app.cash.redwood.layout.widget.Column
-import app.cash.redwood.layout.widget.Row
+import app.cash.redwood.layout.widget.FlexContainer
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
-import app.cash.redwood.yoga.AlignItems
 import app.cash.redwood.yoga.Direction
 import app.cash.redwood.yoga.FlexDirection
-import app.cash.redwood.yoga.JustifyContent
 import app.cash.redwood.yoga.Node
 import app.cash.redwood.yoga.Size
 import app.cash.redwood.yoga.isHorizontal
 
 internal class ComposeUiFlexContainer(
   private val flexDirection: FlexDirection,
-) : Row<@Composable () -> Unit>, Column<@Composable () -> Unit> {
+) : FlexContainer<@Composable () -> Unit> {
   private val rootNode = Node().apply {
     flexDirection = this@ComposeUiFlexContainer.flexDirection
   }
@@ -88,29 +85,13 @@ internal class ComposeUiFlexContainer(
     this.overflow = overflow
   }
 
-  override fun horizontalAlignment(horizontalAlignment: MainAxisAlignment) {
-    justifyContent(horizontalAlignment.toJustifyContent())
-  }
-
-  override fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) {
-    alignItems(horizontalAlignment.toAlignItems())
-  }
-
-  override fun verticalAlignment(verticalAlignment: MainAxisAlignment) {
-    justifyContent(verticalAlignment.toJustifyContent())
-  }
-
-  override fun verticalAlignment(verticalAlignment: CrossAxisAlignment) {
-    alignItems(verticalAlignment.toAlignItems())
-  }
-
-  fun alignItems(alignItems: AlignItems) {
-    rootNode.alignItems = alignItems
+  override fun crossAxisAlignment(crossAxisAlignment: CrossAxisAlignment) {
+    rootNode.alignItems = crossAxisAlignment.toAlignItems()
     invalidate()
   }
 
-  fun justifyContent(justifyContent: JustifyContent) {
-    rootNode.justifyContent = justifyContent
+  override fun mainAxisAlignment(mainAxisAlignment: MainAxisAlignment) {
+    rootNode.justifyContent = mainAxisAlignment.toJustifyContent()
     invalidate()
   }
 

--- a/redwood-layout-dom/src/main/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
+++ b/redwood-layout-dom/src/main/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
@@ -21,6 +21,7 @@ import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.widget.Column
+import app.cash.redwood.layout.widget.FlexContainer
 import app.cash.redwood.layout.widget.RedwoodLayoutWidgetFactory
 import app.cash.redwood.layout.widget.Row
 import app.cash.redwood.layout.widget.Spacer
@@ -58,7 +59,7 @@ private class HTMLFlexContainer(
   override val value: HTMLDivElement,
   direction: String,
   private val overflowSetter: HTMLDivElement.(String) -> Unit,
-) : Row<HTMLElement>, Column<HTMLElement> {
+) : FlexContainer<HTMLElement> {
   init {
     value.style.display = "flex"
     value.style.flexDirection = direction
@@ -87,20 +88,12 @@ private class HTMLFlexContainer(
     value.overflowSetter(overflow.toCss())
   }
 
-  override fun horizontalAlignment(horizontalAlignment: MainAxisAlignment) {
-    value.style.justifyContent = horizontalAlignment.toCss()
+  override fun crossAxisAlignment(crossAxisAlignment: CrossAxisAlignment) {
+    value.style.alignItems = crossAxisAlignment.toCss()
   }
 
-  override fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) {
-    value.style.alignItems = horizontalAlignment.toCss()
-  }
-
-  override fun verticalAlignment(verticalAlignment: MainAxisAlignment) {
-    value.style.justifyContent = verticalAlignment.toCss()
-  }
-
-  override fun verticalAlignment(verticalAlignment: CrossAxisAlignment) {
-    value.style.alignItems = verticalAlignment.toCss()
+  override fun mainAxisAlignment(mainAxisAlignment: MainAxisAlignment) {
+    value.style.justifyContent = mainAxisAlignment.toCss()
   }
 
   override var modifier: Modifier = Modifier

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -20,16 +20,13 @@ import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
-import app.cash.redwood.layout.widget.Column
-import app.cash.redwood.layout.widget.Row
+import app.cash.redwood.layout.widget.FlexContainer
 import app.cash.redwood.ui.Default
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.UIViewChildren
-import app.cash.redwood.yoga.AlignItems
 import app.cash.redwood.yoga.FlexDirection
-import app.cash.redwood.yoga.JustifyContent
 import app.cash.redwood.yoga.Node
 import kotlinx.cinterop.convert
 import platform.UIKit.UIView
@@ -37,7 +34,7 @@ import platform.darwin.NSInteger
 
 internal class UIViewFlexContainer(
   private val direction: FlexDirection,
-) : Row<UIView>, Column<UIView>, ChangeListener {
+) : FlexContainer<UIView>, ChangeListener {
   private val yogaView = YogaUIView()
   override val value: UIView get() = yogaView
   override val children = UIViewChildren(
@@ -85,28 +82,12 @@ internal class UIViewFlexContainer(
     yogaView.scrollEnabled = overflow == Overflow.Scroll
   }
 
-  override fun horizontalAlignment(horizontalAlignment: MainAxisAlignment) {
-    justifyContent(horizontalAlignment.toJustifyContent())
+  override fun crossAxisAlignment(crossAxisAlignment: CrossAxisAlignment) {
+    yogaView.rootNode.alignItems = crossAxisAlignment.toAlignItems()
   }
 
-  override fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) {
-    alignItems(horizontalAlignment.toAlignItems())
-  }
-
-  override fun verticalAlignment(verticalAlignment: MainAxisAlignment) {
-    justifyContent(verticalAlignment.toJustifyContent())
-  }
-
-  override fun verticalAlignment(verticalAlignment: CrossAxisAlignment) {
-    alignItems(verticalAlignment.toAlignItems())
-  }
-
-  private fun alignItems(alignItems: AlignItems) {
-    yogaView.rootNode.alignItems = alignItems
-  }
-
-  private fun justifyContent(justifyContent: JustifyContent) {
-    yogaView.rootNode.justifyContent = justifyContent
+  override fun mainAxisAlignment(mainAxisAlignment: MainAxisAlignment) {
+    yogaView.rootNode.justifyContent = mainAxisAlignment.toJustifyContent()
   }
 
   override fun onEndChanges() {

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
@@ -30,23 +30,20 @@ import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
-import app.cash.redwood.layout.widget.Column
-import app.cash.redwood.layout.widget.Row
+import app.cash.redwood.layout.widget.FlexContainer
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.ViewGroupChildren
-import app.cash.redwood.yoga.AlignItems
 import app.cash.redwood.yoga.Direction
 import app.cash.redwood.yoga.FlexDirection
-import app.cash.redwood.yoga.JustifyContent
 import app.cash.redwood.yoga.Node
 import app.cash.redwood.yoga.isHorizontal
 
 internal class ViewFlexContainer(
   private val context: Context,
   private val direction: FlexDirection,
-) : Row<View>, Column<View>, ChangeListener {
+) : FlexContainer<View>, ChangeListener {
   private val yogaLayout = YogaLayout(context)
   private val density = Density(context.resources)
 
@@ -110,28 +107,12 @@ internal class ViewFlexContainer(
     }
   }
 
-  override fun horizontalAlignment(horizontalAlignment: MainAxisAlignment) {
-    justifyContent(horizontalAlignment.toJustifyContent())
+  override fun crossAxisAlignment(crossAxisAlignment: CrossAxisAlignment) {
+    yogaLayout.rootNode.alignItems = crossAxisAlignment.toAlignItems()
   }
 
-  override fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) {
-    alignItems(horizontalAlignment.toAlignItems())
-  }
-
-  override fun verticalAlignment(verticalAlignment: MainAxisAlignment) {
-    justifyContent(verticalAlignment.toJustifyContent())
-  }
-
-  override fun verticalAlignment(verticalAlignment: CrossAxisAlignment) {
-    alignItems(verticalAlignment.toAlignItems())
-  }
-
-  fun alignItems(alignItems: AlignItems) {
-    yogaLayout.rootNode.alignItems = alignItems
-  }
-
-  fun justifyContent(justifyContent: JustifyContent) {
-    yogaLayout.rootNode.justifyContent = justifyContent
+  override fun mainAxisAlignment(mainAxisAlignment: MainAxisAlignment) {
+    yogaLayout.rootNode.justifyContent = mainAxisAlignment.toJustifyContent()
   }
 
   override fun onEndChanges() {

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -91,11 +91,11 @@ class ViewFlexContainerTest(
     }
 
     override fun crossAxisAlignment(crossAxisAlignment: CrossAxisAlignment) {
-      delegate.alignItems(crossAxisAlignment.toAlignItems())
+      delegate.crossAxisAlignment(crossAxisAlignment)
     }
 
     override fun mainAxisAlignment(mainAxisAlignment: MainAxisAlignment) {
-      delegate.justifyContent(mainAxisAlignment.toJustifyContent())
+      delegate.mainAxisAlignment(mainAxisAlignment)
     }
 
     override fun margin(margin: Margin) {

--- a/redwood-layout-widget/src/commonMain/kotlin/app/cash/redwood/layout/widget/FlexContainer.kt
+++ b/redwood-layout-widget/src/commonMain/kotlin/app/cash/redwood/layout/widget/FlexContainer.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.widget
+
+import app.cash.redwood.layout.api.CrossAxisAlignment
+import app.cash.redwood.layout.api.MainAxisAlignment
+
+public interface FlexContainer<W : Any> : Row<W>, Column<W> {
+  override fun horizontalAlignment(horizontalAlignment: MainAxisAlignment) {
+    mainAxisAlignment(horizontalAlignment)
+  }
+
+  override fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) {
+    crossAxisAlignment(horizontalAlignment)
+  }
+
+  override fun verticalAlignment(verticalAlignment: MainAxisAlignment) {
+    mainAxisAlignment(verticalAlignment)
+  }
+
+  override fun verticalAlignment(verticalAlignment: CrossAxisAlignment) {
+    crossAxisAlignment(verticalAlignment)
+  }
+
+  public fun crossAxisAlignment(crossAxisAlignment: CrossAxisAlignment)
+
+  public fun mainAxisAlignment(mainAxisAlignment: MainAxisAlignment)
+}


### PR DESCRIPTION
Accidentally merged https://github.com/cashapp/redwood/pull/1374 into another PR 🤦 