### PR TITLE
Remove workaround for Compose on native

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,6 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 kotlin.mpp.stability.nowarn=true
 
-# This is needed for the JB Compose runtime to link on native targets. They also use this flag
-# in their samples. Over time it should be removed once they figure out why it was needed.
-kotlin.native.cacheKind=none
-
 # https://github.com/Kotlin/kotlinx-atomicfu/issues/141
 kotlin.native.ignoreIncorrectDependencies=true
 


### PR DESCRIPTION
This is no longer needed as of Kotlin 1.9.0.