### PR TITLE
Make `UiConfiguration` part of Redwood

### DIFF
--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
@@ -25,6 +25,7 @@ import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutTestingWidgetFactory
 import app.cash.redwood.protocol.widget.ProtocolBridge
 import app.cash.redwood.testing.TestRedwoodComposition
 import app.cash.redwood.testing.WidgetValue
+import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.widget.MutableListChildren
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -41,13 +42,14 @@ import com.example.redwood.testing.widget.TestSchemaWidgetFactories
 import com.example.redwood.testing.widget.TestSchemaWidgetFactory
 import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 
 class DirectChangeListenerTest : AbstractChangeListenerTest() {
   override fun <T> CoroutineScope.launchComposition(
     factories: TestSchemaWidgetFactories<WidgetValue>,
     snapshot: () -> T,
-  ) = TestRedwoodComposition(this, factories, MutableListChildren(), snapshot)
+  ) = TestRedwoodComposition(this, factories, MutableListChildren(), MutableStateFlow(UiConfiguration()), snapshot)
 }
 
 class ProtocolChangeListenerTest : AbstractChangeListenerTest() {
@@ -59,7 +61,7 @@ class ProtocolChangeListenerTest : AbstractChangeListenerTest() {
     val widgetBridge = ProtocolBridge(MutableListChildren(), TestSchemaProtocolNodeFactory(factories)) {
       throw AssertionError()
     }
-    return TestRedwoodComposition(this, composeBridge.provider, composeBridge.root) {
+    return TestRedwoodComposition(this, composeBridge.provider, composeBridge.root, MutableStateFlow(UiConfiguration())) {
       composeBridge.getChangesOrNull()?.let { changes ->
         widgetBridge.sendChanges(changes)
       }

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -21,7 +21,11 @@ import androidx.compose.runtime.MonotonicFrameClock
 import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.protocol.ChangesSink
+import app.cash.redwood.ui.UiConfiguration
+import app.cash.redwood.widget.RedwoodView
+import app.cash.redwood.widget.Widget
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * @param scope A [CoroutineScope] whose [coroutineContext][kotlin.coroutines.CoroutineContext]
@@ -32,8 +36,13 @@ public fun ProtocolRedwoodComposition(
   bridge: ProtocolBridge,
   changesSink: ChangesSink,
   widgetVersion: UInt,
+  uiConfigurations: StateFlow<UiConfiguration>,
 ): RedwoodComposition {
-  val composition = RedwoodComposition(scope, bridge.root, bridge.provider) {
+  val view = object : RedwoodView<Nothing> {
+    override val children: Widget.Children<Nothing> = bridge.root
+    override val uiConfiguration: StateFlow<UiConfiguration> = uiConfigurations
+  }
+  val composition = RedwoodComposition(scope, view, bridge.provider) {
     bridge.getChangesOrNull()?.let(changesSink::sendChanges)
   }
   return ProtocolRedwoodComposition(composition, widgetVersion)

--- a/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-compose/src/commonMain/kotlin/app/cash/redwood/protocol/compose/ProtocolRedwoodComposition.kt
@@ -22,8 +22,6 @@ import app.cash.redwood.compose.LocalWidgetVersion
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.protocol.ChangesSink
 import app.cash.redwood.ui.UiConfiguration
-import app.cash.redwood.widget.RedwoodView
-import app.cash.redwood.widget.Widget
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
@@ -38,11 +36,7 @@ public fun ProtocolRedwoodComposition(
   widgetVersion: UInt,
   uiConfigurations: StateFlow<UiConfiguration>,
 ): RedwoodComposition {
-  val view = object : RedwoodView<Nothing> {
-    override val children: Widget.Children<Nothing> = bridge.root
-    override val uiConfiguration: StateFlow<UiConfiguration> = uiConfigurations
-  }
-  val composition = RedwoodComposition(scope, view, bridge.provider) {
+  val composition = RedwoodComposition(scope, bridge.root, uiConfigurations, bridge.provider) {
     bridge.getChangesOrNull()?.let(changesSink::sendChanges)
   }
   return ProtocolRedwoodComposition(composition, widgetVersion)

--- a/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
+++ b/redwood-protocol-compose/src/commonTest/kotlin/app/cash/redwood/protocol/compose/ProtocolTest.kt
@@ -32,6 +32,7 @@ import app.cash.redwood.protocol.PropertyChange
 import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.testing.TestRedwoodComposition
+import app.cash.redwood.ui.UiConfiguration
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.example.redwood.testing.compose.Button
@@ -41,6 +42,7 @@ import com.example.redwood.testing.compose.TestSchemaProtocolBridge
 import com.example.redwood.testing.compose.Text
 import kotlin.test.Test
 import kotlin.test.fail
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.job
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.TestScope
@@ -56,6 +58,7 @@ class ProtocolTest {
       bridge = bridge,
       changesSink = ::error,
       widgetVersion = 22U,
+      uiConfigurations = MutableStateFlow(UiConfiguration()),
     )
 
     var actualDisplayVersion = 0U
@@ -224,6 +227,7 @@ class ProtocolTest {
       scope = backgroundScope,
       provider = bridge.provider,
       container = bridge.root,
+      uiConfigurations = MutableStateFlow(UiConfiguration()),
     ) {
       bridge.getChangesOrNull() ?: emptyList()
     }

--- a/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/TestRedwoodComposition.kt
+++ b/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/TestRedwoodComposition.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.testing
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import app.cash.redwood.compose.RedwoodComposition
+import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.widget.Widget
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -26,6 +27,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withTimeout
@@ -37,9 +39,10 @@ public fun <W : Any, S> TestRedwoodComposition(
   scope: CoroutineScope,
   provider: Widget.Provider<W>,
   container: Widget.Children<W>,
+  uiConfigurations: StateFlow<UiConfiguration>,
   createSnapshot: () -> S,
 ): TestRedwoodComposition<S> {
-  return RealTestRedwoodComposition(scope, provider, container, createSnapshot)
+  return RealTestRedwoodComposition(scope, provider, container, uiConfigurations, createSnapshot)
 }
 
 public interface TestRedwoodComposition<S> : RedwoodComposition {
@@ -56,6 +59,7 @@ private class RealTestRedwoodComposition<W : Any, S>(
   scope: CoroutineScope,
   provider: Widget.Provider<W>,
   container: Widget.Children<W>,
+  uiConfigurations: StateFlow<UiConfiguration>,
   createSnapshot: () -> S,
 ) : TestRedwoodComposition<S> {
   /** Emit frames manually in [sendFrames]. */
@@ -69,6 +73,7 @@ private class RealTestRedwoodComposition<W : Any, S>(
   private val composition = RedwoodComposition(
     scope = scope + clock,
     container = container,
+    uiConfigurations = uiConfigurations,
     provider = provider,
     onEndChanges = {
       val newSnapshot = createSnapshot()

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
@@ -31,6 +31,7 @@ import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.protocol.compose.ProtocolRedwoodComposition
 import app.cash.redwood.protocol.widget.ProtocolBridge
+import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.widget.MutableListChildren
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -42,6 +43,7 @@ import com.example.redwood.testing.widget.TestSchemaTester
 import com.example.redwood.testing.widget.TestSchemaTestingWidgetFactory
 import com.example.redwood.testing.widget.TestSchemaWidgetFactories
 import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
@@ -108,6 +110,7 @@ class ViewTreesTest {
       bridge = TestSchemaProtocolBridge.create(),
       changesSink = { protocolChanges = it },
       widgetVersion = UInt.MAX_VALUE,
+      uiConfigurations = MutableStateFlow(UiConfiguration()),
     )
     composition.setContent(content)
     composition.cancel()

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -50,7 +50,7 @@ suspend fun <R> ExampleTester(
     RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
   )
   val container = MutableListChildren<WidgetValue>()
-  val tester = TestRedwoodComposition(this, factories, container) {
+  val tester = TestRedwoodComposition(this, factories, container, MutableStateFlow(UiConfiguration())) {
     container.map { it.value }
   }
   try {
@@ -86,7 +86,7 @@ internal fun generateTester(schemaSet: SchemaSet): FileSpec {
         }
         .addCode("⇤)\n")
         .addStatement("val container = %T<%T>()", RedwoodWidget.MutableListChildren, RedwoodTesting.WidgetValue)
-        .beginControlFlow("val tester = %T(this, factories, container)", RedwoodTesting.TestRedwoodComposition)
+        .beginControlFlow("val tester = %T(this, factories, container, %M(%T()))", RedwoodTesting.TestRedwoodComposition, KotlinxCoroutines.MutableStateFlow, RedwoodRuntime.UiConfiguration)
         .addStatement("container.map { it.value }")
         .endControlFlow()
         .beginControlFlow("try")

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -67,6 +67,10 @@ internal object Redwood {
     .build()
 }
 
+internal object RedwoodRuntime {
+  val UiConfiguration = ClassName("app.cash.redwood.ui", "UiConfiguration")
+}
+
 internal object RedwoodTesting {
   val TestRedwoodComposition = ClassName("app.cash.redwood.testing", "TestRedwoodComposition")
   val WidgetValue = ClassName("app.cash.redwood.testing", "WidgetValue")
@@ -140,4 +144,5 @@ internal object KotlinxSerialization {
 
 internal object KotlinxCoroutines {
   val coroutineScope = MemberName("kotlinx.coroutines", "coroutineScope")
+  val MutableStateFlow = MemberName("kotlinx.coroutines.flow", "MutableStateFlow")
 }

--- a/redwood-treehouse-guest-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/composition.kt
+++ b/redwood-treehouse-guest-compose/src/commonMain/kotlin/app/cash/redwood/treehouse/composition.kt
@@ -16,25 +16,18 @@
 package app.cash.redwood.treehouse
 
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.saveable.SaveableStateRegistry
-import app.cash.redwood.compose.LocalUiConfiguration
 import app.cash.redwood.compose.RedwoodComposition
-import app.cash.redwood.ui.UiConfiguration
-import kotlinx.coroutines.flow.StateFlow
 
 // Inline at callsite once https://github.com/Kotlin/kotlinx.serialization/issues/1454 is fixed.
 public fun RedwoodComposition.bind(
   treehouseUi: TreehouseUi,
-  uiConfigurations: StateFlow<UiConfiguration>,
   saveableStateRegistry: SaveableStateRegistry,
 ) {
   setContent {
-    val uiConfiguration by uiConfigurations.collectAsState()
     CompositionLocalProvider(
-      LocalUiConfiguration provides uiConfiguration,
       LocalSaveableStateRegistry provides saveableStateRegistry,
     ) {
       treehouseUi.Show()

--- a/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
+++ b/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
@@ -64,6 +64,7 @@ private class RedwoodZiplineTreehouseUi(
       bridge = bridge,
       widgetVersion = appLifecycle.widgetVersion,
       changesSink = changesSink,
+      uiConfigurations = uiConfigurations,
     )
     this.composition = composition
 
@@ -78,7 +79,6 @@ private class RedwoodZiplineTreehouseUi(
 
     composition.bind(
       treehouseUi = treehouseUi,
-      uiConfigurations = uiConfigurations,
       saveableStateRegistry = saveableStateRegistry,
     )
   }

--- a/samples/counter/android-views/src/main/kotlin/com/example/redwood/counter/android/views/MainActivity.kt
+++ b/samples/counter/android-views/src/main/kotlin/com/example/redwood/counter/android/views/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : AppCompatActivity() {
 
     val composition = RedwoodComposition(
       scope = scope,
-      container = redwoodView.children,
+      view = redwoodView,
       provider = SchemaWidgetFactories(
         Schema = AndroidWidgetFactory(this),
         RedwoodLayout = ViewRedwoodLayoutWidgetFactory(this),

--- a/samples/counter/browser/src/commonMain/kotlin/com/example/redwood/counter/browser/main.kt
+++ b/samples/counter/browser/src/commonMain/kotlin/com/example/redwood/counter/browser/main.kt
@@ -18,7 +18,7 @@ package com.example.redwood.counter.browser
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.compose.WindowAnimationFrameClock
 import app.cash.redwood.layout.dom.HTMLElementRedwoodLayoutWidgetFactory
-import app.cash.redwood.widget.HTMLElementChildren
+import app.cash.redwood.widget.asRedwoodView
 import com.example.redwood.counter.presenter.Counter
 import com.example.redwood.counter.widget.SchemaWidgetFactories
 import kotlinx.browser.document
@@ -33,7 +33,7 @@ fun main() {
   @OptIn(DelicateCoroutinesApi::class)
   val composition = RedwoodComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
-    container = HTMLElementChildren(content),
+    view = content.asRedwoodView(),
     provider = SchemaWidgetFactories(
       Schema = HtmlWidgetFactory(document),
       RedwoodLayout = HTMLElementRedwoodLayoutWidgetFactory(document),

--- a/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
@@ -18,7 +18,7 @@ package com.example.redwood.counter.ios
 import app.cash.redwood.compose.DisplayLinkClock
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
-import app.cash.redwood.widget.UIViewChildren
+import app.cash.redwood.widget.RedwoodUIView
 import com.example.redwood.counter.presenter.Counter
 import com.example.redwood.counter.widget.SchemaWidgetFactories
 import kotlinx.coroutines.MainScope
@@ -33,10 +33,9 @@ class CounterViewControllerDelegate(
   private val scope = MainScope() + DisplayLinkClock
 
   init {
-    val children = UIViewChildren(root)
     val composition = RedwoodComposition(
       scope = scope,
-      container = children,
+      view = RedwoodUIView(root),
       provider = SchemaWidgetFactories(
         Schema = IosWidgetFactory,
         RedwoodLayout = UIViewRedwoodLayoutWidgetFactory(),

--- a/samples/emoji-search/browser/src/commonMain/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/commonMain/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -15,14 +15,11 @@
  */
 package com.example.redwood.emojisearch.browser
 
-import androidx.compose.runtime.CompositionLocalProvider
-import app.cash.redwood.compose.LocalUiConfiguration
 import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.compose.WindowAnimationFrameClock
 import app.cash.redwood.layout.dom.HTMLElementRedwoodLayoutWidgetFactory
 import app.cash.redwood.layout.dom.HTMLElementRedwoodLazyLayoutWidgetFactory
-import app.cash.redwood.ui.UiConfiguration
-import app.cash.redwood.widget.HTMLElementChildren
+import app.cash.redwood.widget.asRedwoodView
 import com.example.redwood.emojisearch.presenter.EmojiSearch
 import com.example.redwood.emojisearch.presenter.HttpClient
 import com.example.redwood.emojisearch.presenter.Navigator
@@ -49,7 +46,7 @@ fun main() {
   @OptIn(DelicateCoroutinesApi::class)
   val composition = RedwoodComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
-    container = HTMLElementChildren(content),
+    view = content.asRedwoodView(),
     provider = EmojiSearchWidgetFactories(
       EmojiSearch = HTMLElementEmojiSearchWidgetFactory(document),
       RedwoodLayout = HTMLElementRedwoodLayoutWidgetFactory(document),
@@ -58,9 +55,7 @@ fun main() {
   )
   val httpClient = FetchHttpClient(window)
   composition.setContent {
-    CompositionLocalProvider(LocalUiConfiguration provides UiConfiguration()) {
-      EmojiSearch(httpClient, navigator)
-    }
+    EmojiSearch(httpClient, navigator)
   }
 }
 


### PR DESCRIPTION
@JakeWharton Regarding your comment at https://github.com/cashapp/redwood/pull/1440#discussion_r1312048461, I wanted to ensure that I have the correct north star, by implementing what you mentioned and having it only work for Android Views (for now). Please lmk if this is/isn't what you had in mind!

I'll create the remaining `RedwoodView` implementations so this can work on other platforms in some other PRs and keep rebasing this PR and keeping at as a draft until all the implementations are complete.

Closes https://github.com/cashapp/redwood/issues/1054