### PR TITLE
Convert public API data classes to Poko

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ buildscript {
     mavenCentral()
     google()
     gradlePluginPortal()
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
     classpath libs.buildConfigPlugin
     classpath libs.zipline.gradlePlugin
     classpath libs.paparazzi.gradlePlugin
+    classpath libs.poko.gradlePlugin
     classpath 'app.cash.redwood.build:gradle-plugin'
     classpath 'app.cash.redwood:redwood-gradle-plugin'
   }
@@ -22,6 +23,7 @@ buildscript {
     mavenCentral()
     google()
     gradlePluginPortal()
+    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,6 @@ coil-core = { module = "io.coil-kt:coil", version.ref = "coil" }
 turbine = "app.cash.turbine:turbine:1.0.0"
 ktlint = "com.pinterest:ktlint:0.50.0"
 googleJavaFormat = "com.google.googlejavaformat:google-java-format:1.17.0"
-poko-gradlePlugin = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.0-SNAPSHOT"
+poko-gradlePlugin = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.0"
 
 lint-core = { module = "com.android.tools.lint:lint", version.ref = "lint" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,5 +74,6 @@ coil-core = { module = "io.coil-kt:coil", version.ref = "coil" }
 turbine = "app.cash.turbine:turbine:1.0.0"
 ktlint = "com.pinterest:ktlint:0.50.0"
 googleJavaFormat = "com.google.googlejavaformat:google-java-format:1.17.0"
+poko-gradlePlugin = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.0-SNAPSHOT"
 
 lint-core = { module = "com.android.tools.lint:lint", version.ref = "lint" }

--- a/redwood-lazylayout-api/build.gradle
+++ b/redwood-lazylayout-api/build.gradle
@@ -2,6 +2,7 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
+apply plugin: 'dev.drewhamilton.poko'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/lazylayout/api/properties.kt
+++ b/redwood-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/lazylayout/api/properties.kt
@@ -16,13 +16,15 @@
 package app.cash.redwood.lazylayout.api
 
 import androidx.compose.runtime.Immutable
+import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.Serializable
 
 /**
  * @param id Should only be used to trigger recompositions.
  */
 @[Immutable Serializable]
-public data class ScrollItemIndex(
+@Poko
+public class ScrollItemIndex(
   @Suppress("unused") private val id: Int,
   public val index: Int,
 )

--- a/redwood-protocol/build.gradle
+++ b/redwood-protocol/build.gradle
@@ -2,6 +2,7 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
+apply plugin: 'dev.drewhamilton.poko'
 
 redwoodBuild {
   publishing()

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.protocol
 
+import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -32,12 +33,13 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
-public data class Event(
+@Poko
+public class Event(
   /** Identifier for the widget from which this event originated. */
-  val id: Id,
+  public val id: Id,
   /** Identifies which event occurred on the widget with [id]. */
-  val tag: EventTag,
-  val args: List<JsonElement> = emptyList(),
+  public val tag: EventTag,
+  public val args: List<JsonElement> = emptyList(),
 )
 
 @Serializable
@@ -48,33 +50,37 @@ public sealed interface Change {
 
 @Serializable
 @SerialName("create")
-public data class Create(
+@Poko
+public class Create(
   override val id: Id,
-  val tag: WidgetTag,
+  public val tag: WidgetTag,
 ) : Change
 
 public sealed interface ValueChange : Change
 
 @Serializable
 @SerialName("property")
-public data class PropertyChange(
+@Poko
+public class PropertyChange(
   override val id: Id,
   /** Identifies which property changed on the widget with [id]. */
-  val tag: PropertyTag,
-  val value: JsonElement = JsonNull,
+  public val tag: PropertyTag,
+  public val value: JsonElement = JsonNull,
 ) : ValueChange
 
 @Serializable
 @SerialName("modifier")
-public data class ModifierChange(
+@Poko
+public class ModifierChange(
   override val id: Id,
-  val elements: List<ModifierElement> = emptyList(),
+  public val elements: List<ModifierElement> = emptyList(),
 ) : ValueChange
 
 @Serializable(with = ModifierElementSerializer::class)
-public data class ModifierElement(
-  val tag: ModifierTag,
-  val value: JsonElement = DefaultValue,
+@Poko
+public class ModifierElement(
+  public val tag: ModifierTag,
+  public val value: JsonElement = DefaultValue,
 ) {
   internal companion object {
     val DefaultValue get() = JsonNull
@@ -118,31 +124,34 @@ public sealed interface ChildrenChange : Change {
 
   @Serializable
   @SerialName("add")
-  public data class Add(
+  @Poko
+  public class Add(
     override val id: Id,
     override val tag: ChildrenTag,
-    val childId: Id,
-    val index: Int,
+    public val childId: Id,
+    public val index: Int,
   ) : ChildrenChange
 
   @Serializable
   @SerialName("move")
-  public data class Move(
+  @Poko
+  public class Move(
     override val id: Id,
     override val tag: ChildrenTag,
-    val fromIndex: Int,
-    val toIndex: Int,
-    val count: Int,
+    public val fromIndex: Int,
+    public val toIndex: Int,
+    public val count: Int,
   ) : ChildrenChange
 
   @Serializable
   @SerialName("remove")
-  public data class Remove(
+  @Poko
+  public class Remove(
     override val id: Id,
     override val tag: ChildrenTag,
-    val index: Int,
-    val count: Int,
-    val removedIds: List<Id>,
+    public val index: Int,
+    public val count: Int,
+    public val removedIds: List<Id>,
   ) : ChildrenChange {
     init {
       require(count == removedIds.size) {

--- a/redwood-runtime/build.gradle
+++ b/redwood-runtime/build.gradle
@@ -3,6 +3,7 @@ import app.cash.redwood.buildsupport.KmpTargets
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.android.library'
+apply plugin: 'dev.drewhamilton.poko'
 
 redwoodBuild {
   composeCompiler()

--- a/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/Margin.kt
+++ b/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/Margin.kt
@@ -17,14 +17,16 @@ package app.cash.redwood.ui
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.Serializable
 
 @[Immutable Serializable]
-public data class Margin(
-  val start: Dp = 0.dp,
-  val end: Dp = 0.dp,
-  val top: Dp = 0.dp,
-  val bottom: Dp = 0.dp,
+@Poko
+public class Margin(
+  public val start: Dp = 0.dp,
+  public val end: Dp = 0.dp,
+  public val top: Dp = 0.dp,
+  public val bottom: Dp = 0.dp,
 ) {
 
   override fun toString(): String = when {

--- a/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/UiConfiguration.kt
+++ b/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/UiConfiguration.kt
@@ -15,12 +15,14 @@
  */
 package app.cash.redwood.ui
 
+import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.Serializable
 
 @Serializable
-public data class UiConfiguration(
-  val darkMode: Boolean = false,
-  val safeAreaInsets: Margin = Margin.Zero,
+@Poko
+public class UiConfiguration(
+  public val darkMode: Boolean = false,
+  public val safeAreaInsets: Margin = Margin.Zero,
 ) {
   public companion object
 }

--- a/redwood-yoga/build.gradle
+++ b/redwood-yoga/build.gradle
@@ -2,6 +2,7 @@ import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'kotlinx-atomicfu'
+apply plugin: 'dev.drewhamilton.poko'
 
 redwoodBuild {
   publishing()

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/measure.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/measure.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.yoga
 
 import app.cash.redwood.yoga.internal.Yoga
+import dev.drewhamilton.poko.Poko
 import kotlin.jvm.JvmInline
 
 public fun interface MeasureCallback {
@@ -28,9 +29,9 @@ public fun interface MeasureCallback {
   ): Size
 }
 
-public data class Size(
-  val width: Float,
-  val height: Float,
+@Poko public class Size(
+  public val width: Float,
+  public val height: Float,
 ) {
   public companion object {
     public const val Undefined: Float = Yoga.YGUndefined

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,7 @@
       "matchPackagePrefixes": [
         "androidx.compose.compiler",
         "app.cash.zipline",
+        "dev.drewhamilton.poko",
         "org.jetbrains.compose.compiler",
         "org.jetbrains.kotlin:kotlin",
       ],

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@ dependencyResolutionManagement {
   repositories {
     mavenCentral()
     google()
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
   repositories {
     mavenCentral()
     google()
+    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
   }
 }
 


### PR DESCRIPTION
Reboot of #1366. Closes #1043.

Also replaces lists in public API with arrays, which are more performant on JS.

The arrays cause problems with some of the serialization tests: lists were omitted by default; arrays are included by default because different instances of an empty array are not `equals`.

This PR half-implements a verbose solution – custom serializers for all serializable classes containing an array property. Happy to add the remaining custom serializers if this is the preferred solution. I'm hoping there's a less verbose way though.

Another option is to give these classes singleton default empty array values, but this is brittle because it's easy to write new code generation that doesn't know it should use these singletons. Also adds to the public API in a weird way.

A final option is to punt the array migration to a separate PR and just migrate to Poko with the existing lists in this PR.

Before merging:
- [x] Decide and implement preferred array solution
- [x] Update to a legit Poko release