### PR TITLE
Move `StateSnapshot` into Redwood

### DIFF
--- a/redwood-runtime/build.gradle
+++ b/redwood-runtime/build.gradle
@@ -17,7 +17,7 @@ kotlin {
     commonMain {
       dependencies {
         implementation libs.jetbrains.compose.runtime
-        implementation libs.kotlinx.serialization.core
+        implementation libs.kotlinx.serialization.json
       }
     }
     commonTest {

--- a/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/StateSnapshot.kt
+++ b/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/StateSnapshot.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import kotlin.jvm.JvmInline
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+
+@Serializable
+public class StateSnapshot(
+  public val content: Map<String, List<JsonElement?>>,
+) {
+  public fun toValuesMap(): Map<String, List<Any?>>? {
+    return content.mapValues { entry ->
+      entry.value.map { mutableStateOf(it.fromJsonElement()) }
+    }
+  }
+
+  public fun canBeSaved(): Boolean {
+    return try {
+      // Test if the content is serializable
+      toValuesMap()
+      true
+    } catch (t: IllegalStateException) {
+      false
+    }
+  }
+
+  @JvmInline
+  @Serializable
+  public value class Id(public val value: String?)
+}
+
+/**
+ * Supported types:
+ * String, Boolean, Int, List (of supported primitive types), Map (of supported primitive types)
+ */
+public fun Map<String, List<Any?>>.toStateSnapshot(): StateSnapshot = StateSnapshot(
+  mapValues { entry ->
+    entry.value.map { element ->
+      when (element) {
+        is MutableState<*> -> element.value.toJsonElement()
+        else -> error("unexpected type: $this")
+      }
+    }
+  },
+)
+
+private fun Any?.toJsonElement(): JsonElement {
+  return when (this) {
+    is String -> JsonPrimitive(this)
+    is List<*> -> JsonArray(map { it.toJsonElement() })
+    is JsonElement -> this
+    else -> error("unexpected type: $this")
+    // TODO: add support to Map<*, *>
+  }
+}
+
+private fun JsonElement?.fromJsonElement(): Any {
+  return when (this) {
+    is JsonPrimitive -> {
+      if (this.isString) {
+        return content
+      }
+      return booleanOrNull ?: doubleOrNull ?: error("unexpected type: $this")
+      // TODO add other primitive types (double, float, long) when needed
+    }
+
+    is JsonArray -> listOf({ this.forEach { it.toJsonElement() } })
+    // TODO: map, numbers
+    // is Map<*, *> -> JsonElement
+    else -> error("unexpected type: $this")
+  }
+}

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
@@ -15,79 +15,8 @@
  */
 package app.cash.redwood.treehouse
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import kotlin.jvm.JvmInline
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.doubleOrNull
-
-@Serializable
-public class StateSnapshot(
-  public val content: Map<String, List<JsonElement?>>,
-) {
-  public fun toValuesMap(): Map<String, List<Any?>>? {
-    return content.mapValues { entry ->
-      entry.value.map { mutableStateOf(it.fromJsonElement()) }
-    }
-  }
-
-  public fun canBeSaved(): Boolean {
-    return try {
-      // Test if the content is serializable
-      toValuesMap()
-      true
-    } catch (t: IllegalStateException) {
-      false
-    }
-  }
-
-  @JvmInline
-  @Serializable
-  public value class Id(public val value: String?)
-}
-
-/**
- * Supported types:
- * String, Boolean, Int, List (of supported primitive types), Map (of supported primitive types)
- */
-public fun Map<String, List<Any?>>.toStateSnapshot(): StateSnapshot = StateSnapshot(
-  mapValues { entry ->
-    entry.value.map { element ->
-      when (element) {
-        is MutableState<*> -> element.value.toJsonElement()
-        else -> error("unexpected type: $this")
-      }
-    }
-  },
+@Deprecated(
+  "StateSnapshot has been moved to redwood-runtime.",
+  ReplaceWith("StateSnapshot", "app.cash.redwood.StateSnapshot"),
 )
-
-private fun Any?.toJsonElement(): JsonElement {
-  return when (this) {
-    is String -> JsonPrimitive(this)
-    is List<*> -> JsonArray(map { it.toJsonElement() })
-    is JsonElement -> this
-    else -> error("unexpected type: $this")
-    // TODO: add support to Map<*, *>
-  }
-}
-
-private fun JsonElement?.fromJsonElement(): Any {
-  return when (this) {
-    is JsonPrimitive -> {
-      if (this.isString) {
-        return content
-      }
-      return booleanOrNull ?: doubleOrNull ?: error("unexpected type: $this")
-      // TODO add other primitive types (double, float, long) when needed
-    }
-
-    is JsonArray -> listOf({ this.forEach { it.toJsonElement() } })
-    // TODO: map, numbers
-    // is Map<*, *> -> JsonElement
-    else -> error("unexpected type: $this")
-  }
-}
+public typealias StateSnapshot = app.cash.redwood.StateSnapshot


### PR DESCRIPTION
`TreehouseView` depends on `StateSnapshot`. In order to introduce a `RedwoodView` that is similar to `TreehouseView` (https://github.com/cashapp/redwood/issues/1054), `StateSnapshot` needs to be moved into Redwood.