### PR TITLE
Fix bug replacing of root widget on UIKit

### DIFF
--- a/redwood-widget-testing/src/commonMain/kotlin/app/cash/redwood/widget/testing/AbstractWidgetChildrenTest.kt
+++ b/redwood-widget-testing/src/commonMain/kotlin/app/cash/redwood/widget/testing/AbstractWidgetChildrenTest.kt
@@ -140,6 +140,16 @@ public abstract class AbstractWidgetChildrenTest<W : Any> {
     assertThat(names()).containsExactly("one", "two", "three")
   }
 
+  @Test public fun replace() {
+    // Models what happens when a conditional flips from the second branch to the first.
+    // The new item will be added and then the old item will be removed.
+    // From https://github.com/cashapp/redwood/pull/1706.
+    children.insert(0, widget("one"))
+    children.insert(0, widget("new one"))
+    children.remove(1, 1)
+    assertThat(names()).containsExactly("new one")
+  }
+
   private fun <W : Any> Widget.Children<W>.insert(index: Int, widget: W) {
     insert(
       index = index,

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -28,8 +28,13 @@ public class UIViewChildren(
     else -> { view, index -> parent.insertSubview(view, index.convert<NSInteger>()) }
   },
   private val remove: (index: Int, count: Int) -> Array<UIView> = { index, count ->
-    Array(count) {
-      parent.typedSubviews[index].also(UIView::removeFromSuperview)
+    // Per the docs, these properties are read-only copies we can use stable indexing into.
+    val subviews = when (parent) {
+      is UIStackView -> parent.typedArrangedSubviews
+      else -> parent.typedSubviews
+    }
+    Array(count) { offset ->
+      subviews[index + offset].also(UIView::removeFromSuperview)
     }
   },
 ) : Widget.Children<UIView> {

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/utils.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/utils.kt
@@ -15,9 +15,14 @@
  */
 package app.cash.redwood.widget
 
+import platform.UIKit.UIStackView
 import platform.UIKit.UIView
 import platform.UIKit.subviews
 
 @Suppress("UNCHECKED_CAST")
 internal val UIView.typedSubviews: List<UIView>
   get() = subviews as List<UIView>
+
+@Suppress("UNCHECKED_CAST")
+internal val UIStackView.typedArrangedSubviews: List<UIView>
+  get() = arrangedSubviews as List<UIView>

--- a/redwood-widget/src/iosTest/kotlin/app/cash/redwood/widget/UIStackViewChildrenTest.kt
+++ b/redwood-widget/src/iosTest/kotlin/app/cash/redwood/widget/UIStackViewChildrenTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.widget
+
+import app.cash.redwood.widget.testing.AbstractWidgetChildrenTest
+import platform.UIKit.UILabel
+import platform.UIKit.UIStackView
+import platform.UIKit.UIView
+
+/**
+ * [UIViewChildren] has special support for [UIStackView] containers which (somewhat annoyingly)
+ * use a different collection for managing the children.
+ */
+class UIStackViewChildrenTest : AbstractWidgetChildrenTest<UIView>() {
+  private val parent = UIStackView()
+  override val children = UIViewChildren(parent)
+
+  override fun widget(name: String): UIView {
+    return UILabel().apply { text = name }
+  }
+
+  override fun names(): List<String> {
+    return parent.arrangedSubviews.map { (it as UILabel).text!! }
+  }
+}


### PR DESCRIPTION
Hello!

We find bug on iOS with UIKit and redwood. Case:
create uikit with root `UIStackView` - just like in CounterApp sample:
```
let container = UIStackView()
container.axis = .horizontal
container.alignment = .fill
container.distribution = .fillEqually
container.translatesAutoresizingMaskIntoConstraints = false

view.addSubview(container)
container.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
container.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
container.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
container.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true

self.delegate = CounterViewControllerDelegate(root: container)
```

in delegate use `RedwoodUIView(root)`:
```
val composition = RedwoodComposition(
  scope = scope,
  view = RedwoodUIView(root),
  provider = SchemaWidgetFactories(
    Schema = IosWidgetFactory,
    RedwoodLayout = UIViewRedwoodLayoutWidgetFactory(),
  ),
)
```

but in Composable of our screen we should change root view by some condition (for example we change loading state to successful):
```
@Composable
fun Counter(value: Int = 0) {
  var count by rememberSaveable { mutableStateOf(value) }

  if (count == 3) {
    Text("this is end")
    return
  }
  
  Column(
    width = Constraint.Fill,
    height = Constraint.Fill,
    horizontalAlignment = CrossAxisAlignment.Center,
    verticalAlignment = MainAxisAlignment.Center,
  ) {
    Button("-1", onClick = { count-- })
    Text("Count: $count")
    Button("+1", onClick = { count++ })
  }
}
```

but istead of change root uiview we see that no changes.
reason - UIStackView add new child in arrangedSubviews (at 0 index) but remove child from subviews (that have different order). so when new UILabel added this label will be removed, instead of remove ColumnUIView