### PR TITLE
Disable debug build type for Android libraries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
 
-      - run: ./gradlew verifyPaparazziDebug
+      - run: ./gradlew verifyPaparazzi
 
       - run: xcodebuild -project redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj -scheme RedwoodLayoutUIViewTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' test
 

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -169,10 +169,27 @@ class RedwoodBuildPlugin : Plugin<Project> {
       }
     }
 
-    // Disable the release build type because we never need it for sample applications.
+    plugins.withId("com.android.library") {
+      val androidComponents = extensions.getByType(AndroidComponentsExtension::class.java)
+      androidComponents.beforeVariants {
+        // Disable the debug build type for libraries because we only publish release.
+        if (it.buildType == "debug") {
+          it.enable = false
+        }
+      }
+    }
+
     plugins.withId("com.android.application") {
-      val android = extensions.getByType(AndroidComponentsExtension::class.java)
-      android.beforeVariants {
+      val android = extensions.getByName("android") as BaseExtension
+      android.buildTypes.apply {
+        // Libraries don't build debug so fall back to release.
+        getByName("debug") {
+          it.matchingFallbacks += "release"
+        }
+      }
+      val androidComponents = extensions.getByType(AndroidComponentsExtension::class.java)
+      androidComponents.beforeVariants {
+        // Disable the release build type for sample applications because we never need it.
         if (it.buildType == "release") {
           it.enable = false
         }


### PR DESCRIPTION
We only publish the release build type, so there's no reason to build the debug one.

Before:

    $ gb --dry-run | grep SKIPPED | wc -l
        6253

After:

    $ gb --dry-run | grep SKIPPED | wc -l
        5635

Closes #1649 