### PR TITLE
Support animated programmatic scrolls

### DIFF
--- a/redwood-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/lazylayout/api/properties.kt
+++ b/redwood-lazylayout-api/src/commonMain/kotlin/app/cash/redwood/lazylayout/api/properties.kt
@@ -25,6 +25,8 @@ import kotlinx.serialization.Serializable
 @[Immutable Serializable]
 @Poko
 public class ScrollItemIndex(
-  @Suppress("unused") private val id: Int,
+  public val id: Int,
   public val index: Int,
+  /** True to smoothly scroll to the new position. */
+  public val animated: Boolean = false,
 )

--- a/redwood-lazylayout-api/src/commonTest/kotlin/app/cash/redwood/lazylayout/api/ScrollItemIndexSerializationTest.kt
+++ b/redwood-lazylayout-api/src/commonTest/kotlin/app/cash/redwood/lazylayout/api/ScrollItemIndexSerializationTest.kt
@@ -32,6 +32,10 @@ class ScrollItemIndexSerializationTest {
       ScrollItemIndex(3, 7),
       """{"id":3,"index":7}""",
     )
+    assertRoundTrip(
+      ScrollItemIndex(3, 7, animated = true),
+      """{"id":3,"index":7,"animated":true}""",
+    )
   }
 
   private fun assertRoundTrip(value: ScrollItemIndex, encoded: String) {

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.setValue
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
-import app.cash.redwood.lazylayout.api.ScrollItemIndex
 import app.cash.redwood.ui.Margin
 import kotlin.jvm.JvmName
 
@@ -70,7 +69,7 @@ internal fun LazyList(
     margin = margin,
     crossAxisAlignment = crossAxisAlignment,
     modifier = modifier,
-    scrollItemIndex = ScrollItemIndex(0, state.programmaticScrollIndex),
+    scrollItemIndex = state.programmaticScrollIndex,
     placeholder = { repeat(placeholderPoolSize) { placeholder() } },
     items = {
       for (index in itemsBefore until itemCount - itemsAfter) {
@@ -123,7 +122,7 @@ internal fun RefreshableLazyList(
     margin = margin,
     crossAxisAlignment = crossAxisAlignment,
     modifier = modifier,
-    scrollItemIndex = ScrollItemIndex(0, state.programmaticScrollIndex),
+    scrollItemIndex = state.programmaticScrollIndex,
     placeholder = { repeat(placeholderPoolSize) { placeholder() } },
     pullRefreshContentColor = pullRefreshContentColor,
     items = {

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessor.kt
@@ -23,9 +23,7 @@ public abstract class LazyListScrollProcessor {
 
   /** We can't scroll to this index until we have enough data for it to display! */
   private var deferredProgrammaticScrollIndex: Int = -1
-
-  /** Once we receive a user scroll, we stop forwarding programmatic scrolls. */
-  private var userHasScrolled = false
+  private var deferredProgrammaticScrollAnimated: Boolean = false
 
   /** De-duplicate calls to [onViewportChanged]. */
   private var mostRecentFirstIndex = -1
@@ -38,21 +36,20 @@ public abstract class LazyListScrollProcessor {
   public fun scrollItemIndex(scrollItemIndex: ScrollItemIndex) {
     // Defer until we have data in onEndChanges().
     deferredProgrammaticScrollIndex = scrollItemIndex.index
+    deferredProgrammaticScrollAnimated = scrollItemIndex.animated
   }
 
   public fun onEndChanges() {
     // Do nothing: we don't have deferred scrolls.
     if (deferredProgrammaticScrollIndex == -1) return
 
-    // Do nothing: we don't do programmatic scrolls if the user has already scrolled manually.
-    if (userHasScrolled) return
-
     // Do nothing: we can't scroll to this item because it hasn't loaded yet!
     if (contentSize() <= deferredProgrammaticScrollIndex) return
 
     // Do a programmatic scroll!
-    programmaticScroll(deferredProgrammaticScrollIndex)
+    programmaticScroll(deferredProgrammaticScrollIndex, deferredProgrammaticScrollAnimated)
     deferredProgrammaticScrollIndex = -1
+    deferredProgrammaticScrollAnimated = false
   }
 
   /**
@@ -60,8 +57,6 @@ public abstract class LazyListScrollProcessor {
    * scrolls.
    */
   public fun onUserScroll(firstIndex: Int, lastIndex: Int) {
-    if (firstIndex > 0) userHasScrolled = true
-
     if (firstIndex == mostRecentFirstIndex && lastIndex == mostRecentLastIndex) return
 
     this.mostRecentFirstIndex = firstIndex
@@ -74,5 +69,5 @@ public abstract class LazyListScrollProcessor {
   public abstract fun contentSize(): Int
 
   /** Perform a programmatic scroll. */
-  public abstract fun programmaticScroll(firstIndex: Int)
+  public abstract fun programmaticScroll(firstIndex: Int, animated: Boolean)
 }

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeScrollProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeScrollProcessor.kt
@@ -29,9 +29,9 @@ class FakeScrollProcessor : LazyListScrollProcessor() {
 
   override fun contentSize(): Int = size
 
-  override fun programmaticScroll(firstIndex: Int) {
+  override fun programmaticScroll(firstIndex: Int, animated: Boolean) {
     require(firstIndex < size)
-    events += "programmaticScroll($firstIndex)"
+    events += "programmaticScroll(firstIndex = $firstIndex, animated = $animated)"
   }
 
   fun takeEvents(): List<String> {

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessorTest.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessorTest.kt
@@ -34,7 +34,9 @@ class LazyListScrollProcessorTest {
     assertThat(processor.takeEvents()).isEmpty()
 
     processor.onEndChanges()
-    assertThat(processor.takeEvents()).containsExactly("programmaticScroll(10)")
+    assertThat(processor.takeEvents()).containsExactly(
+      "programmaticScroll(firstIndex = 10, animated = false)",
+    )
   }
 
   @Test
@@ -47,34 +49,41 @@ class LazyListScrollProcessorTest {
     // Once we have enough rows we can apply the scroll.
     processor.size = 30
     processor.onEndChanges()
-    assertThat(processor.takeEvents()).containsExactly("programmaticScroll(10)")
+    assertThat(processor.takeEvents()).containsExactly(
+      "programmaticScroll(firstIndex = 10, animated = false)",
+    )
   }
 
   @Test
-  fun programmaticScrollDiscardedAfterUserScroll() {
-    processor.size = 30
-
-    // Do a user scroll.
-    processor.onUserScroll(5, 14)
-    assertThat(processor.takeEvents()).containsExactly("userScroll(5, 14)")
-
-    // Don't apply the programmatic scroll. That fights the user.
-    processor.scrollItemIndex(ScrollItemIndex(0, 10))
-    processor.onEndChanges()
-    assertThat(processor.takeEvents()).isEmpty()
-  }
-
-  @Test
-  fun programmaticScrollOnlyTriggeredOnce() {
+  fun eachProgrammaticScrollOnlyTriggeredOnce() {
     processor.size = 30
 
     processor.scrollItemIndex(ScrollItemIndex(0, 10))
     processor.onEndChanges()
-    assertThat(processor.takeEvents()).containsExactly("programmaticScroll(10)")
+    assertThat(processor.takeEvents()).containsExactly(
+      "programmaticScroll(firstIndex = 10, animated = false)",
+    )
 
     // Confirm onEndIndex() only applies its change once.
     processor.onEndChanges()
     assertThat(processor.takeEvents()).isEmpty()
+  }
+
+  @Test
+  fun multipleProgrammaticScrolls() {
+    processor.size = 30
+
+    processor.scrollItemIndex(ScrollItemIndex(0, 10))
+    processor.onEndChanges()
+    assertThat(processor.takeEvents()).containsExactly(
+      "programmaticScroll(firstIndex = 10, animated = false)",
+    )
+
+    processor.scrollItemIndex(ScrollItemIndex(1, 20))
+    processor.onEndChanges()
+    assertThat(processor.takeEvents()).containsExactly(
+      "programmaticScroll(firstIndex = 20, animated = false)",
+    )
   }
 
   @Test

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -101,7 +101,7 @@ private fun LazyColumn(
   val lazyListState = rememberLazyListState()
 
   LaunchedEffect(searchTerm) {
-    lazyListState.programmaticScroll(0)
+    lazyListState.programmaticScroll(0, animated = true)
   }
 
   LaunchedEffect(refreshSignal) {


### PR DESCRIPTION
In emoji search when the search terms is changed we scroll to the top of the list. This means we need to treat programmatic scrolls as something that can happen repeatedly, not just when we restore a lazy list.

This moves the feature that prevents programmatic scrolls from colliding with user scrolls from host code to guest code. The benefit is it no longer risks getting the loaded window out of sync with the true scroll window.

This also implements all scroll behavior for iOS.