### PR TITLE
Introduce `RedwoodView`

### DIFF
--- a/redwood-protocol-widget/build.gradle
+++ b/redwood-protocol-widget/build.gradle
@@ -15,6 +15,7 @@ kotlin {
     commonMain {
       kotlin.srcDir(ComposeHelpers.get(tasks, 'app.cash.redwood.protocol.widget'))
       dependencies {
+        api libs.kotlinx.coroutines.core
         api projects.redwoodProtocol
         api projects.redwoodWidget
       }

--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/RedwoodView.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/RedwoodView.kt
@@ -13,42 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.treehouse
+package app.cash.redwood.protocol.widget
 
-import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
-import app.cash.redwood.protocol.widget.ProtocolNode
 import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.widget.Widget
 import kotlin.native.ObjCName
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 
-@ObjCName("TreehouseView", exact = true)
-public interface TreehouseView {
+@ObjCName("RedwoodView", exact = true)
+public interface RedwoodView {
   public val children: Widget.Children<*>
   public val uiConfiguration: StateFlow<UiConfiguration>
   public val widgetSystem: WidgetSystem
   public val readyForContent: Boolean
   public var readyForContentChangeListener: ReadyForContentChangeListener?
-  public var saveCallback: SaveCallback?
-  public val stateSnapshotId: StateSnapshot.Id
 
   /** Invoked when new code is loaded. This should at minimum clear all [children]. */
   public fun reset()
 
-  @ObjCName("TreehouseViewReadyForContentChangeListener", exact = true)
+  @ObjCName("RedwoodViewReadyForContentChangeListener", exact = true)
   public fun interface ReadyForContentChangeListener {
-    /** Called when [TreehouseView.readyForContent] has changed. */
-    public fun onReadyForContentChanged(view: TreehouseView)
+    /** Called when [RedwoodView.readyForContent] has changed. */
+    public fun onReadyForContentChanged(view: RedwoodView)
   }
 
-  @ObjCName("TreehouseViewSaveCallback", exact = true)
-  public interface SaveCallback {
-    /** Called on the UI dispatcher to save the state for the current content. */
-    public fun performSave(id: String)
-  }
-
-  @ObjCName("TreehouseViewWidgetSystem", exact = true)
+  @ObjCName("RedwoodViewWidgetSystem", exact = true)
   public fun interface WidgetSystem {
     /** Returns a widget factory for encoding and decoding changes to the contents of [view]. */
     public fun widgetFactory(

--- a/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -27,14 +27,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import app.cash.redwood.protocol.widget.RedwoodView
+import app.cash.redwood.protocol.widget.RedwoodView.ReadyForContentChangeListener
+import app.cash.redwood.protocol.widget.RedwoodView.WidgetSystem
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.CodeListener
-import app.cash.redwood.treehouse.StateSnapshot
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseContentSource
-import app.cash.redwood.treehouse.TreehouseView
-import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Size
@@ -57,23 +56,21 @@ public fun <A : AppService> TreehouseContent(
     viewportSize = viewportSize,
   )
 
-  val treehouseView = remember(widgetSystem) {
-    object : TreehouseView {
+  val redwoodView = remember(widgetSystem) {
+    object : RedwoodView {
       override val children = ComposeWidgetChildren()
       override val uiConfiguration = MutableStateFlow(uiConfiguration)
       override val widgetSystem = widgetSystem
       override val readyForContent = true
       override var readyForContentChangeListener: ReadyForContentChangeListener? = null
-      override var saveCallback: TreehouseView.SaveCallback? = null
-      override val stateSnapshotId = StateSnapshot.Id(null)
       override fun reset() = children.remove(0, children.widgets.size)
     }
   }
-  LaunchedEffect(treehouseView, uiConfiguration) {
-    treehouseView.uiConfiguration.value = uiConfiguration
+  LaunchedEffect(redwoodView, uiConfiguration) {
+    redwoodView.uiConfiguration.value = uiConfiguration
   }
-  DisposableEffect(treehouseView, contentSource, codeListener) {
-    val closeable = contentSource.bindWhenReady(treehouseView, treehouseApp, codeListener)
+  DisposableEffect(redwoodView, contentSource, codeListener) {
+    val closeable = contentSource.bindWhenReady(redwoodView, treehouseApp, codeListener)
     onDispose {
       closeable.close()
     }
@@ -87,6 +84,6 @@ public fun <A : AppService> TreehouseContent(
       }
     },
   ) {
-    treehouseView.children.render()
+    redwoodView.children.render()
   }
 }

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseWidgetView.kt
@@ -26,8 +26,9 @@ import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.core.graphics.Insets
-import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.protocol.widget.RedwoodView
+import app.cash.redwood.protocol.widget.RedwoodView.ReadyForContentChangeListener
+import app.cash.redwood.protocol.widget.RedwoodView.WidgetSystem
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Size
 import app.cash.redwood.ui.UiConfiguration
@@ -41,7 +42,7 @@ import kotlinx.coroutines.flow.StateFlow
 public class TreehouseWidgetView(
   context: Context,
   override val widgetSystem: WidgetSystem,
-) : FrameLayout(context), TreehouseView {
+) : FrameLayout(context), RedwoodView, Saveable {
   override var readyForContentChangeListener: ReadyForContentChangeListener? = null
     set(value) {
       check(value == null || field == null) { "View already bound to a listener" }
@@ -58,7 +59,7 @@ public class TreehouseWidgetView(
   override var stateSnapshotId: StateSnapshot.Id = StateSnapshot.Id(null)
     private set
 
-  override var saveCallback: TreehouseView.SaveCallback? = null
+  override var saveCallback: Saveable.SaveCallback? = null
 
   private val _children = ViewGroupChildren(this)
   override val children: Widget.Children<View> get() = _children

--- a/redwood-treehouse-host/src/androidUnitTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
+++ b/redwood-treehouse-host/src/androidUnitTest/kotlin/app/cash/redwood/treehouse/TreehouseWidgetViewTest.kt
@@ -25,7 +25,7 @@ import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import app.cash.redwood.Modifier
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.protocol.widget.RedwoodView.WidgetSystem
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.UiConfiguration

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ChangeListRenderer.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ChangeListRenderer.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.protocol.SnapshotChangeList
 import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
 import app.cash.redwood.protocol.widget.ProtocolNode
+import app.cash.redwood.protocol.widget.RedwoodView
 import app.cash.redwood.widget.Widget
 import kotlinx.serialization.json.Json
 
@@ -38,7 +39,7 @@ public class ChangeListRenderer<W : Any>(
 
   @Suppress("UNCHECKED_CAST")
   public fun render(
-    view: TreehouseView,
+    view: RedwoodView,
     changeList: SnapshotChangeList,
   ) {
     view.reset()

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeListener.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeListener.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.widget.RedwoodView
 import kotlin.native.ObjCName
 
 @ObjCName("CodeListener", exact = true)
@@ -23,7 +24,7 @@ public open class CodeListener {
    * Invoked when the initial code is still loading. This can be used to signal a loading state
    * in the UI before there is anything to display.
    */
-  public open fun onInitialCodeLoading(view: TreehouseView) {}
+  public open fun onInitialCodeLoading(view: RedwoodView) {}
 
   /**
    * Invoked each time new code is loaded. This is called after the view's old children have
@@ -31,5 +32,5 @@ public open class CodeListener {
    *
    * @param initial true if this is the first code loaded for this view's current content.
    */
-  public open fun onCodeLoaded(view: TreehouseView, initial: Boolean) {}
+  public open fun onCodeLoaded(view: RedwoodView, initial: Boolean) {}
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/Content.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/Content.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.widget.RedwoodView
 import app.cash.redwood.ui.UiConfiguration
 import kotlin.native.ObjCName
 import kotlinx.coroutines.CancellationException
@@ -47,7 +48,7 @@ public interface Content {
    *
    * This function may only be invoked on [TreehouseDispatchers.ui].
    */
-  public fun bind(view: TreehouseView)
+  public fun bind(view: RedwoodView)
 
   /**
    * Suspends until content is available; either it is already in the view or it is preloaded and a call to [bind]

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ContentBinding.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ContentBinding.kt
@@ -15,17 +15,18 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
+import app.cash.redwood.protocol.widget.RedwoodView
+import app.cash.redwood.protocol.widget.RedwoodView.ReadyForContentChangeListener
 import okio.Closeable
 
 /**
  * Binds this content to [view] whenever the view is
- * [ready for content][TreehouseView.readyForContent]. The content will bind and unbind as this view
+ * [ready for content][RedwoodView.readyForContent]. The content will bind and unbind as this view
  * is attached and detached from the UI.
  *
  * Returns a closeable that unbinds from the content and stops tracking the ready state.
  */
-public fun Content.bindWhenReady(view: TreehouseView): Closeable {
+public fun Content.bindWhenReady(view: RedwoodView): Closeable {
   val listener = ReadyForContentChangeListener {
     if (view.readyForContent) {
       bind(view)
@@ -46,7 +47,7 @@ public fun Content.bindWhenReady(view: TreehouseView): Closeable {
 }
 
 public fun <A : AppService> TreehouseContentSource<A>.bindWhenReady(
-  view: TreehouseView,
+  view: RedwoodView,
   app: TreehouseApp<A>,
   codeListener: CodeListener = CodeListener(),
 ): Closeable {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/Saveable.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/Saveable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Square, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,16 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.protocol.widget.RedwoodView
-import app.cash.redwood.protocol.widget.RedwoodView.ReadyForContentChangeListener
+import kotlin.native.ObjCName
 
-class CountingReadyForContentChangeListener : ReadyForContentChangeListener {
-  var count = 0
+@ObjCName("Saveable", exact = true)
+public interface Saveable {
+  public var saveCallback: SaveCallback?
+  public val stateSnapshotId: StateSnapshot.Id
 
-  override fun onReadyForContentChanged(view: RedwoodView) {
-    count++
+  @ObjCName("SaveableSaveCallback", exact = true)
+  public interface SaveCallback {
+    /** Called on the UI dispatcher to save the state for the current content. */
+    public fun performSave(id: String)
   }
 }

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIKitView.kt
@@ -15,8 +15,9 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.protocol.widget.RedwoodView
+import app.cash.redwood.protocol.widget.RedwoodView.ReadyForContentChangeListener
+import app.cash.redwood.protocol.widget.RedwoodView.WidgetSystem
 import app.cash.redwood.ui.Default
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
@@ -39,10 +40,8 @@ import platform.UIKit.UIView
 @ObjCName("TreehouseUIKitView", exact = true)
 public class TreehouseUIKitView(
   override val widgetSystem: WidgetSystem,
-) : TreehouseView {
+) : RedwoodView {
   public val view: UIView = RootUiView(this)
-  override var saveCallback: TreehouseView.SaveCallback? = null
-  override var stateSnapshotId: StateSnapshot.Id = StateSnapshot.Id(null)
 
   override var readyForContentChangeListener: ReadyForContentChangeListener? = null
     set(value) {
@@ -107,11 +106,11 @@ private fun computeSafeAreaInsets(): Margin {
 }
 
 private class RootUiView(
-  private val treehouseView: TreehouseUIKitView,
+  private val redwoodView: TreehouseUIKitView,
 ) : UIView(cValue { CGRectZero }) {
   override fun layoutSubviews() {
     // Bounds likely changed. Report new size.
-    treehouseView.updateUiConfiguration()
+    redwoodView.updateUiConfiguration()
 
     subviews.forEach {
       (it as UIView).setFrame(bounds)
@@ -119,11 +118,11 @@ private class RootUiView(
   }
 
   override fun didMoveToSuperview() {
-    treehouseView.superviewChanged()
+    redwoodView.superviewChanged()
   }
 
   override fun traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
-    treehouseView.updateUiConfiguration()
+    redwoodView.updateUiConfiguration()
   }
 }

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIKitViewTest.kt
@@ -16,7 +16,7 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.Modifier
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.protocol.widget.RedwoodView.WidgetSystem
 import app.cash.redwood.ui.Default
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin

--- a/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
@@ -25,11 +25,11 @@ import androidx.core.view.WindowCompat
 import app.cash.redwood.compose.AndroidUiDispatcher.Companion.Main
 import app.cash.redwood.layout.composeui.ComposeUiRedwoodLayoutWidgetFactory
 import app.cash.redwood.lazylayout.composeui.ComposeUiRedwoodLazyLayoutWidgetFactory
+import app.cash.redwood.protocol.widget.RedwoodView.WidgetSystem
 import app.cash.redwood.treehouse.EventListener
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseAppFactory
 import app.cash.redwood.treehouse.TreehouseContentSource
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.composeui.TreehouseContent
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineManifest

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -23,11 +23,11 @@ import androidx.core.view.WindowCompat
 import app.cash.redwood.compose.AndroidUiDispatcher.Companion.Main
 import app.cash.redwood.layout.view.ViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.lazylayout.view.ViewRedwoodLazyLayoutWidgetFactory
+import app.cash.redwood.protocol.widget.RedwoodView
 import app.cash.redwood.treehouse.EventListener
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseAppFactory
 import app.cash.redwood.treehouse.TreehouseContentSource
-import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseWidgetView
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.zipline.Zipline
@@ -59,7 +59,7 @@ class EmojiSearchActivity : ComponentActivity() {
     val treehouseApp = createTreehouseApp()
     val treehouseContentSource = TreehouseContentSource(EmojiSearchPresenter::launch)
 
-    val widgetSystem = TreehouseView.WidgetSystem { json, protocolMismatchHandler ->
+    val widgetSystem = RedwoodView.WidgetSystem { json, protocolMismatchHandler ->
       EmojiSearchProtocolNodeFactory(
         provider = EmojiSearchWidgetFactories(
           EmojiSearch = AndroidEmojiSearchWidgetFactory(context),

--- a/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
+++ b/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
@@ -20,11 +20,11 @@ package com.example.redwood.emojisearch.ios
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.lazylayout.uiview.UIViewRedwoodLazyLayoutWidgetFactory
+import app.cash.redwood.protocol.widget.RedwoodView
+import app.cash.redwood.protocol.widget.RedwoodView.WidgetSystem
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.Content
 import app.cash.redwood.treehouse.TreehouseUIKitView
-import app.cash.redwood.treehouse.TreehouseView
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import com.example.redwood.emojisearch.widget.EmojiSearchProtocolNodeFactory
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
@@ -54,5 +54,5 @@ fun modifier(): Modifier = Modifier
 
 fun <A : AppService> bindWhenReady(
   content: Content,
-  view: TreehouseView,
+  view: RedwoodView,
 ): Closeable = content.bindWhenReady(view)

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -36,13 +36,13 @@ class EmojiSearchViewController : UIViewController {
         let emojiSearchLauncher = EmojiSearchLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
         let treehouseApp = emojiSearchLauncher.createTreehouseApp()
         let widgetSystem = EmojiSearchWidgetSystem(treehouseApp: treehouseApp)
-        let treehouseView = TreehouseUIKitView(widgetSystem: widgetSystem)
+        let redwoodView = TreehouseUIKitView(widgetSystem: widgetSystem)
         let content = treehouseApp.createContent(
             source: EmojiSearchContent(),
             codeListener: CodeListener()
         )
-        ExposedKt.bindWhenReady(content: content, view: treehouseView)
-        view = treehouseView.view
+        ExposedKt.bindWhenReady(content: content, view: redwoodView)
+        view = redwoodView.view
     }
 }
 
@@ -53,7 +53,7 @@ class EmojiSearchContent : TreehouseContentSource {
     }
 }
 
-class EmojiSearchWidgetSystem : TreehouseViewWidgetSystem {
+class EmojiSearchWidgetSystem : RedwoodViewWidgetSystem {
     let treehouseApp: TreehouseApp<EmojiSearchPresenter>
 
     init(treehouseApp: TreehouseApp<EmojiSearchPresenter>) {

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/IosEmojiSearchWidgetFactory.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/IosEmojiSearchWidgetFactory.swift
@@ -21,10 +21,10 @@ import EmojiSearchKt
 
 class IosEmojiSearchWidgetFactory<A : AnyObject>: EmojiSearchWidgetFactory {
     let treehouseApp: TreehouseApp<A>
-    let widgetSystem: TreehouseViewWidgetSystem
+    let widgetSystem: RedwoodViewWidgetSystem
     let imageLoader = RemoteImageLoader()
 
-    init(treehouseApp: TreehouseApp<A>, widgetSystem: TreehouseViewWidgetSystem) {
+    init(treehouseApp: TreehouseApp<A>, widgetSystem: RedwoodViewWidgetSystem) {
         self.treehouseApp = treehouseApp
         self.widgetSystem = widgetSystem
     }

--- a/samples/repo-search/android-views/src/main/kotlin/com/example/redwood/reposearch/android/views/RepoSearchActivity.kt
+++ b/samples/repo-search/android-views/src/main/kotlin/com/example/redwood/reposearch/android/views/RepoSearchActivity.kt
@@ -21,10 +21,10 @@ import app.cash.redwood.compose.AndroidUiDispatcher.Companion.Main
 import app.cash.redwood.layout.view.ViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.lazylayout.view.ViewRedwoodLazyLayoutWidgetFactory
 import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
+import app.cash.redwood.protocol.widget.RedwoodView
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.redwood.treehouse.TreehouseAppFactory
 import app.cash.redwood.treehouse.TreehouseContentSource
-import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseWidgetView
 import app.cash.redwood.treehouse.bindWhenReady
 import app.cash.zipline.loader.ManifestVerifier
@@ -50,7 +50,7 @@ class RepoSearchActivity : ComponentActivity() {
     val treehouseApp = createTreehouseApp()
     val treehouseContentSource = TreehouseContentSource(RepoSearchPresenter::launch)
 
-    val widgetSystem = object : TreehouseView.WidgetSystem {
+    val widgetSystem = object : RedwoodView.WidgetSystem {
       override fun widgetFactory(
         json: Json,
         protocolMismatchHandler: ProtocolMismatchHandler,


### PR DESCRIPTION
The only Treehouse specific part of `TreehouseView` was the state restoration, which has now been pulled out into a separate interface, to be implemented on all platforms that support it (currently, just Android Views).

Closes #1116.