### PR TITLE
Do not double-test samples

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           api-level: 29
           emulator-boot-timeout: 20000
-          script: ./gradlew connectedCheck -PredwoodNoSamples
+          script: ./gradlew connectedCheck -PredwoodNoApps
 
   dokka:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Each sample runs its own emulator and performs connected checks on itself. The top-level connected check is for the redwood module's instrumented tests only.