### PR TITLE
Hoist property binding up into abstract types

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -54,8 +54,8 @@ class ComposeUiFlexContainerTest(
 
   override fun flexContainer(direction: FlexDirection) = ComposeTestFlexContainer(direction)
 
-  override fun widget(text: String, modifier: RedwoodModifier) = object : Text<@Composable () -> Unit> {
-    private var text by mutableStateOf(text)
+  override fun widget() = object : Text<@Composable () -> Unit> {
+    private var text by mutableStateOf("")
 
     override val value = @Composable {
       BasicText(
@@ -65,7 +65,7 @@ class ComposeUiFlexContainerTest(
       )
     }
 
-    override var modifier = modifier
+    override var modifier: RedwoodModifier = RedwoodModifier
 
     override fun text(text: String) {
       this.text = text

--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacerTest.kt
@@ -21,10 +21,8 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
-import app.cash.redwood.Modifier
 import app.cash.redwood.layout.AbstractSpacerTest
 import app.cash.redwood.layout.widget.Spacer
-import app.cash.redwood.ui.dp
 import app.cash.redwood.widget.Widget
 import com.android.ide.common.rendering.api.SessionParams
 import org.junit.Rule
@@ -41,15 +39,7 @@ class ComposeUiSpacerTest : AbstractSpacerTest<@Composable () -> Unit>() {
     renderingMode = SessionParams.RenderingMode.SHRINK,
   )
 
-  override fun widget(
-    width: Int,
-    height: Int,
-    modifier: Modifier,
-  ): Spacer<@Composable () -> Unit> = ComposeUiSpacer().apply {
-    this.modifier = modifier
-    width(width.dp)
-    height(height.dp)
-  }
+  override fun widget(): Spacer<@Composable () -> Unit> = ComposeUiSpacer()
 
   override fun wrap(widget: Widget<@Composable () -> Unit>, horizontal: Boolean) = @Composable {
     if (horizontal) {

--- a/redwood-layout-shared-test/build.gradle
+++ b/redwood-layout-shared-test/build.gradle
@@ -1,16 +1,12 @@
-apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'org.jetbrains.kotlin.jvm'
 
 dependencies {
   api projects.redwoodLayoutApi
   api projects.redwoodLayoutModifiers
+  api projects.redwoodLayoutWidget
   api projects.redwoodRuntime
   api projects.redwoodWidget
   api projects.redwoodYoga
   api libs.junit
   api libs.testParameterInjector
-}
-
-android {
-  namespace 'app.cash.redwood.redwoodlayoutsharedtest'
 }

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -37,8 +37,13 @@ import org.junit.Test
 @Suppress("JUnitMalformedDeclaration")
 abstract class AbstractFlexContainerTest<T : Any> {
   abstract fun flexContainer(direction: FlexDirection): TestFlexContainer<T>
-  abstract fun widget(text: String, modifier: Modifier = Modifier): Text<T>
+  abstract fun widget(): Text<T>
   abstract fun verifySnapshot(container: TestFlexContainer<T>, name: String? = null)
+
+  private fun widget(text: String, modifier: Modifier = Modifier): Text<T> = widget().apply {
+    text(text)
+    this.modifier = modifier
+  }
 
   @Test fun emptyLayout(
     @TestParameter flexDirectionEnum: FlexDirectionEnum,

--- a/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractSpacerTest.kt
+++ b/redwood-layout-shared-test/src/main/kotlin/app/cash/redwood/layout/AbstractSpacerTest.kt
@@ -15,21 +15,23 @@
  */
 package app.cash.redwood.layout
 
-import app.cash.redwood.Modifier
+import app.cash.redwood.layout.widget.Spacer
+import app.cash.redwood.ui.dp
 import app.cash.redwood.widget.Widget
 import org.junit.Test
 
 abstract class AbstractSpacerTest<T : Any> {
 
-  abstract fun widget(
-    width: Int = 0,
-    height: Int = 0,
-    modifier: Modifier = Modifier,
-  ): Widget<T>
+  abstract fun widget(): Spacer<T>
 
   abstract fun wrap(widget: Widget<T>, horizontal: Boolean): T
 
   abstract fun verifySnapshot(value: T)
+
+  private fun widget(width: Int, height: Int): Spacer<T> = widget().apply {
+    width(width.dp)
+    height(height.dp)
+  }
 
   @Test fun zeroSpacer() {
     val widget = widget(width = 0, height = 0)

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -51,16 +51,15 @@ class ViewFlexContainerTest(
     return ViewTestFlexContainer(paparazzi.context, direction)
   }
 
-  override fun widget(text: String, modifier: Modifier) = object : Text<View> {
+  override fun widget() = object : Text<View> {
     override val value = TextView(paparazzi.context).apply {
       background = ColorDrawable(Color.GREEN)
       textSize = 18f
       textDirection = View.TEXT_DIRECTION_LOCALE
       setTextColor(Color.BLACK)
-      this.text = text
     }
 
-    override var modifier = modifier
+    override var modifier: Modifier = Modifier
 
     override fun text(text: String) {
       value.text = text

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewSpacerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewSpacerTest.kt
@@ -22,10 +22,8 @@ import android.widget.LinearLayout.VERTICAL
 import android.widget.TextView
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
-import app.cash.redwood.Modifier
 import app.cash.redwood.layout.AbstractSpacerTest
 import app.cash.redwood.layout.widget.Spacer
-import app.cash.redwood.ui.dp
 import app.cash.redwood.widget.Widget
 import com.android.ide.common.rendering.api.SessionParams
 import org.junit.Rule
@@ -42,15 +40,7 @@ class ViewSpacerTest : AbstractSpacerTest<View>() {
     renderingMode = SessionParams.RenderingMode.SHRINK,
   )
 
-  override fun widget(
-    width: Int,
-    height: Int,
-    modifier: Modifier,
-  ): Spacer<View> = ViewSpacer(paparazzi.context).apply {
-    this.modifier = modifier
-    width(width.dp)
-    height(height.dp)
-  }
+  override fun widget(): Spacer<View> = ViewSpacer(paparazzi.context)
 
   override fun wrap(widget: Widget<View>, horizontal: Boolean): View {
     return LinearLayout(paparazzi.context).apply {

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -56,8 +56,8 @@ class ComposeUiLazyListTest(
 
   override fun flexContainer(direction: FlexDirection) = ComposeTestFlexContainer(direction)
 
-  override fun widget(text: String, modifier: RedwoodModifier) = object : Text<@Composable () -> Unit> {
-    private var text by mutableStateOf(text)
+  override fun widget() = object : Text<@Composable () -> Unit> {
+    private var text by mutableStateOf("")
 
     override val value = @Composable {
       BasicText(
@@ -67,7 +67,7 @@ class ComposeUiLazyListTest(
       )
     }
 
-    override var modifier = modifier
+    override var modifier: RedwoodModifier = RedwoodModifier
 
     override fun text(text: String) {
       this.text = text

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListTest.kt
@@ -50,15 +50,14 @@ class ViewLazyListTest(
 
   override fun flexContainer(direction: FlexDirection) = ViewTestFlexContainer(paparazzi.context, direction)
 
-  override fun widget(text: String, modifier: Modifier) = object : Text<View> {
+  override fun widget() = object : Text<View> {
     override val value = TextView(paparazzi.context).apply {
       background = ColorDrawable(Color.GREEN)
       textSize = 18f
       setTextColor(Color.BLACK)
-      this.text = text
     }
 
-    override var modifier = modifier
+    override var modifier: Modifier = Modifier
 
     override fun text(text: String) {
       value.text = text


### PR DESCRIPTION
No need to reimplement in each subtype.

Also switch over to a JVM library as there's nothing Android-specific in use in the abstract types.