### PR TITLE
Handle uncaught exceptions from async calls

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
@@ -370,4 +370,20 @@ public open class EventListener {
     name: String,
   ) {
   }
+
+  /**
+   * Invoked when [app] has thrown an uncaught exception.
+   *
+   * This indicates an unrecoverable software bug. Development implementations should report the
+   * exception to the developer. Production implementations should post the exception to a bug
+   * tracking service.
+   *
+   * When a Treehouse app fails its current [Zipline] instance is canceled so no further code will
+   * execute. A new [Zipline] will start when new code available, or when the app is restarted.
+   */
+  public open fun uncaughtException(
+    app: TreehouseApp<*>,
+    exception: Throwable,
+  ) {
+  }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventPublisher.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventPublisher.kt
@@ -33,4 +33,6 @@ internal interface EventPublisher {
   fun onUnknownEvent(widgetTag: WidgetTag, tag: EventTag)
 
   fun onUnknownEventNode(id: Id, tag: EventTag)
+
+  fun onUncaughtException(exception: Throwable)
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealEventPublisher.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealEventPublisher.kt
@@ -187,4 +187,8 @@ internal class RealEventPublisher(
   override fun onUnknownEventNode(id: Id, tag: EventTag) {
     listener.onUnknownEventNode(app, id, tag)
   }
+
+  override fun onUncaughtException(exception: Throwable) {
+    listener.uncaughtException(app, exception)
+  }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
@@ -55,7 +55,7 @@ internal class FakeCodeHost : CodeHost<FakeAppService> {
     }
   }
 
-  fun triggerException(exception: Throwable) {
+  override fun handleUncaughtException(exception: Throwable) {
     for (listener in listeners) {
       listener.uncaughtException(exception)
     }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeEventPublisher.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeEventPublisher.kt
@@ -37,4 +37,7 @@ class FakeEventPublisher : EventPublisher {
 
   override fun onUnknownEventNode(id: Id, tag: EventTag) {
   }
+
+  override fun onUncaughtException(exception: Throwable) {
+  }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
@@ -304,7 +304,7 @@ class TreehouseAppContentTest {
     content.bind(view1)
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
 
-    codeHost.triggerException(Exception("boom!"))
+    codeHost.handleUncaughtException(Exception("boom!"))
     eventLog.takeEventsInAnyOrder(
       "codeSessionA.app.uis[0].close()",
       "codeListener.onUncaughtException(view1, kotlin.Exception: boom!)",
@@ -321,7 +321,7 @@ class TreehouseAppContentTest {
     codeHost.session = FakeCodeSession("codeSessionA", eventLog)
     eventLog.takeEvent("codeSessionA.start()")
 
-    codeHost.triggerException(Exception("boom!"))
+    codeHost.handleUncaughtException(Exception("boom!"))
     eventLog.takeEvent("codeSessionA.cancel()")
 
     val view1 = FakeTreehouseView("view1")
@@ -347,7 +347,7 @@ class TreehouseAppContentTest {
     content.bind(view1)
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
 
-    codeHost.triggerException(Exception("boom!"))
+    codeHost.handleUncaughtException(Exception("boom!"))
     eventLog.takeEventsInAnyOrder(
       "codeSessionA.app.uis[0].close()",
       "codeListener.onUncaughtException(view1, kotlin.Exception: boom!)",
@@ -376,7 +376,7 @@ class TreehouseAppContentTest {
     content.preload(FakeOnBackPressedDispatcher(), uiConfiguration)
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
 
-    codeHost.triggerException(Exception("boom!"))
+    codeHost.handleUncaughtException(Exception("boom!"))
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeSessionA.cancel()")
 

--- a/redwood-treehouse/api/zipline-api.toml
+++ b/redwood-treehouse/api/zipline-api.toml
@@ -17,6 +17,9 @@ functions = [
   # fun close(): kotlin.Unit
   "moYx+T3e",
 
+  # fun handleUncaughtException(kotlin.Throwable): kotlin.Unit
+  "Hls+uhG7",
+
   # fun onUnknownEvent(app.cash.redwood.protocol.WidgetTag, app.cash.redwood.protocol.EventTag): kotlin.Unit
   "jmKreoSS",
 

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
@@ -30,8 +30,16 @@ public interface AppLifecycle : ZiplineService {
   public interface Host : ZiplineService {
     public fun requestFrame()
 
+    /** Notify the host that an event was unrecognized and will be ignored. */
     public fun onUnknownEvent(widgetTag: WidgetTag, tag: EventTag)
 
+    /**
+     * Notify the host that an event was received for a node that either never existed or that no
+     * longer exists. That event will be ignored.
+     */
     public fun onUnknownEventNode(id: Id, tag: EventTag)
+
+    /** Handle an uncaught exception. The app is now in an undefined state and must be stopped. */
+    public fun handleUncaughtException(exception: Throwable)
   }
 }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
@@ -34,8 +34,8 @@ public interface AppLifecycle : ZiplineService {
     public fun onUnknownEvent(widgetTag: WidgetTag, tag: EventTag)
 
     /**
-     * Notify the host that an event was received for a node that either never existed or that no
-     * longer exists. That event will be ignored.
+     * Notify the host that an event was received for a node that no longer exists.
+     * That event will be ignored.
      */
     public fun onUnknownEventNode(id: Id, tag: EventTag)
 

--- a/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
+++ b/samples/emoji-search/presenter/src/commonMain/kotlin/com/example/redwood/emojisearch/presenter/EmojiSearch.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.SaverScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -44,6 +45,7 @@ import com.example.redwood.emojisearch.compose.Image
 import com.example.redwood.emojisearch.compose.Text
 import com.example.redwood.emojisearch.compose.TextInput
 import example.values.TextFieldState
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
 data class EmojiImage(
@@ -85,6 +87,7 @@ private fun LazyColumn(
   httpClient: HttpClient,
   navigator: Navigator,
 ) {
+  val scope = rememberCoroutineScope()
   val allEmojis = remember { mutableStateListOf<EmojiImage>() }
 
   // Simple counter that allows us to trigger refreshes by simple incrementing the value
@@ -139,9 +142,15 @@ private fun LazyColumn(
       hint = "Search",
       onChange = { textFieldState ->
         // Make it easy to trigger a crash to manually test exception handling!
-        if (textFieldState.text == "crash") {
-          throw RuntimeException("boom!")
+        when (textFieldState.text) {
+          "crash" -> throw RuntimeException("boom!")
+          "async" -> {
+            scope.launch {
+              throw RuntimeException("boom!")
+            }
+          }
         }
+
         searchTerm = textFieldState
       },
     )


### PR DESCRIPTION
When the guest throws an uncaught exception, a guest-side CoroutineExceptionHandler now forwards it to the host via AppLifecycle.handleUncaughtException(). That now triggers a graceful break of all UIs.