### PR TITLE
Add a quick screen to show `UiConfiguration` values

### DIFF
--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/TestApp.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/TestApp.kt
@@ -58,6 +58,12 @@ enum class Screen {
       RepoSearch(httpClient, modifier)
     }
   },
+  UiConfiguration {
+    @Composable
+    override fun Show(httpClient: HttpClient, modifier: Modifier) {
+      UiConfigurationValues(modifier)
+    }
+  },
   ;
 
   @Composable

--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/UiConfiguration.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/UiConfiguration.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.redwood.testing.presenter
+
+import androidx.compose.runtime.Composable
+import app.cash.redwood.Modifier
+import app.cash.redwood.compose.current
+import app.cash.redwood.layout.compose.Column
+import app.cash.redwood.ui.Margin
+import app.cash.redwood.ui.UiConfiguration
+import app.cash.redwood.ui.dp
+import com.example.redwood.testing.compose.Text
+
+@Composable
+fun UiConfigurationValues(modifier: Modifier) {
+  Column(margin = Margin(16.dp), modifier = modifier) {
+    val uiConfiguration = UiConfiguration.current
+
+    Text("Dark mode: ${uiConfiguration.darkMode}")
+
+    val safeAreaInsets = uiConfiguration.safeAreaInsets
+    Text("Safe area insets:")
+    Text("- top: ${safeAreaInsets.top}")
+    Text("- bottom: ${safeAreaInsets.bottom}")
+    Text("- start: ${safeAreaInsets.start}")
+    Text("- end: ${safeAreaInsets.end}")
+
+    val viewportSize = uiConfiguration.viewportSize
+    Text("Viewport size:")
+    Text("- width: ${viewportSize.width}")
+    Text("- height: ${viewportSize.height}")
+
+    Text("Density: ${uiConfiguration.density}")
+  }
+}


### PR DESCRIPTION
Browser height is broken. Math seems weird with Android too.

![Screenshot_20230927_103125](https://github.com/cashapp/redwood/assets/66577/623f3f4b-3ab9-48b5-b892-6ec6567899c9)

![Screenshot 2023-09-27 at 10 31 34 AM](https://github.com/cashapp/redwood/assets/66577/208c5f62-afa9-4389-8f0c-ad8a122a6d26)

![Screenshot 2023-09-27 at 10 31 06 AM](https://github.com/cashapp/redwood/assets/66577/50be38af-f47a-4dbf-afce-534e7ba82668)