### PR TITLE
Move Gradle plugin build directory when included

### DIFF
--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -14,6 +14,10 @@ if (rootProject.name == 'redwood') {
   redwoodBuild {
     publishing()
   }
+} else {
+  // Move the build directory when included in build-support so as to not poison the real build.
+  // If we don't there's a chance incorrect build config values (configured below) will be used.
+  layout.buildDirectory = new File(rootDir, "build/redwood-gradle-plugin")
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
This ensures we do not get stale build config used when publishing from the main build.