### PR TITLE
Split `ProtocolNodeFactory` from `ProtocolNode`

### DIFF
--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.Modifier
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.ChangesSink
 import app.cash.redwood.protocol.ChildrenChange
@@ -40,10 +41,11 @@ import kotlin.native.ObjCName
  * [PropertyChange]s and [ModifierChange]s are forwarded to their respective widgets.
  * Events from widgets are forwarded to [eventSink].
  */
+@OptIn(RedwoodCodegenApi::class)
 @ObjCName("ProtocolBridge", exact = true)
 public class ProtocolBridge<W : Any>(
   container: Widget.Children<W>,
-  private val factory: ProtocolNode.Factory<W>,
+  private val factory: ProtocolNodeFactory<W>,
   private val eventSink: EventSink,
 ) : ChangesSink {
   private val nodes = mutableMapOf<Id, ProtocolNode<W>>(
@@ -120,6 +122,7 @@ public class ProtocolBridge<W : Any>(
   }
 }
 
+@OptIn(RedwoodCodegenApi::class)
 private class RootProtocolNode<W : Any>(
   private val children: Widget.Children<W>,
 ) : ProtocolNode<W>, Widget<W> {

--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNode.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNode.kt
@@ -15,20 +15,19 @@
  */
 package app.cash.redwood.protocol.widget
 
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.ModifierElement
 import app.cash.redwood.protocol.PropertyChange
-import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.Widget
-import kotlin.native.ObjCName
 
 /**
  * A node which consumes protocol changes and applies them to a platform-specific representation.
  *
  * @suppress
  */
-@ObjCName("ProtocolNode", exact = true)
+@RedwoodCodegenApi
 public interface ProtocolNode<W : Any> {
   public val widget: Widget<W>
 
@@ -51,16 +50,4 @@ public interface ProtocolNode<W : Any> {
    * continue executing.
    */
   public fun children(tag: ChildrenTag): Widget.Children<W>?
-
-  @ObjCName("ProtocolNodeFactory", exact = true)
-  public interface Factory<W : Any> {
-    /**
-     * Create a new protocol node of the specified [tag].
-     *
-     * Invalid [tag] values can either produce an exception or result in `null` being returned.
-     * If `null` is returned, the caller should make every effort to ignore this node and
-     * continue executing.
-     */
-    public fun create(tag: WidgetTag): ProtocolNode<W>?
-  }
 }

--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactory.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactory.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import app.cash.redwood.RedwoodCodegenApi
+import app.cash.redwood.protocol.WidgetTag
+import kotlin.native.ObjCName
+
+@ObjCName("ProtocolNodeFactory", exact = true)
+public interface ProtocolNodeFactory<W : Any> {
+  /**
+   * Create a new protocol node of the specified [tag].
+   *
+   * Invalid [tag] values can either produce an exception or result in `null` being returned.
+   * If `null` is returned, the caller should make every effort to ignore this node and
+   * continue executing.
+   *
+   * @suppress
+   */
+  @RedwoodCodegenApi
+  public fun create(tag: WidgetTag): ProtocolNode<W>?
+}

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactoryTest.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolNodeFactoryTest.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.Modifier
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.EventSink
@@ -45,6 +46,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.modules.SerializersModule
 
+@OptIn(RedwoodCodegenApi::class)
 class ProtocolNodeFactoryTest {
   @Test fun unknownWidgetThrowsDefault() {
     val factory = TestSchemaProtocolNodeFactory(

--- a/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/annotations.kt
+++ b/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/annotations.kt
@@ -25,7 +25,8 @@ import androidx.compose.runtime.StableMarker
 public annotation class LayoutScopeMarker
 
 /**
- * Denote an API which should only be used by Redwood's generated code.
+ * Denote an API which should only be used by Redwood's generated code and is not considered
+ * stable across any version.
  *
  * @suppress
  */

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -54,7 +54,7 @@ internal object WidgetProtocol {
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.widget", "ProtocolMismatchHandler")
   val ProtocolNode = ClassName("app.cash.redwood.protocol.widget", "ProtocolNode")
-  val ProtocolNodeFactory = ProtocolNode.nestedClass("Factory")
+  val ProtocolNodeFactory = ClassName("app.cash.redwood.protocol.widget", "ProtocolNodeFactory")
 }
 
 internal object Redwood {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
@@ -112,6 +112,7 @@ internal fun generateProtocolNodeFactory(
           FunSpec.builder("create")
             .addModifiers(OVERRIDE)
             .addParameter("tag", Protocol.WidgetTag)
+            .addAnnotation(Redwood.RedwoodCodegenApi)
             .returns(
               WidgetProtocol.ProtocolNode.parameterizedBy(typeVariableW)
                 .copy(nullable = true),
@@ -197,6 +198,7 @@ internal fun generateProtocolNode(
         .addModifiers(INTERNAL)
         .addTypeVariable(typeVariableW)
         .addSuperinterface(protocolType)
+        .addAnnotation(Redwood.RedwoodCodegenApi)
         .primaryConstructor(
           FunSpec.constructorBuilder()
             .addParameter("widget", widgetType)

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -19,7 +19,7 @@ import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.widget.ProtocolBridge
-import app.cash.redwood.protocol.widget.ProtocolNode
+import app.cash.redwood.protocol.widget.ProtocolNodeFactory
 import app.cash.redwood.ui.OnBackPressedCallback
 import app.cash.redwood.ui.OnBackPressedDispatcher
 import app.cash.redwood.ui.UiConfiguration
@@ -319,7 +319,7 @@ private class ViewContentCodeBinding<A : AppService>(
       factory = view.widgetSystem.widgetFactory(
         json = json,
         protocolMismatchHandler = eventPublisher.widgetProtocolMismatchHandler(app),
-      ) as ProtocolNode.Factory<Any>,
+      ) as ProtocolNodeFactory<Any>,
       eventSink = this,
     )
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -16,7 +16,7 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
-import app.cash.redwood.protocol.widget.ProtocolNode
+import app.cash.redwood.protocol.widget.ProtocolNodeFactory
 import app.cash.redwood.widget.RedwoodView
 import kotlin.native.ObjCName
 import kotlinx.serialization.json.Json
@@ -47,6 +47,6 @@ public interface TreehouseView<W : Any> : RedwoodView<W> {
     public fun widgetFactory(
       json: Json,
       protocolMismatchHandler: ProtocolMismatchHandler,
-    ): ProtocolNode.Factory<W>
+    ): ProtocolNodeFactory<W>
   }
 }


### PR DESCRIPTION
Annotate `ProtocolNode` as codegen API as it always should have been.

This is for #1084 work, but also skates toward #1594.