### PR TITLE
WIP - RootView Visibility

### DIFF
--- a/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/UiConfiguration.kt
+++ b/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/UiConfiguration.kt
@@ -37,6 +37,19 @@ public class UiConfiguration(
    * raw pixels, if needed.
    */
   public val density: Double = 1.0,
+
+  /**
+   * TODO: The visibility of the root view on the screen.
+   * The use case for this is so that a treehouse app can react
+   * to their view going on and off the screen. This means
+   * slightly different things on every platform, but the goal is 
+   * to find common ground.
+   * Some ideas:
+   * iOS - view.window != nil or viewDidAppear vs viewDidDisappear
+   * Android - onWindowVisibilityChanged() or onResume() vs onPause()
+   * Web - window.load vs window.unload
+   * public val isVisible: Bool = false,
+   */
 ) {
   public companion object
 }

--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/RedwoodLayout.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/RedwoodLayout.kt
@@ -99,6 +99,7 @@ public open class RedwoodLayout(
     config: Configuration = context.resources.configuration,
     insets: Insets = rootWindowInsetsCompat.safeDrawing,
   ): UiConfiguration {
+    // TODO: Implement UIConfiguration.isVisible updates.
     val viewportSize: Size
     val density: Double
     with(Density(resources)) {

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
@@ -65,6 +65,7 @@ public open class RedwoodUIView(
   }
 
   protected fun updateUiConfiguration() {
+    // TODO: Implement UIConfiguration.isVisible updates.
     mutableUiConfiguration.value = computeUiConfiguration(
       traitCollection = view.traitCollection,
       bounds = view.bounds,


### PR DESCRIPTION
All just placeholders for discussion for now.

What we want is for treehouse apps to be able to subscribe to changes in the visibility of the root view from the operating system.

Here's a made up use case
```kotlin
@Composble
fun Show() {
  val isVisible = UIConfiguration.current.isVisible.observeAsState(initial = true)

  if (isVisible) {
      pollForMoreData(interval: 10)
  }

  Text(someData)
}
```


`isVisible` is a placeholder name. We need to decide what this should be called so that all platforms have an clear idea of what it means.

These are some ideas of what this could mean on each:

| isVisible | iOS | Android | Web |
| --- | --- | --- | --- |
| true | view.window != nil | view.visibility == VISIBLE | window.load |
| false | view.window == nil | view.visibility == GONE | INVISIBLE | window.unload |
