### PR TITLE
Support RTL layout direction in redwood-layout-dom

### DIFF
--- a/redwood-layout-dom/src/commonMain/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
+++ b/redwood-layout-dom/src/commonMain/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
@@ -77,8 +77,8 @@ private class HTMLFlexContainer(
 
   override fun margin(margin: Margin) {
     value.style.apply {
-      marginLeft = margin.start.toPxString()
-      marginRight = margin.end.toPxString()
+      marginInlineStart = margin.start.toPxString()
+      marginInlineEnd = margin.end.toPxString()
       marginTop = margin.top.toPxString()
       marginBottom = margin.bottom.toPxString()
     }

--- a/redwood-layout-dom/src/commonMain/kotlin/app/cash/redwood/layout/dom/utils.kt
+++ b/redwood-layout-dom/src/commonMain/kotlin/app/cash/redwood/layout/dom/utils.kt
@@ -22,6 +22,7 @@ import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Dp
 import kotlin.math.roundToInt
+import org.w3c.dom.css.CSSStyleDeclaration
 
 internal fun Dp.toPxString(): String = with(Density(1.0)) {
   "${toPx().roundToInt()}px"
@@ -56,3 +57,15 @@ internal fun Overflow.toCss() = when (this) {
   Overflow.Scroll -> "scroll"
   else -> throw AssertionError()
 }
+
+internal var CSSStyleDeclaration.marginInlineStart: String
+  get() = this.getPropertyValue("margin-inline-start")
+  set(value) {
+    this.setProperty("margin-inline-start", value)
+  }
+
+internal var CSSStyleDeclaration.marginInlineEnd: String
+  get() = this.getPropertyValue("margin-inline-end")
+  set(value) {
+    this.setProperty("margin-inline-end", value)
+  }


### PR DESCRIPTION
### Changes 
- `marginInlineStart` and `marginInlineEnd` as extension properties for `CSSStyleDeclaration` that represents ""margin-inline-start" and ""margin-inline-end"
- Replaced `marginLeft` and `marginRight` with `marginInlineStart` and `marginInlineEnd` respectively 

Fixes #1244 