### PR TITLE
Add a TreehouseApp argument to CodeListener

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeEventPublisher.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeEventPublisher.kt
@@ -15,28 +15,18 @@
  */
 package app.cash.redwood.treehouse
 
-class FakeCodeListener(
-  private val eventLog: EventLog,
-) : CodeListener() {
-  override fun onInitialCodeLoading(
+internal interface CodeEventPublisher {
+  fun onInitialCodeLoading(
     view: TreehouseView<*>,
-  ) {
-    eventLog += "codeListener.onInitialCodeLoading($view)"
-  }
+  )
 
-  override fun onCodeLoaded(
+  fun onCodeLoaded(
     view: TreehouseView<*>,
     initial: Boolean,
-  ) {
-    eventLog += "codeListener.onCodeLoaded($view, initial = $initial)"
-  }
+  )
 
-  override fun onUncaughtException(
+  fun onUncaughtException(
     view: TreehouseView<*>,
     exception: Throwable,
-  ) {
-    // Canonicalize "java.lang.Exception(boom!)" to "kotlin.Exception(boom!)".
-    val exceptionString = exception.toString().replace("java.lang.", "kotlin.")
-    eventLog += "codeListener.onUncaughtException($view, $exceptionString)"
-  }
+  )
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeListener.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeListener.kt
@@ -23,7 +23,11 @@ public open class CodeListener {
    * Invoked when the initial code is still loading. This can be used to signal a loading state
    * in the UI before there is anything to display.
    */
-  public open fun onInitialCodeLoading(view: TreehouseView<*>) {}
+  public open fun onInitialCodeLoading(
+    app: TreehouseApp<*>,
+    view: TreehouseView<*>,
+  ) {
+  }
 
   /**
    * Invoked each time new code is loaded. This is called after the view's old children have
@@ -31,7 +35,12 @@ public open class CodeListener {
    *
    * @param initial true if this is the first code loaded for this view's current content.
    */
-  public open fun onCodeLoaded(view: TreehouseView<*>, initial: Boolean) {}
+  public open fun onCodeLoaded(
+    app: TreehouseApp<*>,
+    view: TreehouseView<*>,
+    initial: Boolean,
+  ) {
+  }
 
   /**
    * Invoked when the application powering [view] fails with an uncaught exception. This function
@@ -47,6 +56,7 @@ public open class CodeListener {
    * called.
    */
   public open fun onUncaughtException(
+    app: TreehouseApp<*>,
     view: TreehouseView<*>,
     exception: Throwable,
   ) {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealCodeEventPublisher.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealCodeEventPublisher.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+internal class RealCodeEventPublisher(
+  private val codeListener: CodeListener,
+  private val app: TreehouseApp<*>,
+) : CodeEventPublisher {
+  override fun onInitialCodeLoading(view: TreehouseView<*>) {
+    return codeListener.onInitialCodeLoading(app, view)
+  }
+
+  override fun onCodeLoaded(view: TreehouseView<*>, initial: Boolean) {
+    return codeListener.onCodeLoaded(app, view, initial)
+  }
+
+  override fun onUncaughtException(view: TreehouseView<*>, exception: Throwable) {
+    return codeListener.onUncaughtException(app, view, exception)
+  }
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -87,7 +87,7 @@ public class TreehouseApp<A : AppService> private constructor(
     return TreehouseAppContent(
       codeHost = codeHost,
       dispatchers = dispatchers,
-      codeListener = codeListener,
+      codeEventPublisher = RealCodeEventPublisher(codeListener, this),
       source = source,
     )
   }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
@@ -40,7 +40,7 @@ class CodeHostTest {
     appScope = appScope,
     frameClockFactory = FakeFrameClock.Factory,
   )
-  private val codeListener = FakeCodeListener(eventLog)
+  private val codeEventPublisher = FakeCodeEventPublisher(eventLog)
   private val onBackPressedDispatcher = FakeOnBackPressedDispatcher(eventLog)
 
   @AfterTest
@@ -288,7 +288,7 @@ class CodeHostTest {
     return TreehouseAppContent(
       codeHost = codeHost,
       dispatchers = dispatchers,
-      codeListener = codeListener,
+      codeEventPublisher = codeEventPublisher,
       source = { app -> app.newUi() },
     )
   }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeEventPublisher.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeEventPublisher.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+class FakeCodeEventPublisher(
+  private val eventLog: EventLog,
+) : CodeEventPublisher {
+  override fun onInitialCodeLoading(view: TreehouseView<*>) {
+    eventLog += "codeListener.onInitialCodeLoading($view)"
+  }
+
+  override fun onCodeLoaded(view: TreehouseView<*>, initial: Boolean) {
+    eventLog += "codeListener.onCodeLoaded($view, initial = $initial)"
+  }
+
+  override fun onUncaughtException(view: TreehouseView<*>, exception: Throwable) {
+    // Canonicalize "java.lang.Exception(boom!)" to "kotlin.Exception(boom!)".
+    val exceptionString = exception.toString().replace("java.lang.", "kotlin.")
+    eventLog += "codeListener.onUncaughtException($view, $exceptionString)"
+  }
+}

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
@@ -51,7 +51,7 @@ class TreehouseAppContentTest {
     appScope = appScope,
     frameClockFactory = FakeFrameClock.Factory,
   )
-  private val codeListener = FakeCodeListener(eventLog)
+  private val codeEventPublisher = FakeCodeEventPublisher(eventLog)
   private val uiConfiguration = UiConfiguration()
 
   @BeforeTest
@@ -450,7 +450,7 @@ class TreehouseAppContentTest {
     return TreehouseAppContent(
       codeHost = codeHost,
       dispatchers = dispatchers,
-      codeListener = codeListener,
+      codeEventPublisher = codeEventPublisher,
       source = { app -> app.newUi() },
     )
   }

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -87,7 +87,11 @@ class EmojiSearchActivity : ComponentActivity() {
   }
 
   private val codeListener: CodeListener = object : CodeListener() {
-    override fun onUncaughtException(view: TreehouseView<*>, exception: Throwable) {
+    override fun onUncaughtException(
+      app: TreehouseApp<*>,
+      view: TreehouseView<*>,
+      exception: Throwable,
+    ) {
       treehouseLayout.reset()
       treehouseLayout.addView(
         ExceptionView(treehouseLayout, exception),

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -78,7 +78,7 @@ class EmojiSearchCodeListener : CodeListener {
         self.treehouseView = treehouseView
     }
 
-    override func onUncaughtException(view: TreehouseView, exception: KotlinThrowable) {
+    override func onUncaughtException(app: TreehouseApp<AnyObject>, view: TreehouseView, exception: KotlinThrowable) {
         treehouseView.reset()
 
         let exceptionView = ExceptionView(exception)


### PR DESCRIPTION
A reasonable action to take in onUncaughtException is to call TreehouseApp.restart(). This change makes that easy.