### PR TITLE
Remove unused `canBeSaved` function

### DIFF
--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
@@ -35,16 +35,6 @@ public class StateSnapshot(
     }
   }
 
-  public fun canBeSaved(): Boolean {
-    return try {
-      // Test if the content is serializable
-      toValuesMap()
-      true
-    } catch (t: IllegalStateException) {
-      false
-    }
-  }
-
   @JvmInline
   @Serializable
   public value class Id(public val value: String?)


### PR DESCRIPTION
The only usage of this function was removed in #1381.