### PR TITLE
Fix saving of `rememberSaveable` values

### DIFF
--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
@@ -18,7 +18,6 @@ package app.cash.redwood.treehouse
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import kotlin.jvm.JvmInline
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -29,7 +28,7 @@ import kotlinx.serialization.json.intOrNull
 
 @Serializable
 public class StateSnapshot(
-  public val content: Map<String, List<@Contextual Saveable>>,
+  public val content: Map<String, List<Saveable>>,
 ) {
   public fun toValuesMap(): Map<String, List<Any?>> {
     return content.mapValues { entry ->
@@ -89,6 +88,7 @@ private fun JsonElement?.fromJsonElement(): Any {
   }
 }
 
+@Serializable
 public data class Saveable(
   val isMutableState: Boolean,
   val value: JsonElement,

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/StateSnapshot.kt
@@ -34,7 +34,7 @@ public class StateSnapshot(
     return content.mapValues { entry ->
       entry.value.map {
         if (it.isMutableState) {
-          mutableStateOf(it.value)
+          mutableStateOf(it.value.fromJsonElement())
         } else {
           it.value.fromJsonElement()
         }

--- a/redwood-treehouse/src/commonTest/kotlin/app/cash/redwood/treehouse/StateSnapshotTest.kt
+++ b/redwood-treehouse/src/commonTest/kotlin/app/cash/redwood/treehouse/StateSnapshotTest.kt
@@ -32,12 +32,12 @@ class StateSnapshotTest {
     val valuesMap = stateSnapshot.toValuesMap()
     assertThat(valuesMap.entries.size).isEqualTo(4)
     assertTrue(valuesMap["key1"]!![0] is MutableState<*>)
-    assertThat((valuesMap["key1"]!![0] as MutableState<*>).value).isEqualTo(JsonPrimitive(1))
+    assertThat((valuesMap["key1"]!![0] as MutableState<*>).value).isEqualTo(1.0)
 
     assertThat(valuesMap["key2"]).isEqualTo(listOf(1.0))
 
     assertThat(valuesMap["key3"]!![0] is MutableState<*>)
-    assertThat((valuesMap["key3"]!![0] as MutableState<*>).value).isEqualTo(JsonPrimitive("str"))
+    assertThat((valuesMap["key3"]!![0] as MutableState<*>).value).isEqualTo("str")
 
     assertThat(valuesMap["key4"]).isEqualTo(listOf("str"))
   }


### PR DESCRIPTION
I split the PR into two commits, where each of the commits are fixing a bug in its own right.

To summarise:

- `Saveable` didn't have a serialization adapter, so it'd crash because of that.
- When deserialising a `MutableState`, we didn't deserialise the value within.