### PR TITLE
Add Modifier.flex()

### DIFF
--- a/redwood-layout-compose/build.gradle
+++ b/redwood-layout-compose/build.gradle
@@ -17,6 +17,11 @@ kotlin {
         api projects.redwoodLayoutWidget
       }
     }
+    commonTest {
+      dependencies {
+        api libs.kotlin.test
+      }
+    }
   }
 }
 

--- a/redwood-layout-compose/src/commonMain/kotlin/app/cash/redwood/layout/compose/LayoutScopes.kt
+++ b/redwood-layout-compose/src/commonMain/kotlin/app/cash/redwood/layout/compose/LayoutScopes.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.compose
+
+import androidx.compose.runtime.Stable
+import app.cash.redwood.Modifier
+
+/**
+ * Equivalent to `modifier.grow(value).shrink(value)`.
+ *
+ * Call this in [ColumnScope] or [RowScope].
+ */
+@Stable
+public fun Modifier.flex(`value`: Double): Modifier =
+  then(GrowImpl(`value`)).then(ShrinkImpl(`value`))

--- a/redwood-layout-compose/src/commonTest/kotlin/app/cash/redwood/layout/compose/LayoutScopesTest.kt
+++ b/redwood-layout-compose/src/commonTest/kotlin/app/cash/redwood/layout/compose/LayoutScopesTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.compose
+
+import app.cash.redwood.Modifier
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LayoutScopesTest {
+  @Test
+  fun flexIsGrowAndShrink() {
+    val flex = Modifier.flex(0.5)
+    val components = flex.components()
+    assertEquals(
+      listOf(GrowImpl(0.5), ShrinkImpl(0.5)),
+      components,
+    )
+  }
+
+  private fun Modifier.components(): List<Modifier> {
+    return buildList {
+      this@components.forEach {
+        add(it)
+      }
+    }
+  }
+}

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -34,6 +34,7 @@ import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.compose.Column
 import app.cash.redwood.layout.compose.Row
+import app.cash.redwood.layout.compose.flex
 import app.cash.redwood.lazylayout.compose.ExperimentalRedwoodLazyLayoutApi
 import app.cash.redwood.lazylayout.compose.LazyColumn
 import app.cash.redwood.lazylayout.compose.items
@@ -137,14 +138,13 @@ private fun LazyColumn(
       state = TextFieldState(searchTerm.text),
       hint = "Search",
       onChange = { searchTerm = it },
-      modifier = Modifier.shrink(0.0),
     )
     LazyColumn(
       refreshing = refreshing,
       onRefresh = { refreshSignal++ },
       state = lazyListState,
       width = Constraint.Fill,
-      modifier = Modifier.grow(1.0),
+      modifier = Modifier.flex(1.0),
       placeholder = {
         Item(
           emojiImage = loadingEmojiImage,


### PR DESCRIPTION
This is syntactic sugar for Modifer.grow(x).shrink(x).

Unfortunately I only have one context receiver, so I can't constrain this to only being called in ColumnScope and RowScope.