### PR TITLE
Remove explicit declaration of JS IR compiler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-kotlin.js.compiler=ir
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/lint-android-no-kotlin/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/lint-android-no-kotlin/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/lint-android/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/lint-android/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/lint-js/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/lint-js/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/lint-jvm/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/lint-jvm/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/lint-mpp-android/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/lint-mpp-android/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/lint-mpp-no-android/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/lint-mpp-no-android/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-clean/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-clean/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-missing/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-missing/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-reference/gradle.properties
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-reference/gradle.properties
@@ -1,2 +1,1 @@
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true


### PR DESCRIPTION
It is the default as of Kotlin 1.9.