### PR TITLE
Serialize `MutableState` as a normal `JsonObject`

### DIFF
--- a/redwood-treehouse/src/commonTest/kotlin/app/cash/redwood/treehouse/StateSnapshotTest.kt
+++ b/redwood-treehouse/src/commonTest/kotlin/app/cash/redwood/treehouse/StateSnapshotTest.kt
@@ -47,19 +47,19 @@ class StateSnapshotTest {
     val storedStateSnapshot = storedStateSnapshot()
     val stateSnapshot = storedStateSnapshot.toStateSnapshot()
     assertThat(stateSnapshot.content).containsOnly(
-      "key1" to listOf(Saveable(true, JsonPrimitive(1))),
-      "key2" to listOf(Saveable(false, JsonPrimitive(1))),
-      "key3" to listOf(Saveable(true, JsonPrimitive("str"))),
-      "key4" to listOf(Saveable(false, JsonPrimitive("str"))),
+      "key1" to listOf(JsonMutableState(JsonPrimitive(1))),
+      "key2" to listOf(JsonPrimitive(1)),
+      "key3" to listOf(JsonMutableState(JsonPrimitive("str"))),
+      "key4" to listOf(JsonPrimitive("str")),
     )
   }
 
   private fun stateSnapshot() = StateSnapshot(
     mapOf(
-      "key1" to listOf(Saveable(true, JsonPrimitive(1))),
-      "key2" to listOf(Saveable(false, JsonPrimitive(1))),
-      "key3" to listOf(Saveable(true, JsonPrimitive("str"))),
-      "key4" to listOf(Saveable(false, JsonPrimitive("str"))),
+      "key1" to listOf(JsonMutableState(JsonPrimitive(1))),
+      "key2" to listOf(JsonPrimitive(1)),
+      "key3" to listOf(JsonMutableState(JsonPrimitive("str"))),
+      "key4" to listOf(JsonPrimitive("str")),
     ),
   )
 


### PR DESCRIPTION
We don't need to special case it by wrapping it in a custom `Saveable` object with a boolean flag.

Refs #1384 