### PR TITLE
Explicitly opt-in to expect/actual support

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -201,6 +201,7 @@ class RedwoodBuildPlugin : Plugin<Project> {
     tasks.withType(KotlinCompile::class.java).configureEach {
       it.kotlinOptions.freeCompilerArgs += listOf(
         "-progressive", // https://kotlinlang.org/docs/whatsnew13.html#progressive-mode
+        "-Xexpect-actual-classes",
       )
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
-kotlin.mpp.stability.nowarn=true
 
 # This is needed for the JB Compose runtime to link on native targets. They also use this flag
 # in their samples. Over time it should be removed once they figure out why it was needed.


### PR DESCRIPTION
With KMP going stable in 1.9.20, features we previously relied upon now require opt-in.