### PR TITLE
Move insets to Redwood-only module

### DIFF
--- a/redwood-composeui/build.gradle
+++ b/redwood-composeui/build.gradle
@@ -14,6 +14,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        implementation libs.jetbrains.compose.foundation
         api projects.redwoodCompose
         implementation projects.redwoodWidgetCompose
       }

--- a/redwood-composeui/src/androidMain/kotlin/app/cash/redwood/composeui/insets.kt
+++ b/redwood-composeui/src/androidMain/kotlin/app/cash/redwood/composeui/insets.kt
@@ -15,7 +15,7 @@
  */
 @file:JvmName("insetsAndroid")
 
-package app.cash.redwood.treehouse.composeui
+package app.cash.redwood.composeui
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -29,7 +29,7 @@ import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.fromPlatformDp
 
 @Composable
-internal actual fun safeAreaInsets(): Margin {
+public actual fun safeAreaInsets(): Margin {
   val layoutDirection = LocalLayoutDirection.current
   return WindowInsets.safeDrawing.asPaddingValues().toMargin(layoutDirection)
 }

--- a/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/insets.kt
+++ b/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/insets.kt
@@ -13,26 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:JvmName("insetsJvm")
-
-package app.cash.redwood.treehouse.composeui
+package app.cash.redwood.composeui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalDensity
-import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
-import java.awt.GraphicsEnvironment
-import java.awt.Insets
-import java.awt.Toolkit
 
+/** Return the device's insets in screen density-independent pixels. */
 @Composable
-internal actual fun safeAreaInsets(): Margin {
-  val configuration = GraphicsEnvironment.getLocalGraphicsEnvironment()
-    .defaultScreenDevice.defaultConfiguration
-  val density = Density(LocalDensity.current.density.toDouble())
-  return Toolkit.getDefaultToolkit().getScreenInsets(configuration).toMargin(density)
-}
-
-private fun Insets.toMargin(density: Density) = with(density) {
-  Margin(left.toDp(), right.toDp(), top.toDp(), bottom.toDp())
-}
+public expect fun safeAreaInsets(): Margin

--- a/redwood-composeui/src/iosMain/kotlin/app/cash/redwood/composeui/insets.kt
+++ b/redwood-composeui/src/iosMain/kotlin/app/cash/redwood/composeui/insets.kt
@@ -13,11 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.treehouse.composeui
+package app.cash.redwood.composeui
 
 import androidx.compose.runtime.Composable
+import app.cash.redwood.ui.Default
+import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
+import kotlinx.cinterop.useContents
+import platform.UIKit.UIApplication
 
-/** Return the device's insets in screen density-independent pixels. */
 @Composable
-internal expect fun safeAreaInsets(): Margin
+public actual fun safeAreaInsets(): Margin {
+  val keyWindow = UIApplication.sharedApplication.keyWindow ?: return Margin.Zero
+  return keyWindow.safeAreaInsets.useContents {
+    with(Density.Default) {
+      Margin(left.toDp(), right.toDp(), top.toDp(), bottom.toDp())
+    }
+  }
+}

--- a/redwood-composeui/src/jvmMain/kotlin/app/cash/redwood/composeui/insets.kt
+++ b/redwood-composeui/src/jvmMain/kotlin/app/cash/redwood/composeui/insets.kt
@@ -13,21 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.treehouse.composeui
+@file:JvmName("insetsJvm")
+
+package app.cash.redwood.composeui
 
 import androidx.compose.runtime.Composable
-import app.cash.redwood.ui.Default
+import androidx.compose.ui.platform.LocalDensity
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
-import kotlinx.cinterop.useContents
-import platform.UIKit.UIApplication
+import java.awt.GraphicsEnvironment
+import java.awt.Insets
+import java.awt.Toolkit
 
 @Composable
-internal actual fun safeAreaInsets(): Margin {
-  val keyWindow = UIApplication.sharedApplication.keyWindow ?: return Margin.Zero
-  return keyWindow.safeAreaInsets.useContents {
-    with(Density.Default) {
-      Margin(left.toDp(), right.toDp(), top.toDp(), bottom.toDp())
-    }
-  }
+public actual fun safeAreaInsets(): Margin {
+  val configuration = GraphicsEnvironment.getLocalGraphicsEnvironment()
+    .defaultScreenDevice.defaultConfiguration
+  val density = Density(LocalDensity.current.density.toDouble())
+  return Toolkit.getDefaultToolkit().getScreenInsets(configuration).toMargin(density)
+}
+
+private fun Insets.toMargin(density: Density) = with(density) {
+  Margin(left.toDp(), right.toDp(), top.toDp(), bottom.toDp())
 }

--- a/redwood-composeui/src/macosMain/kotlin/app/cash/redwood/composeui/insets.kt
+++ b/redwood-composeui/src/macosMain/kotlin/app/cash/redwood/composeui/insets.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package app.cash.redwood.treehouse.composeui
+package app.cash.redwood.composeui
 
 import androidx.compose.runtime.Composable
 import app.cash.redwood.ui.Default
@@ -23,7 +23,7 @@ import kotlinx.cinterop.useContents
 import platform.AppKit.NSScreen
 
 @Composable
-internal actual fun safeAreaInsets(): Margin {
+public actual fun safeAreaInsets(): Margin {
   val mainScreen = NSScreen.mainScreen ?: return Margin.Zero
   return mainScreen.safeAreaInsets.useContents {
     with(Density.Default) {

--- a/redwood-treehouse-host-composeui/build.gradle
+++ b/redwood-treehouse-host-composeui/build.gradle
@@ -21,6 +21,7 @@ kotlin {
         api projects.redwoodTreehouse
         api projects.redwoodTreehouseHost
         implementation libs.jetbrains.compose.foundation
+        implementation projects.redwoodComposeui
         implementation projects.redwoodWidgetCompose
       }
     }

--- a/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import app.cash.redwood.composeui.safeAreaInsets
 import app.cash.redwood.treehouse.AppService
 import app.cash.redwood.treehouse.CodeListener
 import app.cash.redwood.treehouse.StateSnapshot


### PR DESCRIPTION
This is in preparation for allowing `UiConfiguration` to be provided within a Redwood-only & Compose UI-specific app.

Refs https://github.com/cashapp/redwood/issues/1054