### PR TITLE
Make `applyModifier` private within Yoga layouts

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -35,7 +35,11 @@ import platform.darwin.NSInteger
 internal class UIViewFlexContainer(
   private val direction: FlexDirection,
 ) : FlexContainer<UIView>, ChangeListener {
-  private val yogaView = YogaUIView()
+  private val yogaView: YogaUIView = YogaUIView(
+    applyModifier = { node, index ->
+      node.applyModifier(children.widgets[index].modifier, Density.Default)
+    },
+  )
   override val value: UIView get() = yogaView
   override val children = UIViewChildren(
     value,
@@ -54,9 +58,6 @@ internal class UIViewFlexContainer(
 
   init {
     yogaView.rootNode.flexDirection = direction
-    yogaView.applyModifier = { node, index ->
-      node.applyModifier(children.widgets[index].modifier, Density.Default)
-    }
   }
 
   override fun width(width: Constraint) {

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -26,13 +26,13 @@ import platform.UIKit.UIScrollViewContentInsetAdjustmentBehavior
 import platform.UIKit.UIView
 import platform.UIKit.UIViewNoIntrinsicMetric
 
-internal class YogaUIView : UIScrollView(cValue { CGRectZero }) {
+internal class YogaUIView(
+  private val applyModifier: (Node, Int) -> Unit,
+) : UIScrollView(cValue { CGRectZero }) {
   val rootNode = Node()
 
   var width = Constraint.Wrap
   var height = Constraint.Wrap
-
-  var applyModifier: (Node, Int) -> Unit = { _, _ -> }
 
   init {
     // TODO: Support Scroll Indicators

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
@@ -44,7 +44,12 @@ internal class ViewFlexContainer(
   private val context: Context,
   private val direction: FlexDirection,
 ) : FlexContainer<View>, ChangeListener {
-  private val yogaLayout = YogaLayout(context)
+  private val yogaLayout: YogaLayout = YogaLayout(
+    context,
+    applyModifier = { node, index ->
+      node.applyModifier(children.widgets[index].modifier, density)
+    },
+  )
   private val density = Density(context.resources)
 
   private val hostView = HostView()
@@ -71,9 +76,6 @@ internal class ViewFlexContainer(
       else -> throw AssertionError()
     }
     yogaLayout.rootNode.flexDirection = direction
-    yogaLayout.applyModifier = { node, index ->
-      node.applyModifier(children.widgets[index].modifier, density)
-    }
   }
 
   override fun width(width: Constraint) {

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/YogaLayout.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/YogaLayout.kt
@@ -6,6 +6,7 @@
  */
 package app.cash.redwood.layout.view
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
@@ -13,9 +14,12 @@ import app.cash.redwood.yoga.Node
 import app.cash.redwood.yoga.Size
 import kotlin.math.roundToInt
 
-internal class YogaLayout(context: Context) : ViewGroup(context) {
+@SuppressLint("ViewConstructor")
+internal class YogaLayout(
+  context: Context,
+  private val applyModifier: (Node, Int) -> Unit,
+) : ViewGroup(context) {
   val rootNode = Node()
-  var applyModifier: (Node, Int) -> Unit = { _, _ -> }
 
   init {
     applyLayoutParams(rootNode, layoutParams)


### PR DESCRIPTION
Moving it to the constructor removes the ability for accidental `applyModifier` no-op invocations to occur.