### PR TITLE
Upgrade to Zipline 1.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-activity = "1.8.1"
 androidx-compose-ui = "1.5.4"
 jbCompose = "1.5.11"
 lint = "31.1.1"
-zipline = "1.6.0"
+zipline = "1.7.0"
 coil = "2.5.0"
 okio = "3.6.0"
 

--- a/redwood-treehouse/build.gradle
+++ b/redwood-treehouse/build.gradle
@@ -17,6 +17,7 @@ kotlin {
       dependencies {
         api projects.redwoodCompose
         api projects.redwoodProtocol
+        api libs.kotlinx.serialization.core
         api libs.okio
         api libs.zipline
       }

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
@@ -20,12 +20,13 @@ import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.zipline.ZiplineService
 import kotlin.native.ObjCName
+import kotlinx.serialization.Contextual
 
 @ObjCName("AppLifecycle", exact = true)
 public interface AppLifecycle : ZiplineService {
   public fun start(host: Host)
 
-  public fun sendFrame(timeNanos: Long)
+  public fun sendFrame(timeNanos: @Contextual Long)
 
   /** Platform features to the guest application. */
   public interface Host : ZiplineService {


### PR DESCRIPTION
The '@Contextual' is both unfortunate ane necessary. There's no automatic way for Zipline to customize encoding of built-in types, and the built-in encoding of longs loses precision.

More details in this Zipline PR:
https://github.com/cashapp/zipline/pull/1171