### PR TITLE
Return SizeOnlyPlaceholder when the placeholder queue is empty

### DIFF
--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -20,8 +20,6 @@ package app.cash.redwood.lazylayout.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import app.cash.redwood.Modifier
 import app.cash.redwood.layout.api.Constraint
@@ -45,23 +43,14 @@ internal fun LazyList(
   val itemCount = itemProvider.itemCount
   val itemsBefore = (state.firstIndex - state.preloadBeforeItemCount).coerceAtLeast(0)
   val itemsAfter = (itemCount - (state.lastIndex + state.preloadAfterItemCount).coerceAtMost(itemCount)).coerceAtLeast(0)
-  // TODO(jwilson): drop this down to 20 once this is fixed:
-  //     https://github.com/cashapp/redwood/issues/1551
-  var placeholderPoolSize by remember { mutableStateOf(30) }
+  val placeholderPoolSize = 30
   LazyList(
-    isVertical,
-    itemsBefore = itemsBefore,
-    itemsAfter = itemsAfter,
+    isVertical = isVertical,
     onViewportChanged = { localFirstVisibleItemIndex, localLastVisibleItemIndex ->
       state.onUserScroll(localFirstVisibleItemIndex, localLastVisibleItemIndex)
-
-      val visibleItemCount = localLastVisibleItemIndex - localFirstVisibleItemIndex
-      val proposedPlaceholderPoolSize = visibleItemCount + visibleItemCount / 2
-      // We only ever want to increase the pool size.
-      if (placeholderPoolSize < proposedPlaceholderPoolSize) {
-        placeholderPoolSize = proposedPlaceholderPoolSize
-      }
     },
+    itemsBefore = itemsBefore,
+    itemsAfter = itemsAfter,
     width = width,
     height = height,
     margin = margin,
@@ -98,20 +87,13 @@ internal fun RefreshableLazyList(
   val itemCount = itemProvider.itemCount
   val itemsBefore = (state.firstIndex - state.preloadBeforeItemCount).coerceAtLeast(0)
   val itemsAfter = (itemCount - (state.lastIndex + state.preloadAfterItemCount).coerceAtMost(itemCount)).coerceAtLeast(0)
-  var placeholderPoolSize by remember { mutableStateOf(20) }
+  val placeholderPoolSize = 30
   RefreshableLazyList(
     isVertical,
     itemsBefore = itemsBefore,
     itemsAfter = itemsAfter,
     onViewportChanged = { localFirstVisibleItemIndex, localLastVisibleItemIndex ->
       state.onUserScroll(localFirstVisibleItemIndex, localLastVisibleItemIndex)
-
-      val visibleItemCount = localLastVisibleItemIndex - localFirstVisibleItemIndex
-      val proposedPlaceholderPoolSize = visibleItemCount + visibleItemCount / 2
-      // We only ever want to increase the pool size.
-      if (placeholderPoolSize < proposedPlaceholderPoolSize) {
-        placeholderPoolSize = proposedPlaceholderPoolSize
-      }
     },
     refreshing = refreshing,
     onRefresh = onRefresh,

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -72,6 +72,14 @@ internal open class ViewLazyList private constructor(
   override val value: View get() = recyclerView
 
   private val processor = object : LazyListUpdateProcessor<ViewHolder, View>() {
+    override fun createPlaceholder(original: View): View {
+      return object : View(value.context) {
+        override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+          setMeasuredDimension(original.width, original.height)
+        }
+      }
+    }
+
     override fun insertRows(index: Int, count: Int) {
       adapter.notifyItemRangeInserted(index, count)
     }

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -104,6 +104,10 @@ class EmojiSearchActivity : ComponentActivity() {
     private var success = true
     private var snackbar: Snackbar? = null
 
+    override fun uncaughtException(exception: Throwable) {
+      Log.e("Treehouse", "uncaughtException", exception)
+    }
+
     override fun codeLoadFailed(exception: Exception, startValue: Any?) {
       Log.w("Treehouse", "codeLoadFailed", exception)
       if (success) {


### PR DESCRIPTION
Return a `SizeOnlyPlaceholder` when the placeholder queue is empty, which could happen when:

``` 
(placeholderPoolSize * height of a single placeholder) < height of the list in view
```

Follow up: 
- implement `createPlaceholder` for iOS and Android compose emoji search

issues:
- https://github.com/cashapp/redwood/issues/1571
- https://github.com/cashapp/redwood/issues/1696
