### PR TITLE
fix ButtonBinding.swift click action error！

### DIFF
--- a/test-app/ios-uikit/TestApp/ButtonBinding.swift
+++ b/test-app/ios-uikit/TestApp/ButtonBinding.swift
@@ -48,7 +48,7 @@ class ButtonBinding: Button {
     
     @objc func clicked() {
         if (self.onClick != nil) {
-            self.onClick()
+            self.onClick?()
         }
     }
 }

--- a/test-app/ios-uikit/TestApp/ButtonBinding.swift
+++ b/test-app/ios-uikit/TestApp/ButtonBinding.swift
@@ -47,8 +47,6 @@ class ButtonBinding: Button {
     }
     
     @objc func clicked() {
-        if (self.onClick != nil) {
-            self.onClick?()
-        }
+        self.onClick?()
     }
 }


### PR DESCRIPTION
The interface method of Button is implemented in ButtonBinding, but the root button executes the interface method again, resulting in the inability to call back the Unit in Kotlin. Here, the assigned attribute OnClick should be called.

Closes #1506