### PR TITLE
Suppress deprecation warnings in generated code

### DIFF
--- a/redwood-tooling-codegen/build.gradle
+++ b/redwood-tooling-codegen/build.gradle
@@ -14,4 +14,5 @@ dependencies {
   testImplementation projects.testApp.schema.compose
   testImplementation libs.junit
   testImplementation libs.assertk
+  testImplementation libs.testParameterInjector
 }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
@@ -68,6 +68,7 @@ internal fun generateComposable(
   val widgetType = schema.widgetType(widget).parameterizedBy(STAR)
   val flatName = widget.type.flatName
   return FileSpec.builder(schema.composePackage(), flatName)
+    .addAnnotation(suppressDeprecations)
     .addFunction(
       FunSpec.builder(flatName)
         .addAnnotation(ComposeRuntime.Composable)
@@ -209,6 +210,7 @@ internal fun generateScope(schema: Schema, scope: FqType): FileSpec {
   val scopeName = scope.flatName
   val scopeType = ClassName(schema.composePackage(), scopeName)
   return FileSpec.builder(scopeType)
+    .addAnnotation(suppressDeprecations)
     .apply {
       val scopeBuilder = TypeSpec.interfaceBuilder(scopeType)
         .addAnnotation(Redwood.LayoutScopeMarker)
@@ -243,6 +245,7 @@ internal fun generateModifierImpls(schema: Schema): FileSpec? {
   if (schema.modifiers.isEmpty()) return null
 
   return FileSpec.builder(schema.composePackage(), "modifier")
+    .addAnnotation(suppressDeprecations)
     .apply {
       for (modifier in schema.modifiers) {
         addType(generateModifierImpl(schema, modifier))

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/modifierGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/modifierGeneration.kt
@@ -24,6 +24,7 @@ import com.squareup.kotlinpoet.TypeSpec
 internal fun generateModifierInterface(schema: Schema, modifier: Modifier): FileSpec {
   val type = schema.modifierType(modifier)
   return FileSpec.builder(type.packageName, type.simpleName)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.interfaceBuilder(type)
         .addSuperinterface(Redwood.ModifierElement)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolGuestGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolGuestGeneration.kt
@@ -86,6 +86,7 @@ internal fun generateProtocolBridge(
   val type = schema.protocolBridgeType()
   val providerType = schema.getWidgetFactoryProviderType().parameterizedBy(NOTHING)
   return FileSpec.builder(type)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(type)
         .addSuperinterface(ProtocolGuest.ProtocolBridge)
@@ -195,6 +196,7 @@ internal fun generateProtocolWidgetFactory(
 ): FileSpec {
   val type = schema.protocolWidgetFactoryType(host)
   return FileSpec.builder(type)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(type)
         .addModifiers(INTERNAL)
@@ -293,6 +295,7 @@ internal fun generateProtocolWidget(
   val type = schema.protocolWidgetType(widget, host)
   val widgetName = schema.widgetType(widget)
   return FileSpec.builder(type)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(type)
         .addModifiers(INTERNAL)
@@ -512,6 +515,7 @@ internal fun generateProtocolModifierSerializers(
     return null
   }
   return FileSpec.builder(schema.composePackage(host), "modifierSerializers")
+    .addAnnotation(suppressDeprecations)
     .apply {
       for (modifier in serializableModifiers) {
         val serializerType = schema.modifierSerializer(modifier, host)
@@ -691,6 +695,7 @@ internal fun generateComposeProtocolModifierSerialization(
   val schema = schemaSet.schema
   val name = schema.modifierToProtocol.simpleName
   return FileSpec.builder(schema.composePackage(), "modifierSerialization")
+    .addAnnotation(suppressDeprecations)
     .addFunction(
       FunSpec.builder(name)
         .addModifiers(INTERNAL)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -213,6 +213,11 @@ internal fun Deprecation.toAnnotationSpec(): AnnotationSpec {
     .build()
 }
 
+internal val suppressDeprecations = AnnotationSpec.builder(Suppress::class)
+  .useSiteTarget(AnnotationSpec.UseSiteTarget.FILE)
+  .addMember("%S", "DEPRECATION")
+  .build()
+
 private fun Deprecation.Level.toMemberName(): MemberName {
   return MemberName(
     DeprecationLevel::class.asClassName(),

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -72,6 +72,7 @@ internal fun generateTester(schemaSet: SchemaSet): FileSpec {
     returnType = typeVarR,
   ).copy(suspending = true)
   return FileSpec.builder(testerFunction.packageName, testerFunction.simpleName)
+    .addAnnotation(suppressDeprecations)
     .addFunction(
       FunSpec.builder(testerFunction)
         .optIn(Redwood.RedwoodCodegenApi)
@@ -127,6 +128,7 @@ public class EmojiSearchTestingWidgetFactory : EmojiSearchWidgetFactory<WidgetVa
 internal fun generateMutableWidgetFactory(schema: Schema): FileSpec {
   val mutableWidgetFactoryType = schema.getTestingWidgetFactoryType()
   return FileSpec.builder(mutableWidgetFactoryType)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(mutableWidgetFactoryType)
         .addSuperinterface(schema.getWidgetFactoryType().parameterizedBy(RedwoodTesting.WidgetValue))
@@ -171,6 +173,7 @@ internal fun generateMutableWidget(schema: Schema, widget: Widget): FileSpec {
   val mutableWidgetType = schema.mutableWidgetType(widget)
   val widgetValueType = schema.widgetValueType(widget)
   return FileSpec.builder(mutableWidgetType)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(mutableWidgetType)
         .addModifiers(INTERNAL)
@@ -360,6 +363,7 @@ internal fun generateWidgetValue(schema: Schema, widget: Widget): FileSpec {
   }
 
   return FileSpec.builder(widgetValueType)
+    .addAnnotation(suppressDeprecations)
     .addType(
       classBuilder
         .primaryConstructor(constructorBuilder.build())

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
@@ -47,6 +47,7 @@ internal fun generateWidgetFactories(schemaSet: SchemaSet): FileSpec {
   val schema = schemaSet.schema
   val widgetFactoriesType = schema.getWidgetFactoriesType()
   return FileSpec.builder(widgetFactoriesType)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(widgetFactoriesType)
         .addTypeVariable(typeVariableW)
@@ -102,6 +103,7 @@ interface ExampleWidgetFactory<W : Any> : Widget.Factory<W> {
 internal fun generateWidgetFactory(schema: Schema): FileSpec {
   val widgetFactoryType = schema.getWidgetFactoryType()
   return FileSpec.builder(widgetFactoryType)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.interfaceBuilder(widgetFactoryType)
         .addTypeVariable(typeVariableW)
@@ -157,6 +159,7 @@ interface Button<W: Any> : Widget<W> {
 internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
   val flatName = widget.type.flatName
   return FileSpec.builder(schema.widgetPackage(), flatName)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.interfaceBuilder(flatName)
         .addTypeVariable(typeVariableW)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
@@ -73,6 +73,7 @@ internal fun generateProtocolFactory(
   val provider = schema.getWidgetFactoryProviderType().parameterizedBy(typeVariableW)
   val type = schema.protocolFactoryType()
   return FileSpec.builder(type)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(type)
         .addTypeVariable(typeVariableW)
@@ -225,6 +226,7 @@ internal fun generateProtocolNode(
   val protocolType = WidgetProtocol.ProtocolNode.parameterizedBy(typeVariableW)
   val (childrens, properties) = widget.traits.partition { it is ProtocolChildren }
   return FileSpec.builder(type)
+    .addAnnotation(suppressDeprecations)
     .addType(
       TypeSpec.classBuilder(type)
         .addModifiers(INTERNAL)
@@ -413,6 +415,7 @@ internal fun generateProtocolModifierImpls(
     return null
   }
   return FileSpec.builder(schema.widgetPackage(host), "modifierImpls")
+    .addAnnotation(suppressDeprecations)
     .apply {
       for (modifier in schema.modifiers) {
         val typeName = ClassName(schema.widgetPackage(host), modifier.type.flatName + "Impl")

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/DeprecatedGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/DeprecatedGenerationTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.tooling.codegen
+
+import app.cash.redwood.schema.Children
+import app.cash.redwood.schema.Modifier
+import app.cash.redwood.schema.Property
+import app.cash.redwood.schema.Schema
+import app.cash.redwood.schema.Widget
+import app.cash.redwood.tooling.schema.ProtocolSchemaSet
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.contains
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import kotlin.DeprecationLevel.ERROR
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class DeprecatedGenerationTest {
+  @Suppress("DEPRECATION")
+  @Schema(
+    [
+      DeprecatedModifier::class,
+      DeprecatedWidget::class,
+    ],
+  )
+  interface DeprecatedSchema
+
+  @Widget(1)
+  @Deprecated("Hey")
+  data class DeprecatedWidget(
+    @Property(1)
+    @Deprecated("Property", level = ERROR)
+    val prop: String,
+    @Property(2)
+    @Deprecated("Event", level = ERROR)
+    val event: () -> Unit,
+    @Children(1)
+    @Deprecated("Children", level = ERROR)
+    val children: () -> Unit,
+  )
+
+  @Modifier(1, ModifierGenerationTest.ModifierScope::class)
+  @Deprecated("Hey")
+  data class DeprecatedModifier(
+    @Deprecated("Hello", level = ERROR)
+    val a: String,
+  )
+
+  @Test fun modifierInterface() {
+    val schema = ProtocolSchemaSet.parse(DeprecatedSchema::class).schema
+
+    val modifier = schema.modifiers.single()
+    val fileSpec = generateModifierInterface(schema, modifier)
+    assertThat(fileSpec.toString()).all {
+      contains(
+        """
+        |@Deprecated(
+        |  "Hey",
+        |  level = WARNING,
+        |)
+        |public interface DeprecatedGenerationTestDeprecatedModifier
+        """.trimMargin(),
+      )
+
+      contains(
+        """
+        |  @Deprecated(
+        |    "Hello",
+        |    level = ERROR,
+        |  )
+        |  public val a:
+        """.trimMargin(),
+      )
+    }
+  }
+
+  @Test fun widget() {
+    val schema = ProtocolSchemaSet.parse(DeprecatedSchema::class).schema
+
+    val widget = schema.widgets.single()
+    val fileSpec = generateWidget(schema, widget)
+    assertThat(fileSpec.toString()).all {
+      contains(
+        """
+        |@Deprecated(
+        |  "Hey",
+        |  level = WARNING,
+        |)
+        |public interface DeprecatedGenerationTestDeprecatedWidget
+        """.trimMargin(),
+      )
+
+      contains(
+        """
+        |  @Deprecated(
+        |    "Property",
+        |    level = ERROR,
+        |  )
+        |  public fun prop(
+        """.trimMargin(),
+      )
+
+      contains(
+        """
+        |  @Deprecated(
+        |    "Event",
+        |    level = ERROR,
+        |  )
+        |  public fun event(
+        """.trimMargin(),
+      )
+
+      contains(
+        """
+        |  @Deprecated(
+        |    "Children",
+        |    level = ERROR,
+        |  )
+        |  public val children:
+        """.trimMargin(),
+      )
+    }
+  }
+
+  @Test
+  fun protocolCodegen(
+    @TestParameter type: ProtocolCodegenType,
+  ) {
+    val schema = ProtocolSchemaSet.parse(DeprecatedSchema::class)
+    assertAll {
+      for (fileSpec in schema.generateFileSpecs(type)) {
+        assertThat(fileSpec.toString()).contains("""@file:Suppress("DEPRECATION")""")
+      }
+    }
+  }
+
+  @Test fun codegen(
+    @TestParameter type: CodegenType,
+  ) {
+    val schema = ProtocolSchemaSet.parse(DeprecatedSchema::class)
+    assertAll {
+      for (fileSpec in schema.generateFileSpecs(type)) {
+        assertThat(fileSpec.toString()).contains("""@file:Suppress("DEPRECATION")""")
+      }
+    }
+  }
+}

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ModifierGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ModifierGenerationTest.kt
@@ -18,12 +18,10 @@ package app.cash.redwood.tooling.codegen
 import app.cash.redwood.schema.Modifier
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import com.example.redwood.testing.compose.TestScope
-import kotlin.DeprecationLevel.ERROR
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Test
@@ -94,48 +92,5 @@ class ModifierGenerationTest {
 
     type = app.cash.redwood.Modifier.customTypeWithDefault(40.minutes, "hello")
     assertThat(type.toString()).isEqualTo("CustomTypeWithDefault(customType=40m, string=hello)")
-  }
-
-  @Suppress("DEPRECATION")
-  @Schema(
-    [
-      DeprecatedModifier::class,
-    ],
-  )
-  interface DeprecatedSchema
-
-  @Modifier(1, ModifierScope::class)
-  @Deprecated("Hey")
-  data class DeprecatedModifier(
-    @Deprecated("Hello", level = ERROR)
-    val a: String,
-  )
-
-  @Test fun deprecation() {
-    val schema = ProtocolSchemaSet.parse(DeprecatedSchema::class).schema
-
-    val modifier = schema.modifiers.single()
-    val fileSpec = generateModifierInterface(schema, modifier)
-    assertThat(fileSpec.toString()).all {
-      contains(
-        """
-        |@Deprecated(
-        |  "Hey",
-        |  level = WARNING,
-        |)
-        |public interface ModifierGenerationTestDeprecatedModifier
-        """.trimMargin(),
-      )
-
-      contains(
-        """
-        |  @Deprecated(
-        |    "Hello",
-        |    level = ERROR,
-        |  )
-        |  public val a:
-        """.trimMargin(),
-      )
-    }
   }
 }

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetGenerationTest.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.tooling.codegen
 
-import app.cash.redwood.schema.Children
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
@@ -23,7 +22,6 @@ import app.cash.redwood.tooling.schema.ProtocolSchemaSet
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
-import kotlin.DeprecationLevel.ERROR
 import org.junit.Test
 
 class WidgetGenerationTest {
@@ -88,76 +86,6 @@ class WidgetGenerationTest {
         |   * {tag=1}
         |   */
         |  public fun text
-        """.trimMargin(),
-      )
-    }
-  }
-
-  @Suppress("DEPRECATION")
-  @Schema(
-    [
-      DeprecatedWidget::class,
-    ],
-  )
-  interface DeprecatedSchema
-
-  @Widget(1)
-  @Deprecated("Hey")
-  data class DeprecatedWidget(
-    @Property(1)
-    @Deprecated("Property", level = ERROR)
-    val prop: String,
-    @Property(2)
-    @Deprecated("Event", level = ERROR)
-    val event: () -> Unit,
-    @Children(1)
-    @Deprecated("Children", level = ERROR)
-    val children: () -> Unit,
-  )
-
-  @Test fun deprecation() {
-    val schema = ProtocolSchemaSet.parse(DeprecatedSchema::class).schema
-
-    val widget = schema.widgets.single()
-    val fileSpec = generateWidget(schema, widget)
-    assertThat(fileSpec.toString()).all {
-      contains(
-        """
-        |@Deprecated(
-        |  "Hey",
-        |  level = WARNING,
-        |)
-        |public interface WidgetGenerationTestDeprecatedWidget
-        """.trimMargin(),
-      )
-
-      contains(
-        """
-        |  @Deprecated(
-        |    "Property",
-        |    level = ERROR,
-        |  )
-        |  public fun prop(
-        """.trimMargin(),
-      )
-
-      contains(
-        """
-        |  @Deprecated(
-        |    "Event",
-        |    level = ERROR,
-        |  )
-        |  public fun event(
-        """.trimMargin(),
-      )
-
-      contains(
-        """
-        |  @Deprecated(
-        |    "Children",
-        |    level = ERROR,
-        |  )
-        |  public val children:
         """.trimMargin(),
       )
     }


### PR DESCRIPTION
Our generated code calls deprecated APIs, either because the Redwood generated interfaces they're calling are deprecated, or because other external symbols like property types are deprecated.

In either case the developer is already getting these deprecation warnings in the code that declares the schema, so Redwood's additional deprecations are just noise.

This PR applies deprecation warnings everywhere. I originally looked into doing it precisely for the Redwood symbols that declare deprecations, but this doesn't cover deprecations on property types.