### PR TITLE
Simplify selection of kotlin.test capability

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", ve
 kotlin-serializationPlugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }

--- a/redwood-treehouse-host/build.gradle
+++ b/redwood-treehouse-host/build.gradle
@@ -59,12 +59,7 @@ dependencies {
 
   // The kotlin.test library provides JVM variants for multiple testing frameworks. The Kotlin
   // plugin does not apply the capability to configurations created by the Android plugin.
-  androidTestImplementation(libs.kotlin.test) {
-    capabilities {
-      requireCapability(
-        "org.jetbrains.kotlin:kotlin-test-framework-junit:${libs.versions.kotlin.get()}")
-    }
-  }
+  androidTestImplementation libs.kotlin.test.junit
 }
 
 android {

--- a/redwood-widget-testing/build.gradle
+++ b/redwood-widget-testing/build.gradle
@@ -18,23 +18,20 @@ kotlin {
         api projects.redwoodWidget
       }
     }
-  }
-}
-
-dependencies {
-  // The kotlin.test library provides JVM variants for multiple testing frameworks. When used
-  // as a test dependency this selection is transparent. But since we are publishing a library
-  // we need to select one ourselves at compilation time.
-  def configurationNames = [
-    "jvmMainImplementation",
-    "debugImplementation",
-    "releaseImplementation",
-  ]
-  for (configurationName in configurationNames) {
-    add(configurationName, libs.kotlin.test) {
-      capabilities {
-        requireCapability(
-          "org.jetbrains.kotlin:kotlin-test-framework-junit:${libs.versions.kotlin.get()}")
+    androidMain {
+      dependencies {
+        // The kotlin.test library provides JVM variants for multiple testing frameworks. When used
+        // as a test dependency this selection is transparent. But since we are publishing a library
+        // we need to select one ourselves at compilation time.
+        api libs.kotlin.test.junit
+      }
+    }
+    jvmMain {
+      dependencies {
+        // The kotlin.test library provides JVM variants for multiple testing frameworks. When used
+        // as a test dependency this selection is transparent. But since we are publishing a library
+        // we need to select one ourselves at compilation time.
+        api libs.kotlin.test.junit
       }
     }
   }


### PR DESCRIPTION
Just declare the explicit dependency of the JUnit variant rather than messing with capabilities.