### PR TITLE
Remove the need to plumb a `Modifier` to screens

### DIFF
--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/RepoSearch.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/RepoSearch.kt
@@ -27,7 +27,6 @@ import app.cash.paging.PagingSourceLoadResult
 import app.cash.paging.PagingSourceLoadResultPage
 import app.cash.paging.PagingState
 import app.cash.paging.compose.collectAsLazyPagingItems
-import app.cash.redwood.Modifier
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.lazylayout.compose.LazyColumn
@@ -45,7 +44,7 @@ private val pagingConfig = PagingConfig(pageSize = 20, initialLoadSize = 20).app
 }
 
 @Composable
-fun RepoSearch(httpClient: HttpClient, modifier: Modifier = Modifier) {
+fun RepoSearch(httpClient: HttpClient) {
   // TODO Make term interactive with TextInput.
   val latestSearchTerm by remember { mutableStateOf("android") }
 
@@ -59,7 +58,6 @@ fun RepoSearch(httpClient: HttpClient, modifier: Modifier = Modifier) {
   LazyColumn(
     width = Constraint.Fill,
     height = Constraint.Fill,
-    modifier = modifier,
     placeholder = { RepositoryItem(Repository(fullName = "Placeholder…", 0)) },
   ) {
     items(lazyPagingItems.itemCount) { index ->

--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/TestApp.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/TestApp.kt
@@ -21,9 +21,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import app.cash.redwood.Modifier
 import app.cash.redwood.compose.BackHandler
-import app.cash.redwood.layout.api.Constraint
-import app.cash.redwood.layout.api.Constraint.Companion
-import app.cash.redwood.layout.api.CrossAxisAlignment
+import app.cash.redwood.layout.api.Constraint.Companion.Fill
+import app.cash.redwood.layout.api.CrossAxisAlignment.Companion.Stretch
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.ui.Margin
@@ -40,12 +39,17 @@ fun TestApp(httpClient: HttpClient) {
   } else {
     val onBack = { screen.value = null }
     BackHandler(onBack = onBack)
-    Column(
-      width = Constraint.Fill,
-      height = Constraint.Fill,
-    ) {
+    Column(width = Fill, height = Fill) {
       Button("Back", onClick = onBack)
-      activeScreen.Show(httpClient, modifier = Modifier.grow(1.0))
+
+      // TODO This should be a Box.
+      Column(
+        width = Fill,
+        horizontalAlignment = Stretch,
+        modifier = Modifier.grow(1.0).horizontalAlignment(Stretch),
+      ) {
+        activeScreen.Show(httpClient)
+      }
     }
   }
 }
@@ -54,29 +58,29 @@ fun TestApp(httpClient: HttpClient) {
 enum class Screen {
   RepoSearch {
     @Composable
-    override fun Show(httpClient: HttpClient, modifier: Modifier) {
-      RepoSearch(httpClient, modifier)
+    override fun Show(httpClient: HttpClient) {
+      RepoSearch(httpClient)
     }
   },
   UiConfiguration {
     @Composable
-    override fun Show(httpClient: HttpClient, modifier: Modifier) {
-      UiConfigurationValues(modifier)
+    override fun Show(httpClient: HttpClient) {
+      UiConfigurationValues()
     }
   },
   ;
 
   @Composable
-  abstract fun Show(httpClient: HttpClient, modifier: Modifier)
+  abstract fun Show(httpClient: HttpClient)
 }
 
 @Composable
 private fun HomeScreen(screen: MutableState<Screen?>) {
   Column(
-    width = Constraint.Fill,
-    height = Companion.Fill,
+    width = Fill,
+    height = Fill,
     overflow = Overflow.Scroll,
-    horizontalAlignment = CrossAxisAlignment.Stretch,
+    horizontalAlignment = Stretch,
   ) {
     Text("Test App Screens:", modifier = Modifier.margin(Margin(8.dp)))
     Screen.entries.forEach {

--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/UiConfiguration.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/UiConfiguration.kt
@@ -16,7 +16,6 @@
 package com.example.redwood.testing.presenter
 
 import androidx.compose.runtime.Composable
-import app.cash.redwood.Modifier
 import app.cash.redwood.compose.current
 import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.ui.Margin
@@ -25,8 +24,8 @@ import app.cash.redwood.ui.dp
 import com.example.redwood.testing.compose.Text
 
 @Composable
-fun UiConfigurationValues(modifier: Modifier) {
-  Column(margin = Margin(16.dp), modifier = modifier) {
+fun UiConfigurationValues() {
+  Column(margin = Margin(16.dp)) {
     val uiConfiguration = UiConfiguration.current
 
     Text("Dark mode: ${uiConfiguration.darkMode}")


### PR DESCRIPTION
iOS repo search is broken. Probably a broken HTTP client impl. Will file a bug...

![Screenshot_20230927_163759](https://github.com/cashapp/redwood/assets/66577/8264ea6a-ea20-46e0-b4ab-598cf4a0aecd)

![Simulator Screen Shot - iPhone 14 Pro - 2023-09-27 at 16 39 25](https://github.com/cashapp/redwood/assets/66577/d417e4f8-fae6-43d1-a084-8ada6afc0d32)

![Screenshot 2023-09-27 at 4 40 23 PM](https://github.com/cashapp/redwood/assets/66577/8c883f1a-b6c5-4f03-a0af-9c607b1fa414)

