### PR TITLE
Add a code load status snackbar for Android Compose UI frontend

### DIFF
--- a/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -51,6 +51,7 @@ public fun <A : AppService> TreehouseContent(
   widgetSystem: WidgetSystem<@Composable () -> Unit>,
   codeListener: CodeListener = CodeListener(),
   contentSource: TreehouseContentSource<A>,
+  modifier: Modifier = Modifier,
 ) {
   val onBackPressedDispatcher = platformOnBackPressedDispatcher()
 
@@ -87,7 +88,7 @@ public fun <A : AppService> TreehouseContent(
   }
 
   Box(
-    modifier = Modifier.onSizeChanged { size ->
+    modifier = modifier.onSizeChanged { size ->
       viewportSize = with(Density(density.density.toDouble())) {
         Size(size.width.toDp().value.redwoodDp, size.height.toDp().value.redwoodDp)
       }


### PR DESCRIPTION
iOS to follow.

Works the same as #1526. Towards #537. Rendering is a bit off but good enough for now.

![Screenshot_20230927_231151](https://github.com/cashapp/redwood/assets/66577/536b025c-abb1-416b-8f97-3502756746cd)
![Screenshot_20230927_231219](https://github.com/cashapp/redwood/assets/66577/132b5418-9133-4d49-8546-c3c39b7172d9)


