### PR TITLE
Move Zipline embedding process to publishing-side

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildExtension.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildExtension.kt
@@ -29,13 +29,13 @@ interface RedwoodBuildExtension {
   /** Bundle a zip with dependencies and startup scripts for a CLI. */
   fun cliApplication(name: String, mainClass: String)
 
-  /** Bundle a zip of a Zipline application's compiled `.zipline` files. */
-  fun ziplineApplication()
-
   /**
-   * Consume a Zipline application in an Android application and embed it within assets.
+   * Bundle a zip of a Zipline application's compiled `.zipline` files ready for embedding.
    *
    * @name Name of the Treehouse application. Will be used to prefix the Zipline manifest file.
    */
-  fun embedZiplineApplication(dependencyNotation: Any, name: String)
+  fun ziplineApplication(name: String)
+
+  /** Consume a Zipline application in an Android application and embed it within assets. */
+  fun embedZiplineApplication(dependencyNotation: Any)
 }

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ZiplineAppEmbedTask.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ZiplineAppEmbedTask.kt
@@ -16,9 +16,7 @@
 package app.cash.redwood.buildsupport
 
 import app.cash.zipline.ZiplineManifest
-import javax.inject.Inject
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
@@ -29,10 +27,7 @@ import org.gradle.api.tasks.TaskAction
 
 private const val ZIPLINE_MANIFEST_JSON = "manifest.zipline.json"
 
-internal abstract class ZiplineAppAssetCopyTask
-@Inject constructor(
-  private val archiveOperations: ArchiveOperations,
-) : DefaultTask() {
+internal abstract class ZiplineAppEmbedTask : DefaultTask() {
   @get:InputFiles
   abstract val files: ConfigurableFileCollection
 
@@ -50,10 +45,8 @@ internal abstract class ZiplineAppAssetCopyTask
       mkdirs()
     }
 
-    val fileMap = archiveOperations.zipTree(files.singleFile)
-      .files
-      .associateBy { it.name }
-      .toMutableMap()
+    val fileMap = files.asFileTree.files
+      .associateByTo(mutableMapOf()) { it.name }
 
     val inputManifestFile = checkNotNull(fileMap.remove(ZIPLINE_MANIFEST_JSON)) {
       "No zipline.manifest.json file found in input files ${fileMap.keys}"

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ZiplineAppExtractTask.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ZiplineAppExtractTask.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.buildsupport
+
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+internal abstract class ZiplineAppExtractTask
+@Inject constructor(
+  private val fsOperations: FileSystemOperations,
+  private val archiveOperations: ArchiveOperations,
+) : DefaultTask() {
+  @get:InputFiles
+  abstract val inputFiles: ConfigurableFileCollection
+
+  @get:OutputDirectory
+  abstract val outputDirectory: DirectoryProperty
+
+  @TaskAction
+  fun copy() {
+    val outputDirectory = outputDirectory.get().asFile
+    fsOperations.delete {
+      it.delete(outputDirectory)
+    }
+    fsOperations.copy {
+      it.from(archiveOperations.zipTree(inputFiles.singleFile))
+      it.into(outputDirectory)
+    }
+  }
+}

--- a/samples/emoji-search/android-composeui/build.gradle
+++ b/samples/emoji-search/android-composeui/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 redwoodBuild {
-  embedZiplineApplication(projects.samples.emojiSearch.presenterTreehouse, 'emoji-search')
+  embedZiplineApplication(projects.samples.emojiSearch.presenterTreehouse)
 }
 
 android {

--- a/samples/emoji-search/android-views/build.gradle
+++ b/samples/emoji-search/android-views/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 redwoodBuild {
-  embedZiplineApplication(projects.samples.emojiSearch.presenterTreehouse, 'emoji-search')
+  embedZiplineApplication(projects.samples.emojiSearch.presenterTreehouse)
 }
 
 android {

--- a/samples/emoji-search/presenter-treehouse/build.gradle
+++ b/samples/emoji-search/presenter-treehouse/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'app.cash.zipline'
 
 redwoodBuild {
-  ziplineApplication()
+  ziplineApplication('emoji-search')
 }
 
 kotlin {


### PR DESCRIPTION
Need this for iOS. Seems more natural anyway.