### PR TITLE
Make CodeSession a base class

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -18,30 +18,96 @@ package app.cash.redwood.treehouse
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
+
 /** The host state for a single code load. We get a new session each time we get new code. */
-internal interface CodeSession<A : AppService> {
-  val scope: CoroutineScope
+internal abstract class CodeSession<A : AppService>(
+  val dispatchers: TreehouseDispatchers,
+  val eventPublisher: EventPublisher,
+  val appScope: CoroutineScope,
+  val appService: A,
+) {
+  private val listeners = mutableListOf<Listener<A>>()
 
-  val eventPublisher: EventPublisher
+  private var stopped = false
 
-  val appService: A
+  /** This scope is canceled when this session stops. */
+  val scope: CoroutineScope = run {
+    val coroutineExceptionHandler = object : CoroutineExceptionHandler {
+      override val key: CoroutineContext.Key<*>
+        get() = CoroutineExceptionHandler.Key
 
-  val json: Json
+      override fun handleException(context: CoroutineContext, exception: Throwable) {
+        handleUncaughtException(exception)
+      }
+    }
 
-  fun start()
+    return@run CoroutineScope(
+      SupervisorJob(appScope.coroutineContext.job) + coroutineExceptionHandler
+    )
+  }
 
-  fun addListener(listener: Listener<A>)
+  abstract val json: Json
 
-  fun removeListener(listener: Listener<A>)
+  fun start() {
+    dispatchers.checkUi()
+    scope.launch(dispatchers.zipline) {
+      ziplineStart()
+    }
+  }
 
-  fun newServiceScope(): ServiceScope<A>
+  /** Invoked on [TreehouseDispatchers.zipline]. */
+  protected abstract fun ziplineStart()
+
+  fun stop() {
+    dispatchers.checkUi()
+
+    if (stopped) return
+    stopped = true
+
+    val listenersArray = listeners.toTypedArray() // onStop mutates.
+    for (listener in listenersArray) {
+      listener.onStop(this)
+    }
+
+    scope.launch(dispatchers.zipline) {
+      ziplineStop()
+      scope.cancel()
+    }
+  }
+
+  /** Invoked on [TreehouseDispatchers.zipline]. */
+  protected abstract fun ziplineStop()
 
   /** Propagates [exception] to all listeners and cancels this session. */
-  fun handleUncaughtException(exception: Throwable)
+  fun handleUncaughtException(exception: Throwable) {
+    scope.launch(dispatchers.ui) {
+      val listenersArray = listeners.toTypedArray() // onUncaughtException mutates.
+      for (listener in listenersArray) {
+        listener.onUncaughtException(this@CodeSession, exception)
+      }
+      stop()
+    }
 
-  fun cancel()
+    eventPublisher.onUncaughtException(exception)
+  }
+
+  abstract fun newServiceScope(): ServiceScope<A>
+
+  fun addListener(listener: Listener<A>) {
+    dispatchers.checkUi()
+    listeners += listener
+  }
+
+  fun removeListener(listener: Listener<A>) {
+    dispatchers.checkUi()
+    listeners -= listener
+  }
 
   /**
    * Tracks all of the services created to produce a UI, and offers a single mechanism to close
@@ -57,17 +123,10 @@ internal interface CodeSession<A : AppService> {
   }
 
   interface Listener<A : AppService> {
+    /** Called when a code session crashed with [exception].*/
     fun onUncaughtException(codeSession: CodeSession<A>, exception: Throwable)
-    fun onCancel(codeSession: CodeSession<A>)
+
+    /** Called when a code session will stop.*/
+    fun onStop(codeSession: CodeSession<A>)
   }
 }
-
-internal val CodeSession<*>.coroutineExceptionHandler: CoroutineExceptionHandler
-  get() = object : CoroutineExceptionHandler {
-    override val key: CoroutineContext.Key<*>
-      get() = CoroutineExceptionHandler.Key
-
-    override fun handleException(context: CoroutineContext, exception: Throwable) {
-      handleUncaughtException(exception)
-    }
-  }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
-
 /** The host state for a single code load. We get a new session each time we get new code. */
 internal abstract class CodeSession<A : AppService>(
   val dispatchers: TreehouseDispatchers,
@@ -48,7 +47,7 @@ internal abstract class CodeSession<A : AppService>(
     }
 
     return@run CoroutineScope(
-      SupervisorJob(appScope.coroutineContext.job) + coroutineExceptionHandler
+      SupervisorJob(appScope.coroutineContext.job) + coroutineExceptionHandler,
     )
   }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealAppLifecycleHost.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealAppLifecycleHost.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import app.cash.redwood.protocol.EventTag
+import app.cash.redwood.protocol.Id
+import app.cash.redwood.protocol.WidgetTag
+
+internal class RealAppLifecycleHost(
+  private val appLifecycle: AppLifecycle,
+  private val frameClock: FrameClock,
+  private val eventPublisher: EventPublisher,
+  private val codeSession: CodeSession<*>,
+) : AppLifecycle.Host {
+  override fun requestFrame() {
+    frameClock.requestFrame(appLifecycle)
+  }
+
+  override fun onUnknownEvent(
+    widgetTag: WidgetTag,
+    tag: EventTag,
+  ) {
+    eventPublisher.onUnknownEvent(widgetTag, tag)
+  }
+
+  override fun onUnknownEventNode(
+    id: Id,
+    tag: EventTag,
+  ) {
+    eventPublisher.onUnknownEventNode(id, tag)
+  }
+
+  override fun handleUncaughtException(exception: Throwable) {
+    codeSession.handleUncaughtException(exception)
+  }
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -229,18 +229,18 @@ internal class TreehouseAppContent<A : AppService>(
   }
 
   override fun onUncaughtException(codeSession: CodeSession<A>, exception: Throwable) {
-    codeSessionCanceled(exception = exception)
+    codeSessionStopped(exception = exception)
   }
 
-  override fun onCancel(codeSession: CodeSession<A>) {
-    codeSessionCanceled(exception = null)
+  override fun onStop(codeSession: CodeSession<A>) {
+    codeSessionStopped(exception = null)
   }
 
   /**
    * If the code crashes or is unloaded, show an error on the UI and cancel the UI binding. This
    * sets the code state back to idle.
    */
-  private fun codeSessionCanceled(exception: Throwable?) {
+  private fun codeSessionStopped(exception: Throwable?) {
     dispatchers.checkUi()
 
     val previousState = stateFlow.value

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
@@ -66,7 +66,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     content.unbind()
   }
@@ -88,7 +88,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     content.unbind()
   }
@@ -109,7 +109,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     codeHost.start()
     eventLog.takeEvent("codeHostUpdates2.collect()")
@@ -119,7 +119,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates2.close()")
     eventLog.takeEvent("codeSessionB.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionB.cancel()")
+    eventLog.takeEvent("codeSessionB.stop()")
 
     content.unbind()
   }
@@ -138,9 +138,9 @@ class CodeHostTest {
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
     codeSessionA.handleUncaughtException(Exception("boom!"))
-    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeListener.onUncaughtException(view1, kotlin.Exception: boom!)")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     codeHost.restart()
     eventLog.takeEvent("codeHostUpdates1.close()")
@@ -151,7 +151,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates2.close()")
     eventLog.takeEvent("codeSessionB.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionB.cancel()")
+    eventLog.takeEvent("codeSessionB.stop()")
 
     content.unbind()
   }
@@ -170,9 +170,9 @@ class CodeHostTest {
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
     codeSessionA.handleUncaughtException(Exception("boom!"))
-    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeListener.onUncaughtException(view1, kotlin.Exception: boom!)")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     codeHost.startCodeSession("codeSessionB")
     eventLog.takeEvent("codeSessionB.start()")
@@ -180,7 +180,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionB.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionB.cancel()")
+    eventLog.takeEvent("codeSessionB.stop()")
 
     content.unbind()
   }
@@ -199,9 +199,9 @@ class CodeHostTest {
     eventLog.takeEvent("codeSessionA.start()")
     eventLog.takeEvent("codeSessionA.app.uis[0].start()")
     codeSessionA.handleUncaughtException(Exception("boom!"))
-    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
     eventLog.takeEvent("codeListener.onUncaughtException(view1, kotlin.Exception: boom!)")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
@@ -230,7 +230,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     content.unbind()
   }
@@ -255,7 +255,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     content.unbind()
   }
@@ -277,7 +277,7 @@ class CodeHostTest {
     codeHost.stop()
     eventLog.takeEvent("codeHostUpdates1.close()")
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     codeHost.stop()
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeHost.kt
@@ -51,7 +51,7 @@ internal class FakeCodeHost(
   }
 
   suspend fun startCodeSession(name: String): CodeSession<FakeAppService> {
-    val result = FakeCodeSession(dispatchers, eventPublisher, eventLog, name, appScope)
+    val result = FakeCodeSession(dispatchers, eventPublisher, appScope, eventLog, name)
     codeSessions!!.send(result)
     return result
   }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
@@ -170,7 +170,7 @@ class TreehouseAppContentTest {
     val codeSessionB = codeHost.startCodeSession("codeSessionB")
     eventLog.takeEventsInAnyOrder(
       "codeSessionA.app.uis[0].close()",
-      "codeSessionA.cancel()",
+      "codeSessionA.stop()",
       "codeSessionB.start()",
       "codeSessionB.app.uis[0].start()",
     )
@@ -314,7 +314,7 @@ class TreehouseAppContentTest {
     eventLog.takeEventsInAnyOrder(
       "codeSessionA.app.uis[0].close()",
       "onBackPressedDispatcher.callbacks[0].cancel()",
-      "codeSessionA.cancel()",
+      "codeSessionA.stop()",
       "codeSessionB.start()",
       "codeSessionB.app.uis[0].start()",
     )
@@ -339,7 +339,7 @@ class TreehouseAppContentTest {
     eventLog.takeEventsInAnyOrder(
       "codeSessionA.app.uis[0].close()",
       "codeListener.onUncaughtException(view1, kotlin.Exception: boom!)",
-      "codeSessionA.cancel()",
+      "codeSessionA.stop()",
     )
 
     content.unbind()
@@ -353,7 +353,7 @@ class TreehouseAppContentTest {
     eventLog.takeEvent("codeSessionA.start()")
 
     codeSessionA.handleUncaughtException(Exception("boom!"))
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     val view1 = treehouseView("view1")
     content.bind(view1)
@@ -382,7 +382,7 @@ class TreehouseAppContentTest {
     eventLog.takeEventsInAnyOrder(
       "codeSessionA.app.uis[0].close()",
       "codeListener.onUncaughtException(view1, kotlin.Exception: boom!)",
-      "codeSessionA.cancel()",
+      "codeSessionA.stop()",
     )
 
     codeHost.startCodeSession("codeSessionB")
@@ -409,7 +409,7 @@ class TreehouseAppContentTest {
 
     codeSessionA.handleUncaughtException(Exception("boom!"))
     eventLog.takeEvent("codeSessionA.app.uis[0].close()")
-    eventLog.takeEvent("codeSessionA.cancel()")
+    eventLog.takeEvent("codeSessionA.stop()")
 
     val view1 = treehouseView("view1")
     content.bind(view1)


### PR DESCRIPTION
This splits the Zipline dependency from the lifecycle management. It lets us test the same lifecycle code for the FakeCodeSession.

Also rename CodeSession.cancel() to CodeSession.stop().