### PR TITLE
Fix JS distribution location

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -205,7 +205,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: samples/counter/browser/build/distributions
+          FOLDER: samples/counter/browser/build/dist/js/productionExecutable
           TARGET_FOLDER: latest/counter/
           CLEAN: true
 
@@ -214,6 +214,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: samples/emoji-search/browser/build/distributions
+          FOLDER: samples/emoji-search/browser/build/dist/js/productionExecutable
           TARGET_FOLDER: latest/emoji-search/
           CLEAN: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: samples/counter/browser/build/distributions
+          FOLDER: samples/counter/browser/build/dist/js/productionExecutable
           TARGET_FOLDER: 0.x/counter/
           CLEAN: true
 
@@ -60,6 +60,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: samples/emoji-search/browser/build/distributions
+          FOLDER: samples/emoji-search/browser/build/dist/js/productionExecutable
           TARGET_FOLDER: 0.x/emoji-search/
           CLEAN: true


### PR DESCRIPTION
This was missed in the Kotlin 1.9 upgrade. Documented here: https://kotlinlang.org/docs/whatsnew19.html#changed-default-destination-of-js-production-distribution