### PR TITLE
Move `UIStackView` insertion logic into `UIViewChildren`

### DIFF
--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -16,14 +16,16 @@
 package app.cash.redwood.widget
 
 import kotlinx.cinterop.convert
+import platform.UIKit.UIStackView
 import platform.UIKit.UIView
 import platform.darwin.NSInteger
 
 @ObjCName("UIViewChildren", exact = true)
 public class UIViewChildren(
   private val parent: UIView,
-  private val insert: (UIView, Int) -> Unit = { view, index ->
-    parent.insertSubview(view, index.convert<NSInteger>())
+  private val insert: (UIView, Int) -> Unit = when (parent) {
+    is UIStackView -> { view, index -> parent.insertArrangedSubview(view, index.convert()) }
+    else -> { view, index -> parent.insertSubview(view, index.convert<NSInteger>()) }
   },
   private val remove: (index: Int, count: Int) -> Array<UIView> = { index, count ->
     Array(count) {

--- a/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
@@ -21,7 +21,6 @@ import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.widget.UIViewChildren
 import com.example.redwood.counter.presenter.Counter
 import com.example.redwood.counter.widget.SchemaWidgetFactories
-import kotlinx.cinterop.convert
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.plus
@@ -34,10 +33,7 @@ class CounterViewControllerDelegate(
   private val scope = MainScope() + DisplayLinkClock
 
   init {
-    val children = UIViewChildren(
-      parent = root,
-      insert = { view, index -> root.insertArrangedSubview(view, index.convert()) },
-    )
+    val children = UIViewChildren(root)
     val composition = RedwoodComposition(
       scope = scope,
       container = children,


### PR DESCRIPTION
In preparation for using `RedwoodView` in the iOS counter sample. `RedwoodUIView` currently instantiates a `UIViewChildren` instance without overriding its `insert` lambda. I _believe_ `UIStackView` is common enough to push the custom handling of it within `UIViewChildren`.