### PR TITLE
Upgrade Zipline to 1.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlinx-serialization = "1.6.0"
 androidx-activity = "1.8.0"
 jbCompose = "1.5.10"
 lint = "31.1.1"
-zipline = "1.3.0"
+zipline = "1.4.0"
 coil = "2.5.0"
 okio = "3.6.0"
 


### PR DESCRIPTION
We still need another Zipline release for Kotlin 1.9.20.