### PR TITLE
Stick to the safe area when rendering test app

### DIFF
--- a/test-app/ios-uikit/TestApp/TestAppViewController.swift
+++ b/test-app/ios-uikit/TestApp/TestAppViewController.swift
@@ -30,9 +30,7 @@ class TestAppViewController : UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .white
-    }
 
-    override func loadView() {
         let testAppLauncher = TestAppLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
         let treehouseApp = testAppLauncher.createTreehouseApp()
         let widgetSystem = TestSchemaWidgetSystem()
@@ -42,7 +40,15 @@ class TestAppViewController : UIViewController {
             codeListener: CodeListener()
         )
         ExposedKt.bindWhenReady(content: content, view: treehouseView)
-        view = treehouseView.view
+
+        let tv = treehouseView.view
+        tv.translatesAutoresizingMaskIntoConstraints = false
+
+        self.view.addSubview(tv)
+        let safeGuide = self.view.safeAreaLayoutGuide
+        tv.heightAnchor.constraint(equalTo: safeGuide.heightAnchor).isActive = true
+        tv.widthAnchor.constraint(equalTo: safeGuide.widthAnchor).isActive = true
+        tv.topAnchor.constraint(equalTo: safeGuide.topAnchor).isActive = true
     }
 }
 


### PR DESCRIPTION
Did I do any of this right? It looks right...

<img width="565" alt="Screenshot 2023-09-25 at 4 32 18 PM" src="https://github.com/cashapp/redwood/assets/66577/926794b8-7ffe-45c4-919b-5463df650e50">
