### PR TITLE
task 'browserRun' not found replace with jsBrowserRun

### DIFF
--- a/samples/counter/README.md
+++ b/samples/counter/README.md
@@ -56,7 +56,7 @@ To simply view the sample app, open: https://cashapp.github.io/redwood/latest/co
 
 To build and modify the app locally, run this:
 ```
-./gradlew samples:counter:browser:browserRun
+./gradlew samples:counter:browser:jsBrowserRun
 ```
 
 If successful, the command will load the app at http://localhost:8080/ in your default web browser.

--- a/samples/emoji-search/README.md
+++ b/samples/emoji-search/README.md
@@ -72,7 +72,7 @@ To simply view the sample app, open: https://cashapp.github.io/redwood/latest/em
 
 To build and modify the app locally, run this:
 ```
-./gradlew samples:emoji-search:browser:browserRun
+./gradlew samples:emoji-search:browser:jsBrowserRun
 ```
 
 If successful, the command will load the app at http://localhost:8080/ in your default web browser.

--- a/test-app/README.md
+++ b/test-app/README.md
@@ -59,7 +59,7 @@ Running Test App on Web
 
 To build and modify the app locally, run this:
 ```
-./gradlew test-app:browser:browserRun
+./gradlew test-app:browser:jsBrowserRun
 ```
 
 If successful, the command will load the app at http://localhost:8080/ in your default web browser.


### PR DESCRIPTION
update the demo apps README to use `jsBrowserRun`, otherwise it has below error report.

```
Cannot locate tasks that match 'samples:emoji-search:browser:browserRun' as task 'browserRun' not found in project ':samples:emoji-search:browser'. Some candidates are: 'jsBrowserRun'.
```

I am not familiar with gradle, but seems this is some change in kotlin multiplatform plugin? 