### PR TITLE
Send some logs to stderr, suppress others

### DIFF
--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
@@ -26,6 +26,9 @@ import org.jetbrains.kotlin.KtVirtualFileSourceFile
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.ERROR
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.EXCEPTION
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.LOGGING
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -102,7 +105,12 @@ public fun parseProtocolSchema(
       message: String,
       location: CompilerMessageSourceLocation?,
     ) {
-      println("$severity: $message")
+      val destination = when (severity) {
+        LOGGING -> null
+        EXCEPTION, ERROR -> System.err
+        else -> System.out
+      }
+      destination?.println(message)
     }
   }
 


### PR DESCRIPTION
This hides a noisy message at the LOGGING level when using a modular JDK:

    > Task :redwood-treehouse-host:compileReleaseKotlinAndroidZiplineApiCheck
    LOGGING: Loading modules: [java.se, jdk.accessibility, jdk.attach, jdk.compiler, jdk.dynalink, jdk.httpserver,
    jdk.incubator.concurrent, jdk.incubator.vector, jdk.jartool, jdk.javadoc, jdk.jconsole, jdk.jdi, jdk.jfr,
    jdk.jshell, jdk.jsobject, jdk.management, jdk.management.jfr, jdk.net, jdk.nio.mapmode, jdk.sctp, jdk.security.auth,
    jdk.security.jgss, jdk.unsupported, jdk.unsupported.desktop, jdk.xml.dom, java.base, java.compiler,
    java.datatransfer, java.desktop, java.xml, java.instrument, java.logging, java.management, java.management.rmi,
    java.rmi, java.naming, java.net.http, java.prefs, java.scripting, java.security.jgss, java.security.sasl, java.sql,
    java.transaction.xa, java.sql.rowset, java.xml.crypto, jdk.internal.jvmstat, jdk.zipfs, jdk.internal.opt,
    jdk.management.agent, jdk.jdwp.agent, jdk.internal.ed, jdk.internal.le]

There are very few messages of this log level in the Kotlin compiler, and they are not useful to consumers: https://github.com/search?q=repo%3AJetBrains%2Fkotlin+%22report%28LOGGING%2C+%22&type=code

Same as https://github.com/cashapp/zipline/pull/1098