### PR TITLE
Try to avoid the Compose compiler plugin being applied twice

### DIFF
--- a/redwood-gradle-plugin/src/test/fixture/with-android-plugin-compose-feature/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/with-android-plugin-compose-feature/build.gradle
@@ -1,0 +1,33 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
+    classpath libs.kotlin.gradlePlugin
+    classpath libs.androidGradlePlugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'app.cash.redwood'
+
+android {
+  buildFeatures {
+    compose true
+  }
+}
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/redwood-gradle-plugin/src/test/fixture/with-android-plugin-compose-feature/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/with-android-plugin-compose-feature/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/fixture/with-jetbrains-compose-plugin/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/with-jetbrains-compose-plugin/build.gradle
@@ -1,0 +1,27 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.redwood:redwood-gradle-plugin:$redwoodVersion"
+    classpath libs.kotlin.gradlePlugin
+    classpath libs.jetbrains.compose.gradlePlugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'org.jetbrains.compose'
+apply plugin: 'app.cash.redwood'
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/redwood-gradle-plugin/src/test/fixture/with-jetbrains-compose-plugin/settings.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/with-jetbrains-compose-plugin/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
+++ b/redwood-gradle-plugin/src/test/kotlin/app/cash/redwood/gradle/FixtureTest.kt
@@ -192,6 +192,22 @@ class FixtureTest {
     fixtureGradleRunner(fixtureDir).build()
   }
 
+  @Test fun withAndroidPluginComposeFeature() {
+    val fixtureDir = File("src/test/fixture/with-android-plugin-compose-feature")
+    val result = fixtureGradleRunner(fixtureDir).buildAndFail()
+    assertThat(result.output).contains(
+      "The Redwood Gradle plugin cannot be applied to an Android project which enables Compose.",
+    )
+  }
+
+  @Test fun withJetbrainsComposePlugin() {
+    val fixtureDir = File("src/test/fixture/with-jetbrains-compose-plugin")
+    val result = fixtureGradleRunner(fixtureDir).buildAndFail()
+    assertThat(result.output).contains(
+      "The Redwood Gradle plugin cannot be applied to the same project as the JetBrains Compose Gradle plugin.",
+    )
+  }
+
   private fun fixtureGradleRunner(
     fixtureDir: File,
     vararg tasks: String = arrayOf("clean", "build"),

--- a/samples/emoji-search/android-composeui/build.gradle
+++ b/samples/emoji-search/android-composeui/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'app.cash.redwood'
 
 android {
   namespace 'com.example.redwood.emojisearch.android.composeui'


### PR DESCRIPTION
This can cause errors which are hard to debug such as impossible ClassCastExceptions.