### PR TITLE
New ZiplineTreehouseUi.Host bridges all host functions

### DIFF
--- a/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
+++ b/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
@@ -135,7 +135,9 @@ private fun ZiplineTreehouseUi.Host.asOnBackPressedDispatcher() = object : OnBac
 }
 
 private fun OnBackPressedCallback.asService() = object : OnBackPressedCallbackService {
-  override var isEnabled: Boolean by this@asService::isEnabled
+  override var isEnabled: Boolean
+    get() = this@asService.isEnabled
+    set(value) = this@asService.isEnabled = value
 
   override fun handleOnBackPressed() {
     this@asService.handleOnBackPressed()

--- a/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
+++ b/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
@@ -137,7 +137,9 @@ private fun ZiplineTreehouseUi.Host.asOnBackPressedDispatcher() = object : OnBac
 private fun OnBackPressedCallback.asService() = object : OnBackPressedCallbackService {
   override var isEnabled: Boolean
     get() = this@asService.isEnabled
-    set(value) = this@asService.isEnabled = value
+    set(value) {
+      this@asService.isEnabled = value
+    }
 
   override fun handleOnBackPressed() {
     this@asService.handleOnBackPressed()

--- a/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
+++ b/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/treehouseCompose.kt
@@ -143,7 +143,8 @@ private fun OnBackPressedCallback.asService() = object : OnBackPressedCallbackSe
 }
 
 private object NullOnBackPressedDispatcherService : OnBackPressedDispatcherService {
-  override fun addCallback(callback: OnBackPressedCallbackService) = object : CancellableService {
-    override fun cancel() = Unit
-  }
+  override fun addCallback(onBackPressedCallback: OnBackPressedCallbackService) =
+    object : CancellableService {
+      override fun cancel() = Unit
+    }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeZiplineTreehouseUi.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeZiplineTreehouseUi.kt
@@ -37,21 +37,16 @@ class FakeZiplineTreehouseUi(
 ) : ZiplineTreehouseUi {
   private var nextWidgetId = 1
 
-  private lateinit var changesSink: ChangesSinkService
+  private lateinit var host: ZiplineTreehouseUi.Host
 
-  override fun start(
-    changesSink: ChangesSinkService,
-    onBackPressedDispatcher: OnBackPressedDispatcherService,
-    uiConfigurations: StateFlow<UiConfiguration>,
-    stateSnapshot: StateSnapshot?,
-  ) {
+  override fun start(host: ZiplineTreehouseUi.Host) {
     eventLog += "$name.start()"
-    this.changesSink = changesSink
+    this.host = host
   }
 
   fun addWidget(label: String) {
     val widgetId = Id(nextWidgetId++)
-    changesSink.sendChanges(
+    host.sendChanges(
       listOf(
         Create(widgetId, WidgetTag(1)),
         PropertyChange(widgetId, PropertyTag(1), JsonPrimitive(label)),
@@ -62,6 +57,16 @@ class FakeZiplineTreehouseUi(
 
   override fun sendEvent(event: Event) {
     eventLog += "$name.sendEvent($event)"
+  }
+
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun start(
+    changesSink: ChangesSinkService,
+    onBackPressedDispatcher: OnBackPressedDispatcherService,
+    uiConfigurations: StateFlow<UiConfiguration>,
+    stateSnapshot: StateSnapshot?,
+  ) {
+    error("unexpected call")
   }
 
   @Suppress("OVERRIDE_DEPRECATION")

--- a/redwood-treehouse/api/zipline-api.toml
+++ b/redwood-treehouse/api/zipline-api.toml
@@ -97,4 +97,26 @@ functions = [
 
   # fun start(app.cash.redwood.treehouse.ChangesSinkService, kotlinx.coroutines.flow.StateFlow<app.cash.redwood.ui.UiConfiguration>, app.cash.redwood.treehouse.StateSnapshot): kotlin.Unit
   "FiVQXMQW",
+
+  # fun start(app.cash.redwood.treehouse.ZiplineTreehouseUi.Host): kotlin.Unit
+  "h9yZr91W",
+]
+
+[app.cash.redwood.treehouse.ZiplineTreehouseUi.Host]
+
+functions = [
+  # fun addOnBackPressedCallback(app.cash.redwood.treehouse.OnBackPressedCallbackService): app.cash.redwood.treehouse.CancellableService
+  "2nRsPBzK",
+
+  # fun close(): kotlin.Unit
+  "moYx+T3e",
+
+  # fun sendChanges(kotlin.collections.List): kotlin.Unit
+  "W8qOuU0t",
+
+  # val stateSnapshot: app.cash.redwood.treehouse.StateSnapshot
+  "hIDyr4lf",
+
+  # val uiConfigurations: kotlinx.coroutines.flow.StateFlow<app.cash.redwood.ui.UiConfiguration>
+  "iAkCX7gg",
 ]

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/OnBackPressedDispatcherService.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/OnBackPressedDispatcherService.kt
@@ -22,5 +22,5 @@ import kotlin.native.ObjCName
 /** Redwood's [OnBackPressedDispatcher] but implementing [ZiplineService]. */
 @ObjCName("OnBackPressedDispatcherService", exact = true)
 public interface OnBackPressedDispatcherService : ZiplineService {
-  public fun addCallback(callback: OnBackPressedCallbackService): CancellableService
+  public fun addCallback(onBackPressedCallback: OnBackPressedCallbackService): CancellableService
 }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/OnBackPressedDispatcherService.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/OnBackPressedDispatcherService.kt
@@ -22,5 +22,5 @@ import kotlin.native.ObjCName
 /** Redwood's [OnBackPressedDispatcher] but implementing [ZiplineService]. */
 @ObjCName("OnBackPressedDispatcherService", exact = true)
 public interface OnBackPressedDispatcherService : ZiplineService {
-  public fun addCallback(onBackPressedCallback: OnBackPressedCallbackService): CancellableService
+  public fun addCallback(callback: OnBackPressedCallbackService): CancellableService
 }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineTreehouseUi.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineTreehouseUi.kt
@@ -28,6 +28,9 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @ObjCName("ZiplineTreehouseUi", exact = true)
 public interface ZiplineTreehouseUi : ZiplineService, EventSink {
+  public fun start(host: Host)
+
+  @Deprecated("Use `start` method that takes in a Host")
   public fun start(
     changesSink: ChangesSinkService,
     onBackPressedDispatcher: OnBackPressedDispatcherService,
@@ -46,4 +49,12 @@ public interface ZiplineTreehouseUi : ZiplineService, EventSink {
   )
 
   public fun snapshotState(): StateSnapshot? = null
+
+  /** Access to the host that presents this UI. */
+  public interface Host : ZiplineService, ChangesSinkService {
+    public val uiConfigurations: StateFlow<UiConfiguration>
+    public val stateSnapshot: StateSnapshot?
+
+    public fun addOnBackPressedCallback(callback: OnBackPressedCallbackService): CancellableService
+  }
 }


### PR DESCRIPTION
At the moment we've got 4 host functions offered to each UI. In a follow-up I'd like to introduce a 5th. I'd like the process of adding a 5th to not require yet another start() overload, so I'm introducing this type to make additional features easier to add later.