### PR TITLE
Make a CodeHost state machine

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeHost.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeHost.kt
@@ -15,16 +15,188 @@
  */
 package app.cash.redwood.treehouse
 
-/** Manages loading and hot-reloading a series of code sessions. */
-internal interface CodeHost<A : AppService> {
-  val stateStore: StateStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
 
-  /** Only accessed on [TreehouseDispatchers.ui]. */
-  val session: CodeSession<A>?
+/**
+ * Manages loading and hot-reloading a series of code sessions.
+ *
+ * The code host has 4 states:
+ *
+ *  * `Idle`
+ *  * `Starting`: collect code updates, and wait for an `Zipline` to load.
+ *  * `Running`: collect code updates, and a `Zipline` is running.
+ *  * `Crashed`: collect code updates, but the most recent `Zipline` failed.
+ *
+ * Transitions between states always occur on the UI dispatcher. These functions initiate state
+ * transitions:
+ *
+ *  * `start()` - transition to `Starting` unless it’s `Starting` or `Running`.
+ *  * `stop()` - transition to `Idle` immediately
+ *  * `restart()` - transition to `Starting` unless it’s already `Starting`.
+ *
+ * Other state transitions also occur:
+ *
+ *  * From `Starting` to `Running` when a `Zipline` finishes loading.
+ *  * From `Running` to `Crashed` when a `Zipline` fails.
+ *  * From `Running` to `Running` when the `Zipline` is replaced by a hot-reload.
+ */
+internal abstract class CodeHost<A : AppService>(
+  private val dispatchers: TreehouseDispatchers,
+  private val appScope: CoroutineScope,
+  private val frameClockFactory: FrameClock.Factory,
+  val stateStore: StateStore,
+) {
+  /** Contents that this app is currently responsible for. */
+  private val listeners = mutableListOf<Listener<A>>()
 
-  fun addListener(listener: Listener<A>)
+  private var state: State<A> = State.Idle()
 
-  fun removeListener(listener: Listener<A>)
+  private val codeSessionListener = object : CodeSession.Listener<A> {
+    override fun onUncaughtException(codeSession: CodeSession<A>, exception: Throwable) {
+    }
+
+    override fun onCancel(codeSession: CodeSession<A>) {
+      dispatchers.checkUi()
+
+      codeSession.removeListener(this)
+
+      // If a code session is canceled while we're still listening to it, it must have crashed.
+      val previous = state
+      if (previous is State.Running) {
+        state = State.Crashed(previous.codeUpdatesScope)
+      }
+    }
+  }
+
+  val codeSession: CodeSession<A>?
+    get() = state.codeSession
+
+  /** Returns a flow that emits a new [CodeSession] each time we should load fresh code. */
+  abstract fun codeUpdatesFlow() : Flow<CodeSession<A>>
+
+  fun start() {
+    dispatchers.checkUi()
+
+    val previous = state
+
+    if (previous is State.Starting || previous is State.Running) return // Nothing to do.
+
+    // Force a restart if we're crashed.
+    previous.codeUpdatesScope?.cancel()
+    val codeUpdatesScope = startReceivingCodeUpdates()
+
+    state = State.Starting(codeUpdatesScope)
+  }
+
+  /** This function may only be invoked on [TreehouseDispatchers.zipline]. */
+  fun stop() {
+    dispatchers.checkUi()
+
+    val previous = state
+    previous.codeUpdatesScope?.cancel()
+    previous.codeSession?.removeListener(codeSessionListener)
+    previous.codeSession?.cancel()
+
+    state = State.Idle()
+  }
+
+  fun restart() {
+    dispatchers.checkUi()
+
+    val previous = state
+    if (previous is State.Starting) return // Nothing to restart.
+
+    previous.codeUpdatesScope?.cancel()
+    previous.codeSession?.removeListener(codeSessionListener)
+    previous.codeSession?.cancel()
+    val codeUpdatesScope = startReceivingCodeUpdates()
+
+    state = State.Starting(codeUpdatesScope)
+  }
+
+  fun addListener(listener: Listener<A>) {
+    dispatchers.checkUi()
+    listeners += listener
+  }
+
+  fun removeListener(listener: Listener<A>) {
+    dispatchers.checkUi()
+    listeners -= listener
+  }
+
+  private fun startReceivingCodeUpdates(): CoroutineScope {
+    val codeUpdatesScope = CoroutineScope(SupervisorJob(appScope.coroutineContext.job))
+    codeUpdatesScope.launch(dispatchers.zipline) {
+      codeUpdatesFlow().collect {
+        codeSessionLoaded(it)
+      }
+    }
+    return codeUpdatesScope
+  }
+
+  private fun codeSessionLoaded(next: CodeSession<A>) {
+    dispatchers.checkZipline()
+
+    val codeSessionScope = CoroutineScope(
+      SupervisorJob(appScope.coroutineContext.job) + next.coroutineExceptionHandler,
+    )
+
+    codeSessionScope.launch(dispatchers.ui) {
+      // Clean up the previous session.
+      val previous = state
+      previous.codeSession?.removeListener(codeSessionListener)
+      previous.codeSession?.cancel()
+
+      // If the codeUpdatesScope is null, we're stopped. Discard the newly-loaded code.
+      val scope = state.codeUpdatesScope
+      if (scope == null) {
+        next.cancel()
+        return@launch
+      }
+
+      // Boot up the new code.
+      state = State.Running(scope, next)
+      next.addListener(codeSessionListener)
+      next.start(
+        sessionScope = codeSessionScope,
+        frameClock = frameClockFactory.create(codeSessionScope, dispatchers),
+      )
+
+      for (listener in listeners) {
+        listener.codeSessionChanged(next)
+      }
+    }
+  }
+
+  private sealed class State<A : AppService> {
+    /** Non-null if we're prepared for code updates and restarts. */
+    open val codeUpdatesScope: CoroutineScope?
+      get() = null
+
+    /** Non-null if we're running code. */
+    open val codeSession: CodeSession<A>?
+      get() = null
+
+    class Idle<A : AppService> : State<A>()
+
+    class Running<A : AppService>(
+      override val codeUpdatesScope: CoroutineScope,
+      override val codeSession: CodeSession<A>,
+    ) : State<A>()
+
+    class Starting<A : AppService>(
+      override val codeUpdatesScope: CoroutineScope,
+    ) : State<A>()
+
+    class Crashed<A : AppService>(
+      override val codeUpdatesScope: CoroutineScope,
+    ) : State<A>()
+  }
 
   interface Listener<A : AppService> {
     fun codeSessionChanged(next: CodeSession<A>)

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -22,13 +22,15 @@ import kotlinx.serialization.json.Json
 
 /** The host state for a single code load. We get a new session each time we get new code. */
 internal interface CodeSession<A : AppService> {
+  val scope: CoroutineScope
+
   val eventPublisher: EventPublisher
 
   val appService: A
 
   val json: Json
 
-  fun start(sessionScope: CoroutineScope, frameClock: FrameClock)
+  fun start()
 
   fun addListener(listener: Listener<A>)
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -24,10 +24,8 @@ import app.cash.zipline.loader.ZiplineHttpClient
 import app.cash.zipline.loader.ZiplineLoader
 import kotlin.native.ObjCName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 import okio.Closeable
@@ -36,8 +34,6 @@ import okio.Path
 
 /**
  * This class binds downloaded code to on-screen views.
- *
- * It updates the content when new code is available in [onCodeChanged].
  */
 @ObjCName("TreehouseApp", exact = true)
 public class TreehouseApp<A : AppService> private constructor(
@@ -45,14 +41,27 @@ public class TreehouseApp<A : AppService> private constructor(
   private val appScope: CoroutineScope,
   public val spec: Spec<A>,
 ) {
-  private val codeHost = ZiplineCodeHost<A>()
-
   public val dispatchers: TreehouseDispatchers = factory.dispatchers
 
-  private var started = false
-
-  /** Only accessed on [TreehouseDispatchers.zipline]. */
-  private var closed = false
+  private val codeHost = object : CodeHost<A>(
+    dispatchers = dispatchers,
+    appScope = appScope,
+    frameClockFactory = factory.frameClockFactory,
+    stateStore = factory.stateStore,
+  ) {
+    override fun codeUpdatesFlow(): Flow<CodeSession<A>> {
+      return ziplineFlow().mapNotNull { loadResult ->
+        when (loadResult) {
+          is LoadResult.Failure -> {
+            null // EventListener already notified.
+          }
+          is LoadResult.Success -> {
+            createCodeSession(loadResult.zipline)
+          }
+        }
+      }
+    }
+  }
 
   /**
    * Returns the current zipline attached to this host, or null if Zipline hasn't loaded yet. The
@@ -62,7 +71,7 @@ public class TreehouseApp<A : AppService> private constructor(
    * instance may be replaced if new code is loaded.
    */
   public val zipline: Zipline?
-    get() = codeHost.session?.zipline
+    get() = (codeHost.codeSession as? ZiplineCodeSession)?.zipline
 
   /**
    * Create content for [source].
@@ -89,25 +98,29 @@ public class TreehouseApp<A : AppService> private constructor(
    * this app.
    *
    * This function returns immediately if this app is already started.
+   *
+   * This function may only be invoked on [TreehouseDispatchers.ui].
    */
   public fun start() {
-    if (started) return
-    started = true
+    codeHost.start()
+  }
 
-    appScope.launch(dispatchers.zipline) {
-      val ziplineFileFlow = ziplineFlow()
-      ziplineFileFlow.collect {
-        when (it) {
-          is LoadResult.Success -> {
-            val app = spec.create(it.zipline)
-            onCodeChanged(it.zipline, app)
-          }
-          is LoadResult.Failure -> {
-            // EventListener already notified.
-          }
-        }
-      }
-    }
+  /**
+   * Stop any currently-running code and stop receiving new code.
+   *
+   * This function may only be invoked on [TreehouseDispatchers.ui].
+   */
+  public fun stop() {
+    codeHost.stop()
+  }
+
+  /**
+   * Stop the currently-running application (if any) and start it again.
+   *
+   * This function may only be invoked on [TreehouseDispatchers.ui].
+   */
+  public fun restart() {
+    codeHost.restart()
   }
 
   /**
@@ -153,95 +166,20 @@ public class TreehouseApp<A : AppService> private constructor(
     }
   }
 
-  /**
-   * Refresh the code. Even if no views are currently showing we refresh the code, so we're ready
-   * when a view is added.
-   *
-   * This function may only be invoked on [TreehouseDispatchers.zipline].
-   */
-  private fun onCodeChanged(zipline: Zipline, appService: A) {
-    dispatchers.checkZipline()
-    check(!closed)
+  private fun createCodeSession(zipline: Zipline): ZiplineCodeSession<A> {
+    val appService = spec.create(zipline)
 
-    codeHost.onCodeChanged(zipline, appService)
-  }
+    // Extract the RealEventPublisher() created in ziplineFlow().
+    val eventListener = zipline.eventListener as RealEventPublisher.ZiplineEventListener
+    val eventPublisher = eventListener.eventPublisher
 
-  /** This function may only be invoked on [TreehouseDispatchers.zipline]. */
-  public fun cancel() {
-    dispatchers.checkZipline()
-    closed = true
-    appScope.launch(dispatchers.ui) {
-      val session = codeHost.session ?: return@launch
-      session.removeListener(codeHost)
-      session.cancel()
-      codeHost.session = null
-    }
-  }
-
-  private inner class ZiplineCodeHost<A : AppService> : CodeHost<A>, CodeSession.Listener<A> {
-    /**
-     * Contents that this app is currently responsible for.
-     *
-     * Only accessed on [TreehouseDispatchers.ui].
-     */
-    private val listeners = mutableListOf<CodeHost.Listener<A>>()
-
-    override val stateStore: StateStore = factory.stateStore
-
-    override var session: ZiplineCodeSession<A>? = null
-
-    override fun addListener(listener: CodeHost.Listener<A>) {
-      dispatchers.checkUi()
-      listeners += listener
-    }
-
-    override fun removeListener(listener: CodeHost.Listener<A>) {
-      dispatchers.checkUi()
-      listeners -= listener
-    }
-
-    override fun onUncaughtException(codeSession: CodeSession<A>, exception: Throwable) {
-    }
-
-    override fun onCancel(codeSession: CodeSession<A>) {
-      check(codeSession == this.session)
-      this.session = null
-    }
-
-    fun onCodeChanged(zipline: Zipline, appService: A) {
-      // Extract the RealEventPublisher() created in ziplineFlow().
-      val eventListener = zipline.eventListener as RealEventPublisher.ZiplineEventListener
-      val eventPublisher = eventListener.eventPublisher
-
-      val next = ZiplineCodeSession(
-        dispatchers = dispatchers,
-        appScope = appScope,
-        eventPublisher = eventPublisher,
-        appService = appService,
-        zipline = zipline,
-      )
-
-      val sessionScope = CoroutineScope(
-        SupervisorJob(appScope.coroutineContext.job) + next.coroutineExceptionHandler,
-      )
-
-      sessionScope.launch(dispatchers.ui) {
-        val previous = session
-        previous?.removeListener(this@ZiplineCodeHost)
-        previous?.cancel()
-
-        session = next
-        next.addListener(this@ZiplineCodeHost)
-        next.start(
-          sessionScope = sessionScope,
-          frameClock = factory.frameClockFactory.create(sessionScope, dispatchers),
-        )
-
-        for (listener in listeners) {
-          listener.codeSessionChanged(next)
-        }
-      }
-    }
+    return ZiplineCodeSession(
+      dispatchers = dispatchers,
+      appScope = appScope,
+      eventPublisher = eventPublisher,
+      appService = appService,
+      zipline = zipline,
+    )
   }
 
   /**

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -87,7 +87,6 @@ public class TreehouseApp<A : AppService> private constructor(
     return TreehouseAppContent(
       codeHost = codeHost,
       dispatchers = dispatchers,
-      appScope = appScope,
       codeListener = codeListener,
       source = source,
     )
@@ -175,10 +174,11 @@ public class TreehouseApp<A : AppService> private constructor(
 
     return ZiplineCodeSession(
       dispatchers = dispatchers,
-      appScope = appScope,
       eventPublisher = eventPublisher,
+      frameClockFactory = factory.frameClockFactory,
       appService = appService,
       zipline = zipline,
+      appScope = appScope,
     )
   }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -59,7 +59,9 @@ private sealed interface ViewState {
 }
 
 private sealed interface CodeState<A : AppService> {
-  class Idle<A : AppService> : CodeState<A>
+  class Idle<A : AppService>(
+    val isInitialLaunch: Boolean,
+  ) : CodeState<A>
 
   class Running<A : AppService>(
     val viewContentCodeBinding: ViewContentCodeBinding<A>,
@@ -70,11 +72,12 @@ private sealed interface CodeState<A : AppService> {
 internal class TreehouseAppContent<A : AppService>(
   private val codeHost: CodeHost<A>,
   private val dispatchers: TreehouseDispatchers,
-  private val appScope: CoroutineScope,
   private val codeListener: CodeListener,
   private val source: TreehouseContentSource<A>,
 ) : Content, CodeHost.Listener<A>, CodeSession.Listener<A> {
-  private val stateFlow = MutableStateFlow<State<A>>(State(ViewState.None, CodeState.Idle()))
+  private val stateFlow = MutableStateFlow<State<A>>(
+    State(ViewState.None, CodeState.Idle(isInitialLaunch = true)),
+  )
 
   override fun preload(
     onBackPressedDispatcher: OnBackPressedDispatcher,
@@ -169,7 +172,7 @@ internal class TreehouseAppContent<A : AppService>(
     if (previousViewState is ViewState.None) return // Idempotent.
 
     val nextViewState = ViewState.None
-    val nextCodeState = CodeState.Idle<A>()
+    val nextCodeState = CodeState.Idle<A>(isInitialLaunch = true)
 
     // Cancel the code if necessary.
     codeHost.removeListener(this)
@@ -204,7 +207,7 @@ internal class TreehouseAppContent<A : AppService>(
     val nextCodeState = CodeState.Running(
       startViewCodeContentBinding(
         codeSession = next,
-        isInitialLaunch = previousCodeState is CodeState.Idle,
+        isInitialLaunch = (previousCodeState as? CodeState.Idle)?.isInitialLaunch == true,
         onBackPressedDispatcher = onBackPressedDispatcher,
         firstUiConfiguration = uiConfiguration,
       ),
@@ -225,11 +228,19 @@ internal class TreehouseAppContent<A : AppService>(
     stateFlow.value = State(viewState, nextCodeState)
   }
 
-  /**
-   * If the code crashes, show an error on the UI and cancel the UI binding. This sets the code
-   * state back to idle.
-   */
   override fun onUncaughtException(codeSession: CodeSession<A>, exception: Throwable) {
+    codeSessionCanceled(exception = exception)
+  }
+
+  override fun onCancel(codeSession: CodeSession<A>) {
+    codeSessionCanceled(exception = null)
+  }
+
+  /**
+   * If the code crashes or is unloaded, show an error on the UI and cancel the UI binding. This
+   * sets the code state back to idle.
+   */
+  private fun codeSessionCanceled(exception: Throwable?) {
     dispatchers.checkUi()
 
     val previousState = stateFlow.value
@@ -239,22 +250,19 @@ internal class TreehouseAppContent<A : AppService>(
     // This listener should only fire if we're actively running code.
     require(previousCodeState is CodeState.Running)
 
-    // Cancel the UI binding to the crashed code.
+    // Cancel the UI binding to the canceled code.
     val binding = previousCodeState.viewContentCodeBinding
     binding.cancel()
     binding.codeSession.removeListener(this)
 
-    // If there's a UI, give it the error to display.
+    // If there's an error and a UI, show it.
     val view = (viewState as? ViewState.Bound)?.view
-    if (view != null) {
+    if (exception != null && view != null) {
       codeListener.onUncaughtException(view, exception)
     }
 
-    val nextCodeState = CodeState.Idle<A>()
+    val nextCodeState = CodeState.Idle<A>(isInitialLaunch = false)
     stateFlow.value = State(viewState, nextCodeState)
-  }
-
-  override fun onCancel(codeSession: CodeSession<A>) {
   }
 
   /** This function may only be invoked on [TreehouseDispatchers.ui]. */
@@ -270,7 +278,6 @@ internal class TreehouseAppContent<A : AppService>(
     return ViewContentCodeBinding(
       stateStore = codeHost.stateStore,
       dispatchers = dispatchers,
-      appScope = appScope,
       eventPublisher = codeSession.eventPublisher,
       contentSource = source,
       codeListener = codeListener,
@@ -300,7 +307,6 @@ internal class TreehouseAppContent<A : AppService>(
 private class ViewContentCodeBinding<A : AppService>(
   val stateStore: StateStore,
   val dispatchers: TreehouseDispatchers,
-  val appScope: CoroutineScope,
   val eventPublisher: EventPublisher,
   val contentSource: TreehouseContentSource<A>,
   val codeListener: CodeListener,
@@ -313,7 +319,7 @@ private class ViewContentCodeBinding<A : AppService>(
   private val uiConfigurationFlow = SequentialStateFlow(firstUiConfiguration)
 
   private val bindingScope = CoroutineScope(
-    SupervisorJob(appScope.coroutineContext.job) + codeSession.coroutineExceptionHandler,
+    SupervisorJob(codeSession.scope.coroutineContext.job),
   )
 
   /** Only accessed on [TreehouseDispatchers.ui]. Null before [initView] and after [cancel]. */
@@ -486,10 +492,10 @@ private class ViewContentCodeBinding<A : AppService>(
     viewOrNull?.saveCallback = null
     viewOrNull = null
     bridgeOrNull = null
-    appScope.launch(dispatchers.zipline) {
+    bindingScope.launch(dispatchers.zipline) {
       treehouseUiOrNull = null
-      bindingScope.cancel()
       serviceScope.close()
+      bindingScope.cancel()
     }
   }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -88,7 +88,7 @@ internal class TreehouseAppContent<A : AppService>(
     val nextViewState = ViewState.Preloading(onBackPressedDispatcher, uiConfiguration)
 
     // Start the code if necessary.
-    val codeSession = codeHost.session
+    val codeSession = codeHost.codeSession
     val nextCodeState = when {
       previousState.codeState is CodeState.Idle && codeSession != null -> {
         CodeState.Running(
@@ -120,7 +120,7 @@ internal class TreehouseAppContent<A : AppService>(
     val nextViewState = ViewState.Bound(view)
 
     // Start the code if necessary.
-    val codeSession = codeHost.session
+    val codeSession = codeHost.codeSession
     val nextCodeState = when {
       previousState.codeState is CodeState.Idle && codeSession != null -> {
         CodeState.Running(

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+/** This test focuses on how [CodeHost] and its state machine. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CodeHostTest {
+  private val eventLog = EventLog()
+  private val appScope = CoroutineScope(EmptyCoroutineContext)
+
+  private val dispatcher = UnconfinedTestDispatcher()
+  private val eventPublisher = FakeEventPublisher()
+  private val dispatchers = FakeDispatchers(dispatcher, dispatcher)
+  private val codeHost = FakeCodeHost(
+    eventLog = eventLog,
+    eventPublisher = eventPublisher,
+    dispatchers = dispatchers,
+    appScope = appScope,
+    frameClockFactory = FakeFrameClock.Factory,
+  )
+  private val codeListener = FakeCodeListener(eventLog)
+  private val onBackPressedDispatcher = FakeOnBackPressedDispatcher(eventLog)
+
+  @AfterTest
+  fun tearDown() {
+    eventLog.assertNoEvents()
+    appScope.cancel()
+  }
+
+  /** Confirm that we can bind() before CodeHost.start(). */
+  @Test
+  fun bind_start_session_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    content.unbind()
+  }
+
+  /** CodeHost doesn't have to stay resident forever. */
+  @Test
+  fun bind_start_session_stop_start_session_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    codeHost.startCodeSession("codeSessionB")
+    eventLog.takeEvent("codeSessionB.start()")
+    eventLog.takeEvent("codeSessionB.app.uis[0].start()")
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionB.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionB.cancel()")
+
+    content.unbind()
+  }
+
+  /** CodeHost can restart() after a failure. */
+  @Test
+  fun bind_start_session_crash_restart_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    val codeSessionA = codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+    codeSessionA.handleUncaughtException(Exception("boom!"))
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeListener.onUncaughtException(view1, kotlin.Exception: boom!)")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    codeHost.restart()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    codeHost.startCodeSession("codeSessionB")
+    eventLog.takeEvent("codeSessionB.start()")
+    eventLog.takeEvent("codeSessionB.app.uis[0].start()")
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionB.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionB.cancel()")
+
+    content.unbind()
+  }
+
+  /** Fresh code will also restart after a failure. */
+  @Test
+  fun bind_start_session_crash_session_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    val codeSessionA = codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+    codeSessionA.handleUncaughtException(Exception("boom!"))
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeListener.onUncaughtException(view1, kotlin.Exception: boom!)")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    codeHost.startCodeSession("codeSessionB")
+    eventLog.takeEvent("codeSessionB.start()")
+    eventLog.takeEvent("codeSessionB.app.uis[0].start()")
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionB.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionB.cancel()")
+
+    content.unbind()
+  }
+
+  /** Calling start() while it's starting is a no-op. */
+  @Test
+  fun bind_start_start_session() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.assertNoEvents()
+
+    codeHost.start()
+    eventLog.assertNoEvents()
+
+    codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    content.unbind()
+  }
+
+  /** Calling start() while it's running is a no-op. */
+  @Test
+  fun bind_start_session_start_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+
+    codeHost.start()
+    eventLog.assertNoEvents()
+
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    content.unbind()
+  }
+
+  /** Calling stop() while it's idle is a no-op. */
+  @Test
+  fun bind_start_session_stop_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+
+    codeHost.stop()
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    codeHost.stop()
+
+    content.unbind()
+  }
+
+  private fun treehouseAppContent(): TreehouseAppContent<FakeAppService> {
+    return TreehouseAppContent(
+      codeHost = codeHost,
+      dispatchers = dispatchers,
+      codeListener = codeListener,
+      source = { app -> app.newUi() },
+    )
+  }
+
+  private fun treehouseView(name: String): FakeTreehouseView {
+    return FakeTreehouseView(onBackPressedDispatcher, name)
+  }
+}

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
@@ -58,12 +58,35 @@ class CodeHostTest {
     eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.collect()")
     codeHost.startCodeSession("codeSessionA")
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
 
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    content.unbind()
+  }
+
+  /** Calling CodeHost.restart() from idle starts it up. */
+  @Test
+  fun bind_restart_session_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.restart()
+    eventLog.takeEvent("codeHostUpdates1.collect()")
+    codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+
+    codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeSessionA.cancel()")
 
@@ -79,20 +102,22 @@ class CodeHostTest {
     eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.collect()")
     codeHost.startCodeSession("codeSessionA")
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeSessionA.cancel()")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates2.collect()")
     codeHost.startCodeSession("codeSessionB")
     eventLog.takeEvent("codeSessionB.start()")
     eventLog.takeEvent("codeSessionB.app.uis[0].start()")
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates2.close()")
     eventLog.takeEvent("codeSessionB.app.uis[0].close()")
     eventLog.takeEvent("codeSessionB.cancel()")
 
@@ -108,7 +133,7 @@ class CodeHostTest {
     eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.collect()")
     val codeSessionA = codeHost.startCodeSession("codeSessionA")
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
@@ -118,18 +143,20 @@ class CodeHostTest {
     eventLog.takeEvent("codeSessionA.cancel()")
 
     codeHost.restart()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.close()")
+    eventLog.takeEvent("codeHostUpdates2.collect()")
     codeHost.startCodeSession("codeSessionB")
     eventLog.takeEvent("codeSessionB.start()")
     eventLog.takeEvent("codeSessionB.app.uis[0].start()")
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates2.close()")
     eventLog.takeEvent("codeSessionB.app.uis[0].close()")
     eventLog.takeEvent("codeSessionB.cancel()")
 
     content.unbind()
   }
 
-  /** Fresh code will also restart after a failure. */
+  /** New code will also trigger a restart after a failure. */
   @Test
   fun bind_start_session_crash_session_stop() = runTest {
     val content = treehouseAppContent()
@@ -138,7 +165,7 @@ class CodeHostTest {
     eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.collect()")
     val codeSessionA = codeHost.startCodeSession("codeSessionA")
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
@@ -151,8 +178,33 @@ class CodeHostTest {
     eventLog.takeEvent("codeSessionB.start()")
     eventLog.takeEvent("codeSessionB.app.uis[0].start()")
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionB.app.uis[0].close()")
     eventLog.takeEvent("codeSessionB.cancel()")
+
+    content.unbind()
+  }
+
+  /** We can stop after a failure. */
+  @Test
+  fun bind_start_session_crash_stop() = runTest {
+    val content = treehouseAppContent()
+    val view1 = treehouseView("view1")
+    content.bind(view1)
+    eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
+
+    codeHost.start()
+    eventLog.takeEvent("codeHostUpdates1.collect()")
+    val codeSessionA = codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+    codeSessionA.handleUncaughtException(Exception("boom!"))
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeListener.onUncaughtException(view1, kotlin.Exception: boom!)")
+    eventLog.takeEvent("codeSessionA.cancel()")
+
+    codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
 
     content.unbind()
   }
@@ -166,7 +218,7 @@ class CodeHostTest {
     eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.collect()")
     eventLog.assertNoEvents()
 
     codeHost.start()
@@ -176,6 +228,7 @@ class CodeHostTest {
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeSessionA.cancel()")
 
@@ -191,7 +244,7 @@ class CodeHostTest {
     eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.collect()")
     codeHost.startCodeSession("codeSessionA")
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
@@ -200,6 +253,7 @@ class CodeHostTest {
     eventLog.assertNoEvents()
 
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeSessionA.cancel()")
 
@@ -215,12 +269,13 @@ class CodeHostTest {
     eventLog.takeEvent("codeListener.onInitialCodeLoading(view1)")
 
     codeHost.start()
-    eventLog.takeEvent("codeHost.collectCodeUpdates()")
+    eventLog.takeEvent("codeHostUpdates1.collect()")
     codeHost.startCodeSession("codeSessionA")
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
 
     codeHost.stop()
+    eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeSessionA.cancel()")
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
@@ -33,14 +33,19 @@ internal class FakeCodeHost(
   stateStore = MemoryStateStore(),
 ) {
   private var codeSessions: Channel<CodeSession<FakeAppService>>? = null
+  private var nextCollectId = 1
 
   /**
    * Create a new channel every time we subscribe to code updates. The channel will be closed when
    * the superclass is done consuming the flow.
    */
   override fun codeUpdatesFlow(): Flow<CodeSession<FakeAppService>> {
-    eventLog += "codeHost.collectCodeUpdates()"
+    val collectId = nextCollectId++
+    eventLog += "codeHostUpdates$collectId.collect()"
     val channel = Channel<CodeSession<FakeAppService>>(Int.MAX_VALUE)
+    channel.invokeOnClose {
+      eventLog += "codeHostUpdates$collectId.close()"
+    }
     codeSessions = channel
     return channel.consumeAsFlow()
   }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeFrameClock.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeFrameClock.kt
@@ -15,7 +15,18 @@
  */
 package app.cash.redwood.treehouse
 
-class FakeFrameClock : FrameClock {
+import kotlinx.coroutines.CoroutineScope
+
+internal class FakeFrameClock : FrameClock {
   override fun requestFrame(appLifecycle: AppLifecycle) {
+  }
+
+  object Factory : FrameClock.Factory {
+    override fun create(
+      scope: CoroutineScope,
+      dispatchers: TreehouseDispatchers,
+    ): FrameClock {
+      return FakeFrameClock()
+    }
   }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeOnBackPressedDispatcher.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeOnBackPressedDispatcher.kt
@@ -19,17 +19,27 @@ import app.cash.redwood.ui.Cancellable
 import app.cash.redwood.ui.OnBackPressedCallback
 import app.cash.redwood.ui.OnBackPressedDispatcher
 
-internal class FakeOnBackPressedDispatcher : OnBackPressedDispatcher {
+internal class FakeOnBackPressedDispatcher(
+  val eventLog: EventLog,
+) : OnBackPressedDispatcher {
   private val mutableCallbacks = mutableListOf<OnBackPressedCallback>()
+  private var nextCallbackId = 0
 
   val callbacks: List<OnBackPressedCallback>
     get() = mutableCallbacks.toList()
 
   override fun addCallback(onBackPressedCallback: OnBackPressedCallback): Cancellable {
+    val id = nextCallbackId++
     mutableCallbacks += onBackPressedCallback
 
     return object : Cancellable {
+      var canceled = false
+
       override fun cancel() {
+        if (canceled) return
+        canceled = true
+
+        eventLog += "onBackPressedDispatcher.callbacks[$id].cancel()"
         mutableCallbacks -= onBackPressedCallback
       }
     }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseView.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseView.kt
@@ -36,8 +36,7 @@ internal class FakeTreehouseView(
 
   override var saveCallback: TreehouseView.SaveCallback? = null
 
-  override val stateSnapshotId: StateSnapshot.Id
-    get() = error("unexpected call")
+  override val stateSnapshotId: StateSnapshot.Id = StateSnapshot.Id(null)
 
   override val children = MutableListChildren<FakeWidget>()
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseView.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseView.kt
@@ -22,6 +22,7 @@ import app.cash.redwood.widget.SavedStateRegistry
 import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class FakeTreehouseView(
+  override val onBackPressedDispatcher: FakeOnBackPressedDispatcher,
   private val name: String,
 ) : TreehouseView<FakeWidget> {
   override val widgetSystem = FakeWidgetSystem()
@@ -39,8 +40,6 @@ internal class FakeTreehouseView(
   override val stateSnapshotId: StateSnapshot.Id = StateSnapshot.Id(null)
 
   override val children = MutableListChildren<FakeWidget>()
-
-  override val onBackPressedDispatcher = FakeOnBackPressedDispatcher()
 
   override val uiConfiguration = MutableStateFlow(UiConfiguration())
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
@@ -58,7 +58,7 @@ class TreehouseAppContentTest {
   fun setUp() {
     runBlocking {
       codeHost.start()
-      eventLog.takeEvent("codeHost.collectCodeUpdates()")
+      eventLog.takeEvent("codeHostUpdates1.collect()")
     }
   }
 


### PR DESCRIPTION
This simplifies much of the internal complexity of TreehouseApp. We can also delete FakeCodeHost because the single implementation is suitable for unit testing.

Closes: https://github.com/cashapp/redwood/issues/1660