### PR TITLE
Rename test schema `Row` to `TestRow`

### DIFF
--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
@@ -30,8 +30,8 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
 import com.example.redwood.testing.compose.Button
-import com.example.redwood.testing.compose.Row
-import com.example.redwood.testing.compose.ScopedRow
+import com.example.redwood.testing.compose.ScopedTestRow
+import com.example.redwood.testing.compose.TestRow
 import com.example.redwood.testing.compose.TestSchemaProtocolBridge
 import com.example.redwood.testing.compose.TestScope
 import com.example.redwood.testing.compose.Text
@@ -168,10 +168,10 @@ abstract class AbstractChangeListenerTest {
   }
 
   @Test fun childrenChangeNotifiesWidget() = runTest {
-    val row = ListeningRow()
+    val row = ListeningTestRow()
     val factories = TestSchemaWidgetFactories(
       TestSchema = object : TestSchemaWidgetFactory<WidgetValue> by TestSchemaTestingWidgetFactory() {
-        override fun Row() = row
+        override fun TestRow() = row
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
       RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
@@ -180,7 +180,7 @@ abstract class AbstractChangeListenerTest {
 
     var two by mutableStateOf(false)
     c.setContent {
-      Row {
+      TestRow {
         Button("one", onClick = null)
         if (two) {
           Button("two", onClick = null)
@@ -195,10 +195,10 @@ abstract class AbstractChangeListenerTest {
   }
 
   @Test fun childrenDescendantChangeDoesNotNotifyWidget() = runTest {
-    val row = ListeningRow()
+    val row = ListeningTestRow()
     val factories = TestSchemaWidgetFactories(
       TestSchema = object : TestSchemaWidgetFactory<WidgetValue> by TestSchemaTestingWidgetFactory() {
-        override fun Row() = row
+        override fun TestRow() = row
       },
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
       RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
@@ -207,8 +207,8 @@ abstract class AbstractChangeListenerTest {
 
     var two by mutableStateOf(false)
     c.setContent {
-      Row {
-        ScopedRow {
+      TestRow {
+        ScopedTestRow {
           Button("one", onClick = null)
           if (two) {
             Button("two", onClick = null)

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
@@ -19,9 +19,9 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.testing.WidgetValue
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.Widget
-import com.example.redwood.testing.widget.Row
+import com.example.redwood.testing.widget.TestRow
 
-class ListeningRow : Row<WidgetValue>, ChangeListener {
+class ListeningTestRow : TestRow<WidgetValue>, ChangeListener {
   private val changes = ArrayList<String>()
   fun changes(): List<String> {
     val snapshot = changes.toList()

--- a/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
+++ b/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
@@ -36,7 +36,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.example.redwood.testing.compose.Button
 import com.example.redwood.testing.compose.Button2
-import com.example.redwood.testing.compose.Row
+import com.example.redwood.testing.compose.TestRow
 import com.example.redwood.testing.compose.TestSchemaProtocolBridge
 import com.example.redwood.testing.compose.Text
 import kotlin.test.Test
@@ -71,9 +71,9 @@ class ProtocolTest {
     val composition = testProtocolComposition()
 
     composition.setContent {
-      Row {
+      TestRow {
         Text("hey")
-        Row {
+        TestRow {
           Text("hello")
         }
       }

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
@@ -18,15 +18,15 @@ package app.cash.redwood.protocol.widget
 import app.cash.redwood.Modifier
 import com.example.redwood.testing.widget.Button
 import com.example.redwood.testing.widget.Button2
-import com.example.redwood.testing.widget.Row
-import com.example.redwood.testing.widget.ScopedRow
+import com.example.redwood.testing.widget.ScopedTestRow
+import com.example.redwood.testing.widget.TestRow
 import com.example.redwood.testing.widget.TestSchemaWidgetFactory
 import com.example.redwood.testing.widget.Text
 import com.example.redwood.testing.widget.TextInput
 
 open class EmptyTestSchemaWidgetFactory : TestSchemaWidgetFactory<Nothing> {
-  override fun Row(): Row<Nothing> = TODO()
-  override fun ScopedRow(): ScopedRow<Nothing> = TODO()
+  override fun TestRow(): TestRow<Nothing> = TODO()
+  override fun ScopedTestRow(): ScopedTestRow<Nothing> = TODO()
   override fun Text(): Text<Nothing> = TODO()
   override fun Button() = object : Button<Nothing> {
     override val value get() = TODO()

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
@@ -34,7 +34,7 @@ import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.widget.MutableListChildren
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.example.redwood.testing.compose.Row
+import com.example.redwood.testing.compose.TestRow
 import com.example.redwood.testing.compose.TestSchemaProtocolBridge
 import com.example.redwood.testing.compose.Text
 import com.example.redwood.testing.widget.TestSchemaProtocolNodeFactory
@@ -50,12 +50,12 @@ import kotlinx.serialization.json.JsonPrimitive
 class ViewTreesTest {
   @Test fun nested() = runTest {
     val content = @Composable {
-      Row {
-        Row {
+      TestRow {
+        TestRow {
           Text("One Fish")
           Text("Two Fish")
         }
-        Row {
+        TestRow {
           Text("Red Fish")
           Text("Blue Fish")
         }

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeProtocolGenerationTest.kt
@@ -56,7 +56,7 @@ class ComposeProtocolGenerationTest {
 
     val fileSpec = generateComposeProtocolModifierSerialization(schemaSet)
     assertThat(fileSpec.toString()).all {
-      contains("is RowVerticalAlignment -> RowVerticalAlignmentSerializer.encode(json, this)")
+      contains("is TestRowVerticalAlignment -> TestRowVerticalAlignmentSerializer.encode(json, this)")
       contains("is Grow -> GrowSerializer.encode(json, this)")
     }
   }

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
@@ -63,7 +63,7 @@ class WidgetProtocolGenerationTest {
 
     val fileSpec = generateWidgetProtocolModifierSerialization(schema)
     assertThat(fileSpec.toString()).all {
-      contains("1 -> RowVerticalAlignmentImpl.serializer()")
+      contains("1 -> TestRowVerticalAlignmentImpl.serializer()")
       contains("1_000_001 -> GrowImpl.serializer()")
     }
   }

--- a/test-app/schema/src/main/kotlin/com/example/redwood/testing/schema.kt
+++ b/test-app/schema/src/main/kotlin/com/example/redwood/testing/schema.kt
@@ -28,9 +28,9 @@ import kotlin.time.Duration
 
 @Schema(
   members = [
-    Row::class,
-    ScopedRow::class,
-    RowVerticalAlignment::class,
+    TestRow::class,
+    ScopedTestRow::class,
+    TestRowVerticalAlignment::class,
     AccessibilityDescription::class,
     CustomType::class,
     CustomTypeStateless::class,
@@ -48,16 +48,24 @@ import kotlin.time.Duration
 )
 public interface TestSchema
 
+/**
+ * A trivial row-like type for testing purposes only.
+ * Use redwood-layout for any real views in the test app.
+ */
 @Widget(1)
-public data class Row(
+public data class TestRow(
   @Children(1) val children: () -> Unit,
 )
 
-public object RowScope
+public object TestRowScope
 
+/**
+ * A trivial row-like type with a scope for testing purposes only.
+ * Use redwood-layout for any real views in the test app.
+ */
 @Widget(2)
-public data class ScopedRow(
-  @Children(1) val children: RowScope.() -> Unit,
+public data class ScopedTestRow(
+  @Children(1) val children: TestRowScope.() -> Unit,
 )
 
 @Widget(3)
@@ -91,8 +99,8 @@ public object TestScope
 
 public object SecondaryTestScope
 
-@Modifier(1, RowScope::class)
-public data class RowVerticalAlignment(
+@Modifier(1, TestRowScope::class)
+public data class TestRowVerticalAlignment(
   /** -1 for top, 0 for middle, 1 for bottom. */
   val direction: Int,
 )


### PR DESCRIPTION
This will not be implemented by the real test apps (or maybe it will be backed by the layout `Row`) and is only for use in testing.

Refs #1362 