### PR TITLE
Stop the duplicate creation of `ZiplineTreehouseUi` on launch in Compose UI for Treehouse

### DIFF
--- a/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
+++ b/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/TreehouseContent.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 public fun <A : AppService> TreehouseContent(
   treehouseApp: TreehouseApp<A>,
   widgetSystem: WidgetSystem<@Composable () -> Unit>,
-  codeListener: CodeListener = CodeListener(),
+  codeListener: CodeListener = remember { CodeListener() },
   contentSource: TreehouseContentSource<A>,
   modifier: Modifier = Modifier,
 ) {


### PR DESCRIPTION
Putting a log in `RealEmojiSearchPresenter#launch()` without the PR changes shows that Emoji Search gets "launched" twice.