### PR TITLE
Two bits of cleanup In UIViewLazyList

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -239,7 +239,6 @@ internal class LazyListContainerCell(
       removeAllSubviews()
       if (value != null) {
         contentView.addSubview(value.value)
-        contentView.translatesAutoresizingMaskIntoConstraints = false
       }
       setNeedsLayout()
     }
@@ -273,6 +272,7 @@ internal class LazyListContainerCell(
 
   override fun prepareForReuse() {
     super.prepareForReuse()
+    removeAllSubviews()
     binding?.unbind()
     binding = null
   }


### PR DESCRIPTION
- Removing call to set contentView.translatesAutoresizingMaskIntoConstraints to false, because this is not supported by iOS, and yields the following warning:

"Changing the translatesAutoresizingMaskIntoConstraints property of the contentView of a UITableViewCell is not supported and will result in undefined behavior, as this property is managed by the owning UITableViewCell"

- Adding call to removeAllSubviews within prepareForReuse