### PR TITLE
Add a test to confirm there's no unnecessary recompositions

### DIFF
--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -29,8 +29,6 @@ import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.ui.Margin
 import kotlin.jvm.JvmName
 
-private const val OFFSCREEN_ITEMS_BUFFER_COUNT = 30
-
 @Composable
 internal fun LazyList(
   isVertical: Boolean,
@@ -45,8 +43,8 @@ internal fun LazyList(
 ) {
   val itemProvider = rememberLazyListItemProvider(content)
   val itemCount = itemProvider.itemCount
-  val itemsBefore = (state.firstIndex - OFFSCREEN_ITEMS_BUFFER_COUNT / 2).coerceAtLeast(0)
-  val itemsAfter = (itemCount - (state.lastIndex + OFFSCREEN_ITEMS_BUFFER_COUNT / 2).coerceAtMost(itemCount)).coerceAtLeast(0)
+  val itemsBefore = (state.firstIndex - state.preloadBeforeItemCount).coerceAtLeast(0)
+  val itemsAfter = (itemCount - (state.lastIndex + state.preloadAfterItemCount).coerceAtMost(itemCount)).coerceAtLeast(0)
   // TODO(jwilson): drop this down to 20 once this is fixed:
   //     https://github.com/cashapp/redwood/issues/1551
   var placeholderPoolSize by remember { mutableStateOf(30) }
@@ -98,8 +96,8 @@ internal fun RefreshableLazyList(
 ) {
   val itemProvider = rememberLazyListItemProvider(content)
   val itemCount = itemProvider.itemCount
-  val itemsBefore = (state.firstIndex - OFFSCREEN_ITEMS_BUFFER_COUNT / 2).coerceAtLeast(0)
-  val itemsAfter = (itemCount - (state.lastIndex + OFFSCREEN_ITEMS_BUFFER_COUNT / 2).coerceAtMost(itemCount)).coerceAtLeast(0)
+  val itemsBefore = (state.firstIndex - state.preloadBeforeItemCount).coerceAtLeast(0)
+  val itemsAfter = (itemCount - (state.lastIndex + state.preloadAfterItemCount).coerceAtMost(itemCount)).coerceAtLeast(0)
   var placeholderPoolSize by remember { mutableStateOf(20) }
   RefreshableLazyList(
     isVertical,

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import app.cash.redwood.lazylayout.api.ScrollItemIndex
 
+private const val DEFAULT_PRELOAD_ITEM_COUNT = 15
+
 @Composable
 public fun rememberLazyListState(): LazyListState {
   return rememberSaveable(saver = saver) {
@@ -58,6 +60,12 @@ public open class LazyListState {
     private set
   public var lastIndex: Int by mutableStateOf(0)
     private set
+
+  /** How many items to load in anticipation of scrolling up. */
+  public var preloadBeforeItemCount: Int by mutableStateOf(DEFAULT_PRELOAD_ITEM_COUNT)
+
+  /** How many items to load in anticipation of scrolling down. */
+  public var preloadAfterItemCount: Int by mutableStateOf(DEFAULT_PRELOAD_ITEM_COUNT)
 
   /** Perform a programmatic scroll. */
   public fun programmaticScroll(

--- a/redwood-lazylayout-compose/src/commonTest/kotlin/app/cash/redwood/lazylayout/compose/LazyListTest.kt
+++ b/redwood-lazylayout-compose/src/commonTest/kotlin/app/cash/redwood/lazylayout/compose/LazyListTest.kt
@@ -122,7 +122,7 @@ class LazyListTest {
         }
         LazyColumn(
           state = lazyListState,
-          placeholder = { Text("Placeholder") }
+          placeholder = { Text("Placeholder") },
         ) {
           items(100) {
             if (it == 5) index5ComposeCount++


### PR DESCRIPTION
Also expose the size of the preload window in
LazyListState. It should be possible for the
application layer to change this as necessary.