### PR TITLE
Set Android View ID on `TreehouseLayout` by default

### DIFF
--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseLayout.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseLayout.kt
@@ -25,6 +25,7 @@ import androidx.activity.OnBackPressedDispatcher as AndroidOnBackPressedDispatch
 import app.cash.redwood.treehouse.TreehouseView.ReadyForContentChangeListener
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.widget.RedwoodLayout
+import app.cash.treehouse.host.R
 import java.util.UUID
 
 @Deprecated(
@@ -58,9 +59,8 @@ public class TreehouseLayout(
   override var saveCallback: TreehouseView.SaveCallback? = null
 
   init {
-    // The view needs to have an id for Android to populate saved data back
-    @SuppressLint("ResourceType")
-    id = 9000
+    // The view needs to have an ID to participate in instance state saving.
+    id = R.id.treehouse_layout
   }
 
   override fun onAttachedToWindow() {

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseLayout.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/TreehouseLayout.kt
@@ -57,6 +57,12 @@ public class TreehouseLayout(
 
   override var saveCallback: TreehouseView.SaveCallback? = null
 
+  init {
+    // The view needs to have an id for Android to populate saved data back
+    @SuppressLint("ResourceType")
+    id = 9000
+  }
+
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     readyForContent = true

--- a/redwood-treehouse-host/src/androidMain/res/values/ids.xml
+++ b/redwood-treehouse-host/src/androidMain/res/values/ids.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2023 Square, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <item type="id" name="treehouse_layout"/>
+</resources>

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -73,8 +73,6 @@ class EmojiSearchActivity : ComponentActivity() {
 
     setContentView(
       TreehouseLayout(this, widgetSystem, onBackPressedDispatcher).apply {
-        // The view needs to have an id for Android to populate saved data back
-        this.id = 9000
         treehouseContentSource.bindWhenReady(this, treehouseApp)
       },
     )


### PR DESCRIPTION
If one doesn't explicitly set an Android View ID, `onSaveInstanceState` is never invoked, and thus `rememberSaveable` will never work as intended.