### PR TITLE
Propagate `BackHandler#enabled` changing in Redwood

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "1.9.20"
 kotlinx-coroutines = "1.7.3"
 kotlinx-serialization = "1.6.0"
 androidx-activity = "1.8.0"
+androidx-compose-ui = "1.5.4"
 jbCompose = "1.5.10"
 lint = "31.1.1"
 zipline = "1.5.0"
@@ -37,6 +38,8 @@ androidx-activity = { module = "androidx.activity:activity", version.ref = "andr
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx.activity" }
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version = "1.6.1" }
 androidx-compose-compiler = "androidx.compose.compiler:compiler:1.5.4"
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-ui" }
 androidx-core = { module = "androidx.core:core-ktx", version = "1.12.0" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.3.2" }
 androidx-swipeRefreshLayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"

--- a/redwood-composeui/build.gradle
+++ b/redwood-composeui/build.gradle
@@ -19,9 +19,21 @@ kotlin {
         implementation projects.redwoodWidgetCompose
       }
     }
+    commonTest {
+      dependencies {
+        implementation libs.assertk
+      }
+    }
     androidMain {
       dependencies {
         implementation libs.androidx.activity.compose
+      }
+    }
+    androidUnitTest {
+      dependencies {
+        implementation libs.androidx.compose.ui.test.manifest
+        implementation libs.androidx.compose.ui.test.junit4
+        implementation libs.robolectric
       }
     }
   }
@@ -29,4 +41,8 @@ kotlin {
 
 android {
   namespace 'app.cash.redwood.composeui'
+
+  testOptions {
+    unitTests.includeAndroidResources = true  // Required by Robolectric.
+  }
 }

--- a/redwood-composeui/src/androidMain/kotlin/app/cash/redwood/composeui/RedwoodContent.android.kt
+++ b/redwood-composeui/src/androidMain/kotlin/app/cash/redwood/composeui/RedwoodContent.android.kt
@@ -30,9 +30,13 @@ internal actual fun platformOnBackPressedDispatcher(): RedwoodOnBackPressedDispa
     object : RedwoodOnBackPressedDispatcher {
       override fun addCallback(onBackPressedCallback: RedwoodOnBackPressedCallback): Cancellable {
         val androidOnBackPressedCallback = onBackPressedCallback.toAndroid()
+        onBackPressedCallback.enabledChangedCallback = {
+          androidOnBackPressedCallback.isEnabled = onBackPressedCallback.isEnabled
+        }
         delegate.addCallback(androidOnBackPressedCallback)
         return object : Cancellable {
           override fun cancel() {
+            onBackPressedCallback.enabledChangedCallback = null
             androidOnBackPressedCallback.remove()
           }
         }

--- a/redwood-composeui/src/androidUnitTest/kotlin/app/cash/redwood/composeui/AndroidOnBackPressedDispatcherTest.kt
+++ b/redwood-composeui/src/androidUnitTest/kotlin/app/cash/redwood/composeui/AndroidOnBackPressedDispatcherTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.composeui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import app.cash.redwood.ui.OnBackPressedCallback
+import assertk.assertThat
+import assertk.assertions.hasSize
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class AndroidOnBackPressedDispatcherTest {
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun disabledToEnabledOnBackPressedCallback() {
+    composeTestRule.setContent {
+      val onBackPressedDispatcher = platformOnBackPressedDispatcher()
+      val onBackPressedCallback = FakeOnBackPressedCallback(enabled = false)
+      onBackPressedDispatcher.addCallback(onBackPressedCallback)
+      composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+      assertThat(onBackPressedCallback.handleOnBackPressedEvents).hasSize(0)
+      onBackPressedCallback.isEnabled = true
+      composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+      assertThat(onBackPressedCallback.handleOnBackPressedEvents).hasSize(1)
+    }
+  }
+}
+
+private class FakeOnBackPressedCallback(enabled: Boolean) : OnBackPressedCallback(enabled) {
+  private val _handleOnBackPressedEvents = ArrayDeque<Unit>()
+  val handleOnBackPressedEvents: List<Unit> = _handleOnBackPressedEvents
+
+  override fun handleOnBackPressed() {
+    _handleOnBackPressedEvents += Unit
+  }
+}

--- a/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/OnBackPressedCallback.kt
+++ b/redwood-runtime/src/commonMain/kotlin/app/cash/redwood/ui/OnBackPressedCallback.kt
@@ -17,6 +17,12 @@ package app.cash.redwood.ui
 
 public abstract class OnBackPressedCallback(enabled: Boolean) {
   public var isEnabled: Boolean = enabled
+    set(value) {
+      field = value
+      enabledChangedCallback?.invoke()
+    }
+
+  public var enabledChangedCallback: (() -> Unit)? = null
 
   public abstract fun handleOnBackPressed()
 }

--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/RedwoodLayout.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/RedwoodLayout.kt
@@ -52,9 +52,13 @@ public open class RedwoodLayout(
     object : RedwoodOnBackPressedDispatcher {
       override fun addCallback(onBackPressedCallback: RedwoodOnBackPressedCallback): Cancellable {
         val androidOnBackPressedCallback = onBackPressedCallback.toAndroid()
+        onBackPressedCallback.enabledChangedCallback = {
+          androidOnBackPressedCallback.isEnabled = onBackPressedCallback.isEnabled
+        }
         androidOnBackPressedDispatcher.addCallback(androidOnBackPressedCallback)
         return object : Cancellable {
           override fun cancel() {
+            onBackPressedCallback.enabledChangedCallback = null
             androidOnBackPressedCallback.remove()
           }
         }

--- a/redwood-widget/src/androidUnitTest/kotlin/app/cash/redwood/widget/RedwoodLayoutTest.kt
+++ b/redwood-widget/src/androidUnitTest/kotlin/app/cash/redwood/widget/RedwoodLayoutTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.widget
+
+import androidx.activity.ComponentActivity
+import app.cash.redwood.ui.OnBackPressedCallback
+import assertk.assertThat
+import assertk.assertions.hasSize
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class RedwoodLayoutTest {
+  private val activity = Robolectric.buildActivity(ComponentActivity::class.java).resume().visible().get()
+
+  @Test
+  fun disabledToEnabledOnBackPressedCallback() {
+    val layout = RedwoodLayout(activity, activity.onBackPressedDispatcher)
+    val onBackPressedCallback = FakeOnBackPressedCallback(enabled = false)
+    layout.onBackPressedDispatcher.addCallback(onBackPressedCallback)
+    activity.onBackPressedDispatcher.onBackPressed()
+    assertThat(onBackPressedCallback.handleOnBackPressedEvents).hasSize(0)
+    onBackPressedCallback.isEnabled = true
+    activity.onBackPressedDispatcher.onBackPressed()
+    assertThat(onBackPressedCallback.handleOnBackPressedEvents).hasSize(1)
+  }
+}
+
+private class FakeOnBackPressedCallback(enabled: Boolean) : OnBackPressedCallback(enabled) {
+  private val _handleOnBackPressedEvents = ArrayDeque<Unit>()
+  val handleOnBackPressedEvents: List<Unit> = _handleOnBackPressedEvents
+
+  override fun handleOnBackPressed() {
+    _handleOnBackPressedEvents += Unit
+  }
+}


### PR DESCRIPTION
This only fixes the bug for Redwood. I'll make a follow up PR(s) to fix it for Treehouse.

Refs #1672 
