### PR TITLE
Preserve saveable values on config change

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -423,9 +423,7 @@ private class ViewContentCodeBinding<A : AppService>(
   override fun performSave(id: String) {
     appScope.launch(app.dispatchers.zipline) {
       val state = treehouseUiOrNull?.snapshotState() ?: return@launch
-      appScope.launch(app.dispatchers.ui) {
-        app.stateStore.put(id, state)
-      }
+      app.stateStore.put(id, state)
     }
   }
 


### PR DESCRIPTION
Not sure if it's necessary to have the `put` be on the UI thread, but moving it off the UI thread means that saveable values persist across config changes (e.g. rotation).

[before.webm](https://github.com/cashapp/redwood/assets/6900601/608183c2-4ac5-4030-b2b5-e490e35afe05)

[after.webm](https://github.com/cashapp/redwood/assets/6900601/0ccb6f84-9e70-41be-b4ea-887a083f6e38)