### PR TITLE
Promote more lifecycle to ZiplineCodeSession

### DIFF
--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/AndroidChoreographerFrameClock.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/AndroidChoreographerFrameClock.kt
@@ -22,18 +22,11 @@ import kotlinx.coroutines.launch
 /**
  * A [FrameClock] that sends frames using [Choreographer].
  */
-internal class AndroidChoreographerFrameClock : FrameClock {
-  private val choreographer = Choreographer.getInstance()
-  private lateinit var scope: CoroutineScope
-  private lateinit var dispatchers: TreehouseDispatchers
-
-  override fun start(
-    scope: CoroutineScope,
-    dispatchers: TreehouseDispatchers,
-  ) {
-    this.scope = scope
-    this.dispatchers = dispatchers
-  }
+internal class AndroidChoreographerFrameClock private constructor(
+  private val choreographer: Choreographer,
+  private val scope: CoroutineScope,
+  private val dispatchers: TreehouseDispatchers,
+) : FrameClock {
 
   override fun requestFrame(appLifecycle: AppLifecycle) {
     choreographer.postFrameCallback { frameTimeNanos ->
@@ -41,5 +34,13 @@ internal class AndroidChoreographerFrameClock : FrameClock {
         appLifecycle.sendFrame(frameTimeNanos)
       }
     }
+  }
+
+  class Factory : FrameClock.Factory {
+    private val choreographer = Choreographer.getInstance()
+    override fun create(
+      scope: CoroutineScope,
+      dispatchers: TreehouseDispatchers,
+    ) = AndroidChoreographerFrameClock(choreographer, scope, dispatchers)
   }
 }

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -38,7 +38,7 @@ public fun TreehouseAppFactory(
   dispatchers = AndroidTreehouseDispatchers(),
   eventListener = eventListener,
   httpClient = httpClient.asZiplineHttpClient(),
-  frameClock = AndroidChoreographerFrameClock(),
+  frameClockFactory = AndroidChoreographerFrameClock.Factory(),
   manifestVerifier = manifestVerifier,
   embeddedDir = embeddedDir,
   embeddedFileSystem = embeddedFileSystem,

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeHost.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeHost.kt
@@ -15,9 +15,6 @@
  */
 package app.cash.redwood.treehouse
 
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.CoroutineExceptionHandler
-
 /** Manages loading and hot-reloading a series of code sessions. */
 internal interface CodeHost<A : AppService> {
   val stateStore: StateStore
@@ -25,39 +22,11 @@ internal interface CodeHost<A : AppService> {
   /** Only accessed on [TreehouseDispatchers.ui]. */
   val session: CodeSession<A>?
 
-  fun newServiceScope(): ServiceScope<A>
-
-  /** Cancels the current code and propagates [exception] to all listeners. */
-  fun handleUncaughtException(exception: Throwable)
-
   fun addListener(listener: Listener<A>)
 
   fun removeListener(listener: Listener<A>)
 
   interface Listener<A : AppService> {
     fun codeSessionChanged(next: CodeSession<A>)
-    fun uncaughtException(exception: Throwable)
-  }
-
-  /**
-   * Tracks all of the services created to produce a UI, and offers a single mechanism to close
-   * them all. Note that closing this does not close the app services it was applied to.
-   */
-  interface ServiceScope<A : AppService> {
-    /**
-     * Returns a new instance that forwards calls to [appService] and keeps track of returned
-     * instances so they may be closed.
-     */
-    fun apply(appService: A): A
-    fun close()
-  }
-}
-
-internal fun CodeHost<*>.asExceptionHandler() = object : CoroutineExceptionHandler {
-  override val key: CoroutineContext.Key<*>
-    get() = CoroutineExceptionHandler.Key
-
-  override fun handleException(context: CoroutineContext, exception: Throwable) {
-    handleUncaughtException(exception)
   }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -15,6 +15,9 @@
  */
 package app.cash.redwood.treehouse
 
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
 
 /** The host state for a single code load. We get a new session each time we get new code. */
@@ -23,7 +26,44 @@ internal interface CodeSession<A : AppService> {
 
   val json: Json
 
-  fun start()
+  fun start(sessionScope: CoroutineScope)
+
+  fun addListener(listener: Listener<A>)
+
+  fun removeListener(listener: Listener<A>)
+
+  fun newServiceScope(): ServiceScope<A>
+
+  /** Propagates [exception] to all listeners and cancels this session. */
+  fun handleUncaughtException(exception: Throwable)
 
   fun cancel()
+
+  /**
+   * Tracks all of the services created to produce a UI, and offers a single mechanism to close
+   * them all. Note that closing this does not close the app services it was applied to.
+   */
+  interface ServiceScope<A : AppService> {
+    /**
+     * Returns a new instance that forwards calls to [appService] and keeps track of returned
+     * instances so they may be closed.
+     */
+    fun apply(appService: A): A
+    fun close()
+  }
+
+  interface Listener<A : AppService> {
+    fun onUncaughtException(codeSession: CodeSession<A>, exception: Throwable)
+    fun onCancel(codeSession: CodeSession<A>)
+  }
 }
+
+internal val CodeSession<*>.coroutineExceptionHandler: CoroutineExceptionHandler
+  get() = object : CoroutineExceptionHandler {
+    override val key: CoroutineContext.Key<*>
+      get() = CoroutineExceptionHandler.Key
+
+    override fun handleException(context: CoroutineContext, exception: Throwable) {
+      handleUncaughtException(exception)
+    }
+  }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -26,7 +26,7 @@ internal interface CodeSession<A : AppService> {
 
   val json: Json
 
-  fun start(sessionScope: CoroutineScope)
+  fun start(sessionScope: CoroutineScope, frameClock: FrameClock)
 
   fun addListener(listener: Listener<A>)
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/FrameClock.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/FrameClock.kt
@@ -18,12 +18,6 @@ package app.cash.redwood.treehouse
 import kotlinx.coroutines.CoroutineScope
 
 internal interface FrameClock {
-  /** Run this clock until [scope] is canceled. */
-  fun start(
-    scope: CoroutineScope,
-    dispatchers: TreehouseDispatchers,
-  )
-
   /**
    * Request a call to [AppLifecycle.sendFrame]. It is an error to call [requestFrame] again before
    * that call is made.
@@ -31,4 +25,9 @@ internal interface FrameClock {
    * It is an error to call this before [start].
    */
   fun requestFrame(appLifecycle: AppLifecycle)
+
+  interface Factory {
+    /** Creates a new FrameClock that sends frames on [dispatchers] in [scope]. */
+    fun create(scope: CoroutineScope, dispatchers: TreehouseDispatchers): FrameClock
+  }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -212,7 +212,6 @@ public class TreehouseApp<A : AppService> private constructor(
         dispatchers = dispatchers,
         eventPublisher = eventPublisher,
         appScope = appScope,
-        frameClock = factory.frameClock,
         appService = appService,
         zipline = zipline,
       )
@@ -228,7 +227,10 @@ public class TreehouseApp<A : AppService> private constructor(
 
         session = next
         next.addListener(this@ZiplineCodeHost)
-        next.start(sessionScope)
+        next.start(
+          sessionScope = sessionScope,
+          frameClock = factory.frameClockFactory.create(sessionScope, dispatchers),
+        )
 
         for (listener in listeners) {
           listener.codeSessionChanged(next)
@@ -249,7 +251,7 @@ public class TreehouseApp<A : AppService> private constructor(
     public val dispatchers: TreehouseDispatchers,
     internal val eventListener: EventListener,
     internal val httpClient: ZiplineHttpClient,
-    internal val frameClock: FrameClock,
+    internal val frameClockFactory: FrameClock.Factory,
     internal val manifestVerifier: ManifestVerifier,
     internal val embeddedDir: Path?,
     internal val embeddedFileSystem: FileSystem?,

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseDispatchers.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseDispatchers.kt
@@ -15,8 +15,8 @@
  */
 package app.cash.redwood.treehouse
 
-import kotlin.coroutines.CoroutineContext
 import kotlin.native.ObjCName
+import kotlinx.coroutines.CoroutineDispatcher
 
 /**
  * One of the trickiest things Treehouse needs to do is balance its two dispatchers:
@@ -28,11 +28,9 @@ import kotlin.native.ObjCName
  */
 @ObjCName("TreehouseDispatchers", exact = true)
 public interface TreehouseDispatchers {
-  /** Must contain a non-null [kotlinx.coroutines.CoroutineDispatcher]. */
-  public val ui: CoroutineContext
+  public val ui: CoroutineDispatcher
 
-  /** Must contain a non-null [kotlinx.coroutines.CoroutineDispatcher]. */
-  public val zipline: CoroutineContext
+  public val zipline: CoroutineDispatcher
 
   /**
    * Confirm that this is being called on the UI thread.

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.treehouse
 import app.cash.redwood.protocol.EventTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.WidgetTag
+import app.cash.redwood.treehouse.CodeSession.Listener
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineScope
 import app.cash.zipline.withScope
@@ -27,45 +28,68 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
 internal class ZiplineCodeSession<A : AppService>(
-  private val codeHost: CodeHost<*>,
   private val dispatchers: TreehouseDispatchers,
   private val eventPublisher: EventPublisher,
   private val appScope: CoroutineScope,
   private val frameClock: FrameClock,
-  private val sessionScope: CoroutineScope,
   override val appService: A,
   val zipline: Zipline,
-) : CodeSession<A> {
+) : CodeSession<A>, AppLifecycle.Host {
+  private val listeners = mutableListOf<Listener<A>>()
   private val ziplineScope = ZiplineScope()
 
   override val json: Json
     get() = zipline.json
 
-  override fun start() {
-    frameClock.start(sessionScope, dispatchers)
+  /** Only accessed on [TreehouseDispatchers.zipline]. */
+  private lateinit var sessionScope: CoroutineScope
+
+  /** Only accessed on [TreehouseDispatchers.zipline]. */
+  private lateinit var appLifecycle: AppLifecycle
+
+  private var canceled = false
+
+  override fun start(sessionScope: CoroutineScope) {
+    dispatchers.checkUi()
     sessionScope.launch(dispatchers.zipline) {
-      val appLifecycle = appService.withScope(ziplineScope).appLifecycle
-      val host = RealAppLifecycleHost(codeHost, appLifecycle, eventPublisher, frameClock)
-      appLifecycle.start(host)
+      this@ZiplineCodeSession.sessionScope = sessionScope
+
+      frameClock.start(sessionScope, dispatchers)
+
+      val service = appService.withScope(ziplineScope).appLifecycle
+      appLifecycle = service
+      service.start(this@ZiplineCodeSession)
     }
   }
 
+  override fun addListener(listener: Listener<A>) {
+    dispatchers.checkUi()
+    listeners += listener
+  }
+
+  override fun removeListener(listener: Listener<A>) {
+    dispatchers.checkUi()
+    listeners -= listener
+  }
+
   override fun cancel() {
+    if (canceled) return
+    canceled = true
+
+    dispatchers.checkUi()
+
+    val listenersArray = listeners.toTypedArray() // onCancel mutates.
+    for (listener in listenersArray) {
+      listener.onCancel(this)
+    }
+
     appScope.launch(dispatchers.zipline) {
       sessionScope.cancel()
       ziplineScope.close()
       zipline.close()
     }
   }
-}
 
-/** Platform features to the guest application. */
-private class RealAppLifecycleHost(
-  val codeHost: CodeHost<*>,
-  val appLifecycle: AppLifecycle,
-  val eventPublisher: EventPublisher,
-  val frameClock: FrameClock,
-) : AppLifecycle.Host {
   override fun requestFrame() {
     frameClock.requestFrame(appLifecycle)
   }
@@ -85,6 +109,28 @@ private class RealAppLifecycleHost(
   }
 
   override fun handleUncaughtException(exception: Throwable) {
-    codeHost.handleUncaughtException(exception)
+    appScope.launch(dispatchers.ui) {
+      val listenersArray = listeners.toTypedArray() // onUncaughtException mutates.
+      for (listener in listenersArray) {
+        listener.onUncaughtException(this@ZiplineCodeSession, exception)
+      }
+      this@ZiplineCodeSession.cancel()
+    }
+
+    eventPublisher.onUncaughtException(exception)
+  }
+
+  override fun newServiceScope(): CodeSession.ServiceScope<A> {
+    val ziplineScope = ZiplineScope()
+
+    return object : CodeSession.ServiceScope<A> {
+      override fun apply(appService: A): A {
+        return appService.withScope(ziplineScope)
+      }
+
+      override fun close() {
+        ziplineScope.close()
+      }
+    }
   }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/AbstractFrameClockTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/AbstractFrameClockTest.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 abstract class AbstractFrameClockTest {
-  internal abstract val frameClock: FrameClock
+  internal abstract val frameClockFactory: FrameClock.Factory
 
   @Test fun ticksWithTime() = runTest {
     val dispatchers = object : TreehouseDispatchers {
@@ -38,7 +38,7 @@ abstract class AbstractFrameClockTest {
       override fun checkZipline() {}
       override fun close() {}
     }
-    frameClock.start(this, dispatchers)
+    val frameClock = frameClockFactory.create(this, dispatchers)
 
     val frameTimes = Channel<Long>(Channel.UNLIMITED)
     val appLifecycle = object : AppLifecycle {

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
@@ -46,7 +46,7 @@ internal class FakeCodeHost(
       previous?.cancel()
 
       if (value != null) {
-        value.start(CoroutineScope(EmptyCoroutineContext))
+        value.start(CoroutineScope(EmptyCoroutineContext), FakeFrameClock())
         for (listener in listeners) {
           listener.codeSessionChanged(value)
         }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
@@ -15,58 +15,60 @@
  */
 package app.cash.redwood.treehouse
 
-internal class FakeCodeHost : CodeHost<FakeAppService> {
+import app.cash.redwood.treehouse.CodeHost.Listener
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.CoroutineScope
+
+internal class FakeCodeHost(
+  private val eventLog: EventLog,
+) : CodeHost<FakeAppService> {
   override val stateStore = MemoryStateStore()
+
+  private val codeSessionListener = object : CodeSession.Listener<FakeAppService> {
+    override fun onUncaughtException(
+      codeSession: CodeSession<FakeAppService>,
+      exception: Throwable,
+    ) {
+    }
+
+    override fun onCancel(
+      codeSession: CodeSession<FakeAppService>,
+    ) {
+      check(codeSession == this@FakeCodeHost.session)
+      this@FakeCodeHost.session = null
+    }
+  }
 
   override var session: CodeSession<FakeAppService>? = null
     set(value) {
       val previous = field
+      previous?.removeListener(codeSessionListener)
       previous?.cancel()
 
       if (value != null) {
-        value.start()
+        value.start(CoroutineScope(EmptyCoroutineContext))
         for (listener in listeners) {
           listener.codeSessionChanged(value)
         }
       }
 
+      value?.addListener(codeSessionListener)
       field = value
     }
 
-  private val listeners = mutableListOf<CodeHost.Listener<FakeAppService>>()
+  private val listeners = mutableListOf<Listener<FakeAppService>>()
 
-  override fun newServiceScope(): CodeHost.ServiceScope<FakeAppService> {
-    return object : CodeHost.ServiceScope<FakeAppService> {
-      val uisToClose = mutableListOf<ZiplineTreehouseUi>()
-
-      override fun apply(appService: FakeAppService): FakeAppService {
-        return appService.withListener(object : FakeAppService.Listener {
-          override fun onNewUi(ui: ZiplineTreehouseUi) {
-            uisToClose += ui
-          }
-        })
-      }
-
-      override fun close() {
-        for (ui in uisToClose) {
-          ui.close()
-        }
-      }
-    }
+  fun startCodeSession(name: String): CodeSession<FakeAppService> {
+    val result = FakeCodeSession(eventLog, name)
+    session = result
+    return result
   }
 
-  override fun handleUncaughtException(exception: Throwable) {
-    for (listener in listeners) {
-      listener.uncaughtException(exception)
-    }
-    session = null
-  }
-
-  override fun addListener(listener: CodeHost.Listener<FakeAppService>) {
+  override fun addListener(listener: Listener<FakeAppService>) {
     listeners += listener
   }
 
-  override fun removeListener(listener: CodeHost.Listener<FakeAppService>) {
+  override fun removeListener(listener: Listener<FakeAppService>) {
     listeners -= listener
   }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
@@ -32,7 +32,7 @@ internal class FakeCodeSession(
 
   private var canceled = false
 
-  override fun start(sessionScope: CoroutineScope) {
+  override fun start(sessionScope: CoroutineScope, frameClock: FrameClock) {
     eventLog += "$name.start()"
   }
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
@@ -15,21 +15,72 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.treehouse.CodeSession.Listener
+import app.cash.redwood.treehouse.CodeSession.ServiceScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
 
 internal class FakeCodeSession(
-  private val name: String,
   private val eventLog: EventLog,
+  private val name: String,
 ) : CodeSession<FakeAppService> {
+  private val listeners = mutableListOf<Listener<FakeAppService>>()
+
   override val json = Json
 
   override val appService = FakeAppService("$name.app", eventLog)
 
-  override fun start() {
+  private var canceled = false
+
+  override fun start(sessionScope: CoroutineScope) {
     eventLog += "$name.start()"
   }
 
+  override fun addListener(listener: Listener<FakeAppService>) {
+    listeners += listener
+  }
+
+  override fun removeListener(listener: Listener<FakeAppService>) {
+    listeners -= listener
+  }
+
+  override fun handleUncaughtException(exception: Throwable) {
+    val listenersArray = listeners.toTypedArray() // onUncaughtException mutates.
+    for (listener in listenersArray) {
+      listener.onUncaughtException(this, exception)
+    }
+    cancel()
+  }
+
+  override fun newServiceScope(): ServiceScope<FakeAppService> {
+    return object : ServiceScope<FakeAppService> {
+      val uisToClose = mutableListOf<ZiplineTreehouseUi>()
+
+      override fun apply(appService: FakeAppService): FakeAppService {
+        return appService.withListener(object : FakeAppService.Listener {
+          override fun onNewUi(ui: ZiplineTreehouseUi) {
+            uisToClose += ui
+          }
+        })
+      }
+
+      override fun close() {
+        for (ui in uisToClose) {
+          ui.close()
+        }
+      }
+    }
+  }
+
   override fun cancel() {
+    if (canceled) return
+    canceled = true
+
+    val listenersArray = listeners.toTypedArray() // onCancel mutates.
+    for (listener in listenersArray) {
+      listener.onCancel(this)
+    }
+
     eventLog += "$name.cancel()"
   }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeFrameClock.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeFrameClock.kt
@@ -15,12 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-
-class AndroidChoreographerFrameClockTest : AbstractFrameClockTest() {
-  // Tests run on a background thread but Choreographer can only be grabbed from the main thread.
-  override val frameClockFactory = runBlocking(Dispatchers.Main) {
-    AndroidChoreographerFrameClock.Factory()
+class FakeFrameClock : FrameClock {
+  override fun requestFrame(appLifecycle: AppLifecycle) {
   }
 }

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
@@ -35,7 +35,7 @@ public fun TreehouseAppFactory(
   dispatchers = IosTreehouseDispatchers(),
   eventListener = eventListener,
   httpClient = httpClient,
-  frameClock = IosDisplayLinkClock(),
+  frameClockFactory = IosDisplayLinkClock,
   manifestVerifier = manifestVerifier,
   embeddedDir = embeddedDir,
   embeddedFileSystem = embeddedFileSystem,

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/IosDisplayLinkClockTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/IosDisplayLinkClockTest.kt
@@ -19,5 +19,6 @@ import kotlin.test.Ignore
 
 @Ignore // TODO Does not work without linking XCTest and showing a XCUIApplication.
 class IosDisplayLinkClockTest : AbstractFrameClockTest() {
-  override val frameClock = IosDisplayLinkClock()
+  override val frameClockFactory: FrameClock.Factory
+    get() = IosDisplayLinkClock
 }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
@@ -27,6 +27,7 @@ public interface AppLifecycle : ZiplineService {
 
   public fun sendFrame(timeNanos: Long)
 
+  /** Platform features to the guest application. */
   public interface Host : ZiplineService {
     public fun requestFrame()
 


### PR DESCRIPTION
Previously TreehouseApp was tracking exceptions on behalf of a class that could do it better.

This introduces listeners at the CodeSession level in addition to the existing listeners at the CodeHost level.