### PR TITLE
Add a code load status snackbar for Android view frontend

### DIFF
--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -39,6 +39,8 @@ import com.example.redwood.emojisearch.launcher.EmojiSearchAppSpec
 import com.example.redwood.emojisearch.treehouse.EmojiSearchPresenter
 import com.example.redwood.emojisearch.widget.EmojiSearchProtocolNodeFactory
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.snackbar.Snackbar.LENGTH_INDEFINITE
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flowOf
@@ -49,6 +51,7 @@ import okio.Path.Companion.toOkioPath
 
 class EmojiSearchActivity : ComponentActivity() {
   private val scope: CoroutineScope = CoroutineScope(Main)
+  private lateinit var treehouseLayout: TreehouseLayout
 
   @SuppressLint("ResourceType")
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,13 +74,42 @@ class EmojiSearchActivity : ComponentActivity() {
       )
     }
 
-    setContentView(
-      TreehouseLayout(this, widgetSystem, onBackPressedDispatcher).apply {
-        // The view needs to have an id for Android to populate saved data back
-        this.id = 9000
-        treehouseContentSource.bindWhenReady(this, treehouseApp)
-      },
-    )
+    treehouseLayout = TreehouseLayout(this, widgetSystem, onBackPressedDispatcher).apply {
+      // The view needs to have an id for Android to populate saved data back
+      this.id = 9000
+      treehouseContentSource.bindWhenReady(this, treehouseApp)
+    }
+    setContentView(treehouseLayout)
+  }
+
+  private val appEventListener: EventListener = object : EventListener() {
+    private var success = true
+    private var snackbar: Snackbar? = null
+
+    override fun codeLoadFailed(app: TreehouseApp<*>, manifestUrl: String?, exception: Exception, startValue: Any?) {
+      Log.w("Treehouse", "codeLoadFailed", exception)
+      if (success) {
+        // Only show the Snackbar on the first transition from success.
+        success = false
+        snackbar =
+          Snackbar.make(treehouseLayout, "Unable to load guest code from server", LENGTH_INDEFINITE)
+            .setAction("Dismiss") { maybeDismissSnackbar() }
+            .also(Snackbar::show)
+      }
+    }
+
+    override fun codeLoadSuccess(app: TreehouseApp<*>, manifestUrl: String?, manifest: ZiplineManifest, zipline: Zipline, startValue: Any?) {
+      Log.i("Treehouse", "codeLoadSuccess")
+      success = true
+      maybeDismissSnackbar()
+    }
+
+    private fun maybeDismissSnackbar() {
+      snackbar?.let {
+        it.dismiss()
+        snackbar = null
+      }
+    }
   }
 
   private fun createTreehouseApp(): TreehouseApp<EmojiSearchPresenter> {
@@ -115,15 +147,5 @@ class EmojiSearchActivity : ComponentActivity() {
   override fun onDestroy() {
     scope.cancel()
     super.onDestroy()
-  }
-}
-
-val appEventListener: EventListener = object : EventListener() {
-  override fun codeLoadFailed(app: TreehouseApp<*>, manifestUrl: String?, exception: Exception, startValue: Any?) {
-    Log.w("Treehouse", "codeLoadFailed", exception)
-  }
-
-  override fun codeLoadSuccess(app: TreehouseApp<*>, manifestUrl: String?, manifest: ZiplineManifest, zipline: Zipline, startValue: Any?) {
-    Log.i("Treehouse", "codeLoadSuccess")
   }
 }


### PR DESCRIPTION
Other frontends to follow.

This is an effort to eventually get automated UI tests running on Emoji Search (#537). Soon the APK will bundle the compile-time JS into assets so that the app always works on cold launch even without the server running. We need this to simplify running the UI tests. The snackbar will be important then because it will indicate when you do not have a server running for live reloads during development.

Here's a demo:
1. App starts without server running
2. Server is started
3. Server is disconnected
4. Snackbar is dismissed (does not reshow despite server still down)

[Screen_recording_20230927_220042.webm](https://github.com/cashapp/redwood/assets/66577/cc493b40-8236-485f-b9f8-aa468835df1b)
