### PR TITLE
Use `RedwoodWidgetView` in Counter sample on Android

### DIFF
--- a/samples/counter/android-views/build.gradle
+++ b/samples/counter/android-views/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation projects.samples.counter.schema.widget
   implementation projects.samples.counter.presenter
   implementation projects.redwoodLayoutView
+  implementation projects.redwoodWidget
   implementation libs.kotlinx.coroutines.android
   implementation libs.google.material
   implementation libs.androidx.core

--- a/samples/counter/android-views/src/main/kotlin/com/example/redwood/counter/android/views/MainActivity.kt
+++ b/samples/counter/android-views/src/main/kotlin/com/example/redwood/counter/android/views/MainActivity.kt
@@ -16,12 +16,11 @@
 package com.example.redwood.counter.android.views
 
 import android.os.Bundle
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import app.cash.redwood.compose.AndroidUiDispatcher
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.layout.view.ViewRedwoodLayoutWidgetFactory
-import app.cash.redwood.widget.ViewGroupChildren
+import app.cash.redwood.widget.RedwoodWidgetView
 import com.example.redwood.counter.presenter.Counter
 import com.example.redwood.counter.widget.SchemaWidgetFactories
 import kotlinx.coroutines.CoroutineScope
@@ -33,10 +32,12 @@ class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val root = findViewById<ViewGroup>(android.R.id.content)!!
+    val redwoodView = RedwoodWidgetView(this)
+    setContentView(redwoodView)
+
     val composition = RedwoodComposition(
       scope = scope,
-      container = ViewGroupChildren(root),
+      container = redwoodView.children,
       provider = SchemaWidgetFactories(
         Schema = AndroidWidgetFactory(this),
         RedwoodLayout = ViewRedwoodLayoutWidgetFactory(this),


### PR DESCRIPTION
Shamelessly stole it from your comment at https://github.com/cashapp/redwood/pull/1440#discussion_r1311996740. We don't have `RedwoodView`'s for Compose UI nor the web, and the `RedwoodUIKitView` still resides in `redwood-treehouse-host`, and I don't want to add a Treehouse dependency within the Counter sample.