### PR TITLE
Remove old annotation suppression

### DIFF
--- a/redwood-layout-shared-test/build.gradle
+++ b/redwood-layout-shared-test/build.gradle
@@ -23,7 +23,6 @@ kotlin {
         // as a test dependency this selection is transparent. But since we are publishing a library
         // we need to select one ourselves at compilation time.
         api libs.kotlin.test.junit
-        api libs.testParameterInjector
       }
     }
   }

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -35,7 +35,6 @@ import app.cash.redwood.yoga.FlexDirection
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-@Suppress("JUnitMalformedDeclaration")
 abstract class AbstractFlexContainerTest<T : Any> {
   abstract fun flexContainer(direction: FlexDirection): TestFlexContainer<T>
   abstract fun widget(): Text<T>


### PR DESCRIPTION
Removing parameterization eliminated the need for this suppression. Also delete the dependency that is now unused.