### PR TITLE
Preserve scroll position on Android Activity restoration

### DIFF
--- a/redwood-lazylayout-compose/build.gradle
+++ b/redwood-lazylayout-compose/build.gradle
@@ -13,6 +13,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        api libs.jetbrains.compose.runtime.saveable
         api projects.redwoodLazylayoutWidget
       }
     }

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
@@ -18,14 +18,15 @@ package app.cash.redwood.lazylayout.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 
 @Composable
 public fun rememberLazyListState(
   initialFirstVisibleItemIndex: Int = 0,
 ): LazyListState {
-  return remember {
+  return rememberSaveable(saver = LazyListState.Saver) {
     LazyListState(
       initialFirstVisibleItemIndex,
     )
@@ -45,5 +46,19 @@ public class LazyListState(
   ) {
     firstVisibleItemIndex = index
     scrollToItemTriggeredId++
+  }
+
+  public companion object {
+    /**
+     * The default [Saver] implementation for [LazyListState].
+     */
+    public val Saver: Saver<LazyListState, *> = Saver(
+      save = { it.firstVisibleItemIndex },
+      restore = {
+        LazyListState(
+          firstVisibleItemIndex = it,
+        )
+      },
+    )
   }
 }


### PR DESCRIPTION
This doesn't work yet, as `rememberSaveable` needs to support saving of values that _aren't_ `MutableState`'s. Currently, when trying to save the state, we get the following error:


```
app.cash.zipline.ZiplineException: IllegalStateException: unexpected type: {-exvejj=[MutableState(value=medal)@632700585], udeaau=[0]}
                 	at captureStack (runtime/coreRuntime.kt:12)
                 	at IllegalStateException_init_$Create$_0 (kotlin-kotlin-stdlib-js-ir.js)
                 	at toStateSnapshot (commonMainSources/libraries/stdlib/src/kotlin/collections/Maps.kt:84)
                 	at <anonymous> (redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt:114)
                 	at <anonymous> (redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineTreehouseUi.kt)
                 	…
```

One trade-off here is that we're just saving the first visible item index, and thus we only restore the first visible item index when we come back. What this means is that if we scroll past 4 items, and the top of the `LazyList` has scrolled half of the fifth item, when we restore the scroll position, we will show the whole of the fifth item instead of half of it. I think this is perfectly okay for now, as the gains we get from restoring the scroll index is ginormous.