### PR TITLE
Track the index of a `ProtocolNode` within its parent container

### DIFF
--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
@@ -74,8 +74,7 @@ public class ProtocolBridge<W : Any>(
           when (change) {
             is Add -> {
               val child = node(change.childId)
-              children.insert(change.index, child.widget)
-              child.attachTo(children)
+              children.insert(change.index, child)
             }
             is Move -> {
               children.move(change.fromIndex, change.toIndex, change.count)
@@ -131,8 +130,10 @@ public class ProtocolBridge<W : Any>(
 
 @OptIn(RedwoodCodegenApi::class)
 private class RootProtocolNode<W : Any>(
-  private val children: Widget.Children<W>,
+  children: Widget.Children<W>,
 ) : ProtocolNode<W>(), Widget<W> {
+  private val children = ProtocolChildren(children)
+
   override fun apply(change: PropertyChange, eventSink: EventSink) {
     throw AssertionError("unexpected: $change")
   }

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ChildrenNodeIndexTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ChildrenNodeIndexTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.widget
+
+import app.cash.redwood.Modifier
+import app.cash.redwood.RedwoodCodegenApi
+import app.cash.redwood.protocol.ChildrenTag
+import app.cash.redwood.protocol.EventSink
+import app.cash.redwood.protocol.PropertyChange
+import app.cash.redwood.widget.MutableListChildren
+import app.cash.redwood.widget.Widget
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+/**
+ * This class tests an implementation detail of [ProtocolChildren] which maintains the correct
+ * index value on its child [ProtocolNode]s. While it could conceivably be tested through public
+ * API it's far easier to validate the behavior this way.
+ */
+@OptIn(RedwoodCodegenApi::class)
+class ChildrenNodeIndexTest {
+  private val root = ProtocolChildren(MutableListChildren<String>())
+
+  @Test fun insert() {
+    val a = WidgetNode(StringWidget("a"))
+    assertThat(a.index).isEqualTo(-1)
+    root.insert(0, a)
+    assertThat(a.index).isEqualTo(0)
+
+    val b = WidgetNode(StringWidget("a"))
+    root.insert(1, b)
+    assertThat(a.index).isEqualTo(0)
+    assertThat(b.index).isEqualTo(1)
+
+    val c = WidgetNode(StringWidget("a"))
+    root.insert(0, c)
+    assertThat(c.index).isEqualTo(0)
+    assertThat(a.index).isEqualTo(1)
+    assertThat(b.index).isEqualTo(2)
+  }
+
+  @Test fun remove() {
+    val a = WidgetNode(StringWidget("a"))
+    val b = WidgetNode(StringWidget("b"))
+    val c = WidgetNode(StringWidget("c"))
+    val d = WidgetNode(StringWidget("d"))
+    val e = WidgetNode(StringWidget("e"))
+    root.insert(0, a)
+    root.insert(1, b)
+    root.insert(2, c)
+    root.insert(3, d)
+    root.insert(4, e)
+    assertThat(a.index).isEqualTo(0)
+    assertThat(b.index).isEqualTo(1)
+    assertThat(c.index).isEqualTo(2)
+    assertThat(d.index).isEqualTo(3)
+    assertThat(e.index).isEqualTo(4)
+
+    root.remove(2, 1) // c
+    assertThat(a.index).isEqualTo(0)
+    assertThat(b.index).isEqualTo(1)
+    assertThat(d.index).isEqualTo(2)
+    assertThat(e.index).isEqualTo(3)
+
+    root.remove(1, 2) // b, d
+    assertThat(a.index).isEqualTo(0)
+    assertThat(e.index).isEqualTo(1)
+
+    root.remove(1, 1) // e
+    assertThat(a.index).isEqualTo(0)
+  }
+
+  @Test fun move() {
+    val a = WidgetNode(StringWidget("a"))
+    val b = WidgetNode(StringWidget("b"))
+    val c = WidgetNode(StringWidget("c"))
+    val d = WidgetNode(StringWidget("d"))
+    val e = WidgetNode(StringWidget("e"))
+    root.insert(0, a)
+    root.insert(1, b)
+    root.insert(2, c)
+    root.insert(3, d)
+    root.insert(4, e)
+    assertThat(a.index).isEqualTo(0)
+    assertThat(b.index).isEqualTo(1)
+    assertThat(c.index).isEqualTo(2)
+    assertThat(d.index).isEqualTo(3)
+    assertThat(e.index).isEqualTo(4)
+
+    root.move(0, 5, 1) // a 0 --> 4
+    assertThat(b.index).isEqualTo(0)
+    assertThat(c.index).isEqualTo(1)
+    assertThat(d.index).isEqualTo(2)
+    assertThat(e.index).isEqualTo(3)
+    assertThat(a.index).isEqualTo(4)
+
+    root.move(1, 4, 2) // c,d 1 --> 2
+    assertThat(b.index).isEqualTo(0)
+    assertThat(e.index).isEqualTo(1)
+    assertThat(c.index).isEqualTo(2)
+    assertThat(d.index).isEqualTo(3)
+    assertThat(a.index).isEqualTo(4)
+
+    root.move(2, 1, 3) // c,d,a 2 --> 1
+    assertThat(b.index).isEqualTo(0)
+    assertThat(c.index).isEqualTo(1)
+    assertThat(d.index).isEqualTo(2)
+    assertThat(a.index).isEqualTo(3)
+    assertThat(e.index).isEqualTo(4)
+  }
+}
+
+@OptIn(RedwoodCodegenApi::class)
+private class WidgetNode(override val widget: StringWidget) : ProtocolNode<String>() {
+  override fun apply(change: PropertyChange, eventSink: EventSink) {
+    throw UnsupportedOperationException()
+  }
+
+  override fun children(tag: ChildrenTag): ProtocolChildren<String>? {
+    throw UnsupportedOperationException()
+  }
+}
+
+private class StringWidget(override val value: String) : Widget<String> {
+  override var modifier: Modifier = Modifier
+}

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -54,6 +54,7 @@ internal object WidgetProtocol {
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.widget", "ProtocolMismatchHandler")
   val ProtocolNode = ClassName("app.cash.redwood.protocol.widget", "ProtocolNode")
+  val ProtocolChildren = ClassName("app.cash.redwood.protocol.widget", "ProtocolChildren")
   val GeneratedProtocolFactory = ClassName("app.cash.redwood.protocol.widget", "GeneratedProtocolFactory")
 }
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
@@ -19,8 +19,8 @@ import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.PropertyChange
+import app.cash.redwood.protocol.widget.ProtocolChildren
 import app.cash.redwood.protocol.widget.ProtocolNode
-import app.cash.redwood.widget.Widget
 import kotlinx.serialization.json.JsonPrimitive
 
 /**
@@ -34,7 +34,7 @@ internal class FakeProtocolNode : ProtocolNode<FakeWidget>() {
     widget.label = (change.value as JsonPrimitive).content
   }
 
-  override fun children(tag: ChildrenTag): Widget.Children<FakeWidget>? {
+  override fun children(tag: ChildrenTag): ProtocolChildren<FakeWidget>? {
     error("unexpected call")
   }
 }


### PR DESCRIPTION
This uses a new type, `ProtocolChildren`, to maintain a list of `ProtocolNode`s corresponding to a Widget.Children grouping. This class is mostly a copy of `ChildrenNode` from redwood-compose. In the future hopefully we can unify their logic.

For #1084. Wants #1594.