### PR TITLE
Fix protocol nodes failing to notify their container of modifier changes

### DIFF
--- a/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
+++ b/redwood-protocol-widget/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
@@ -72,6 +72,7 @@ public class ProtocolBridge<W : Any>(
             is Add -> {
               val child = node(change.childId)
               children.insert(change.index, child.widget)
+              child.attachTo(children)
             }
             is Move -> {
               children.move(change.fromIndex, change.toIndex, change.count)

--- a/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
+++ b/redwood-protocol-widget/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
@@ -31,9 +31,7 @@ open class EmptyTestSchemaWidgetFactory : TestSchemaWidgetFactory<Nothing> {
   override fun Text(): Text<Nothing> = TODO()
   override fun Button() = object : Button<Nothing> {
     override val value get() = TODO()
-    override var modifier: Modifier
-      get() = TODO()
-      set(_) { TODO() }
+    override var modifier: Modifier = Modifier
 
     override fun text(text: String?) = TODO()
     override fun onClick(onClick: (() -> Unit)?) = TODO()

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
@@ -25,6 +25,7 @@ import kotlin.native.ObjCName
 @ObjCName("MutableListChildren", exact = true)
 public class MutableListChildren<W : Any>(
   private val list: MutableList<Widget<W>> = mutableListOf(),
+  private val modifierUpdated: () -> Unit = {},
 ) : Widget.Children<W>, MutableList<Widget<W>> by list {
   override fun insert(index: Int, widget: Widget<W>) {
     list.add(index, widget)
@@ -38,5 +39,7 @@ public class MutableListChildren<W : Any>(
     list.remove(index, count)
   }
 
-  override fun onModifierUpdated() {}
+  override fun onModifierUpdated() {
+    modifierUpdated()
+  }
 }


### PR DESCRIPTION
Whoops, we forgot to attach the node to its parent container.