### PR TITLE
Make `TreehouseAppContent#preload` idempotent

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -49,7 +49,7 @@ private class State<A : AppService>(
 private sealed interface ViewState {
   object None : ViewState
 
-  class Preloading(
+  data class Preloading(
     val onBackPressedDispatcher: OnBackPressedDispatcher,
     val uiConfiguration: UiConfiguration,
   ) : ViewState
@@ -87,13 +87,7 @@ internal class TreehouseAppContent<A : AppService>(
     dispatchers.checkUi()
     val previousState = stateFlow.value
 
-    if (
-      previousState.viewState is ViewState.Preloading &&
-      previousState.viewState.uiConfiguration == uiConfiguration &&
-      previousState.viewState.onBackPressedDispatcher == onBackPressedDispatcher
-    ) {
-      return // Idempotent.
-    }
+    if (previousState.viewState == ViewState.Preloading(onBackPressedDispatcher, uiConfiguration)) return // Idempotent.
     check(previousState.viewState is ViewState.None)
 
     val nextViewState = ViewState.Preloading(onBackPressedDispatcher, uiConfiguration)

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -87,6 +87,13 @@ internal class TreehouseAppContent<A : AppService>(
     dispatchers.checkUi()
     val previousState = stateFlow.value
 
+    if (
+      previousState.viewState is ViewState.Preloading &&
+      previousState.viewState.uiConfiguration == uiConfiguration &&
+      previousState.viewState.onBackPressedDispatcher == onBackPressedDispatcher
+    ) {
+      return // Idempotent.
+    }
     check(previousState.viewState is ViewState.None)
 
     val nextViewState = ViewState.Preloading(onBackPressedDispatcher, uiConfiguration)

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
@@ -447,6 +447,23 @@ class TreehouseAppContentTest {
   }
 
   @Test
+  fun preload_idempotent() = runTest {
+    val content = treehouseAppContent()
+
+    codeHost.startCodeSession("codeSessionA")
+    eventLog.takeEvent("codeSessionA.start()")
+
+    content.preload(onBackPressedDispatcher, uiConfiguration)
+    eventLog.takeEvent("codeSessionA.app.uis[0].start()")
+
+    content.preload(onBackPressedDispatcher, uiConfiguration)
+    eventLog.assertNoEvents()
+
+    content.unbind()
+    eventLog.takeEvent("codeSessionA.app.uis[0].close()")
+  }
+
+  @Test
   fun bind_idempotent() = runTest {
     val content = treehouseAppContent()
 


### PR DESCRIPTION
Both `TreehouseAppContent#bind` and `TreehouseAppContent#unbind` are idempotent. We should make `TreehouseAppContent#preload` idempotent for consistency.