### PR TITLE
Only measure `UIViewLazyList` rows when in viewport

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -39,7 +39,6 @@ import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGFloat
 import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectZero
-import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.NSIndexPath
 import platform.Foundation.classForCoder
@@ -48,7 +47,9 @@ import platform.UIKit.UICollectionViewCell
 import platform.UIKit.UICollectionViewDataSourceProtocol
 import platform.UIKit.UICollectionViewDelegateFlowLayoutProtocol
 import platform.UIKit.UICollectionViewFlowLayout
+import platform.UIKit.UICollectionViewFlowLayoutAutomaticSize
 import platform.UIKit.UICollectionViewLayout
+import platform.UIKit.UICollectionViewLayoutAttributes
 import platform.UIKit.UICollectionViewScrollDirection.UICollectionViewScrollDirectionHorizontal
 import platform.UIKit.UICollectionViewScrollDirection.UICollectionViewScrollDirectionVertical
 import platform.UIKit.UICollectionViewScrollPositionTop
@@ -64,7 +65,9 @@ import platform.darwin.NSInteger
 import platform.darwin.NSObject
 
 internal open class UIViewLazyList(
-  private var collectionViewFlowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout(),
+  private var collectionViewFlowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout().apply {
+    estimatedItemSize = UICollectionViewFlowLayoutAutomaticSize.readValue()
+  },
   internal val collectionView: UICollectionView = UICollectionView(
     CGRectZero.readValue(),
     collectionViewFlowLayout,
@@ -95,6 +98,9 @@ internal open class UIViewLazyList(
           forIndexPath = cellForItemAtIndexPath,
         ) as LazyListContainerCell
 
+        cell.collectionView = collectionView
+        cell.collectionViewFlowLayout = collectionViewFlowLayout
+
         val widget = items.itemForGlobalIndex(cellForItemAtIndexPath.item.toInt())
         cell.set(widget.value)
 
@@ -104,20 +110,6 @@ internal open class UIViewLazyList(
 
   private val collectionViewDelegate: UICollectionViewDelegateFlowLayoutProtocol =
     object : NSObject(), UICollectionViewDelegateFlowLayoutProtocol {
-      override fun collectionView(
-        collectionView: UICollectionView,
-        layout: UICollectionViewLayout,
-        sizeForItemAtIndexPath: NSIndexPath,
-      ): CValue<CGSize> {
-        val widget = items.itemForGlobalIndex(sizeForItemAtIndexPath.item.toInt())
-        val itemSize = widget.value.sizeThatFits(collectionView.frame().useContents { size.readValue() })
-        return if (collectionViewFlowLayout.scrollDirection == UICollectionViewScrollDirectionVertical) {
-          CGSizeMake(collectionView.frame().useContents { size.width }, itemSize.useContents { height })
-        } else {
-          CGSizeMake(itemSize.useContents { width }, collectionView.frame().useContents { size.height })
-        }
-      }
-
       override fun collectionView(
         collectionView: UICollectionView,
         layout: UICollectionViewLayout,
@@ -196,6 +188,8 @@ internal open class UIViewLazyList(
 private const val reuseIdentifier = "LazyListContainerCell"
 
 private class LazyListContainerCell(frame: CValue<CGRect>) : UICollectionViewCell(frame) {
+  lateinit var collectionView: UICollectionView
+  lateinit var collectionViewFlowLayout: UICollectionViewFlowLayout
 
   private var widgetView: UIView? = null
   override fun initWithFrame(frame: CValue<CGRect>): UICollectionViewCell = LazyListContainerCell(frame)
@@ -217,6 +211,19 @@ private class LazyListContainerCell(frame: CValue<CGRect>) : UICollectionViewCel
   override fun layoutSubviews() {
     super.layoutSubviews()
     widgetView?.setFrame(this.contentView.bounds)
+  }
+
+  override fun preferredLayoutAttributesFittingAttributes(
+    layoutAttributes: UICollectionViewLayoutAttributes,
+  ): UICollectionViewLayoutAttributes {
+    val itemSize = widgetView!!.sizeThatFits(collectionView.frame.useContents { size.readValue() })
+    return layoutAttributes.apply {
+      size = if (collectionViewFlowLayout.scrollDirection == UICollectionViewScrollDirectionVertical) {
+        CGSizeMake(collectionView.frame.useContents { size.width }, itemSize.useContents { height })
+      } else {
+        CGSizeMake(itemSize.useContents { width }, collectionView.frame.useContents { size.height })
+      }
+    }
   }
 }
 

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -98,7 +98,7 @@ internal open class UIViewLazyList(
           forIndexPath = cellForItemAtIndexPath,
         ) as LazyListContainerCell
 
-        cell.collectionView = collectionView
+        cell.collectionViewFrame = collectionView.frame
         cell.collectionViewFlowLayout = collectionViewFlowLayout
 
         val widget = items.itemForGlobalIndex(cellForItemAtIndexPath.item.toInt())
@@ -188,7 +188,7 @@ internal open class UIViewLazyList(
 private const val reuseIdentifier = "LazyListContainerCell"
 
 private class LazyListContainerCell(frame: CValue<CGRect>) : UICollectionViewCell(frame) {
-  lateinit var collectionView: UICollectionView
+  lateinit var collectionViewFrame: CValue<CGRect>
   lateinit var collectionViewFlowLayout: UICollectionViewFlowLayout
 
   private var widgetView: UIView? = null
@@ -216,12 +216,12 @@ private class LazyListContainerCell(frame: CValue<CGRect>) : UICollectionViewCel
   override fun preferredLayoutAttributesFittingAttributes(
     layoutAttributes: UICollectionViewLayoutAttributes,
   ): UICollectionViewLayoutAttributes {
-    val itemSize = widgetView!!.sizeThatFits(collectionView.frame.useContents { size.readValue() })
+    val itemSize = widgetView!!.sizeThatFits(collectionViewFrame.useContents { size.readValue() })
     return layoutAttributes.apply {
       size = if (collectionViewFlowLayout.scrollDirection == UICollectionViewScrollDirectionVertical) {
-        CGSizeMake(collectionView.frame.useContents { size.width }, itemSize.useContents { height })
+        CGSizeMake(collectionViewFrame.useContents { size.width }, itemSize.useContents { height })
       } else {
-        CGSizeMake(itemSize.useContents { width }, collectionView.frame.useContents { size.height })
+        CGSizeMake(itemSize.useContents { width }, collectionViewFrame.useContents { size.height })
       }
     }
   }


### PR DESCRIPTION
### Before

On load, `UICollectionViewFlowLayout` will ask **EVERY** row for its size, regardless of whether its in the viewport or not. On every scroll event, `UICollectionViewFlowLayout` will _again_ ask **EVERY** row for its size.

In the case of Emoji Search (which has 1877 rows/emojis), all 1877 rows have their item size recalculated on initial load/ scroll.

https://github.com/cashapp/redwood/assets/6900601/529fd97f-83f4-4f48-8d52-d7e6d9075e04

### After

On load, `UICollectionViewFlowLayout` will ask the rows **within the viewport** for their size, and guess the sizes of the other rows. On every scroll event, `UICollectionViewFlowLayout` will _again_ the rows **within the viewport** for their size.

In the case of Emoji Search (which has 1877 rows/emojis), about 12 rows have their item size recalculated on initial load/ scroll.

https://github.com/cashapp/redwood/assets/6900601/5d1e8bfb-79f4-4d23-b3eb-d175d5f92a66

The only con of this new approach, is that the scroll bar doesn't always scroll smoothly (as it doesn't if its estimated row heights for the rows off screen is correct). This is a completely fine trade-off IMO, particularly given the HUGE performance improvements we receive.