### PR TITLE
Make TreehouseApp an interface

### DIFF
--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -34,7 +34,7 @@ public fun TreehouseAppFactory(
   cacheMaxSizeInBytes: Long = 50L * 1024L * 1024L,
   concurrentDownloads: Int = 8,
   stateStore: StateStore = MemoryStateStore(),
-): TreehouseApp.Factory = TreehouseApp.Factory(
+): TreehouseApp.Factory = RealTreehouseApp.Factory(
   platform = AndroidTreehousePlatform(context),
   dispatchers = AndroidTreehouseDispatchers(),
   eventListenerFactory = eventListenerFactory,

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import app.cash.zipline.EventListener as ZiplineEventListener
+import app.cash.zipline.Zipline
+import app.cash.zipline.loader.LoadResult
+import app.cash.zipline.loader.ManifestVerifier
+import app.cash.zipline.loader.ZiplineCache
+import app.cash.zipline.loader.ZiplineHttpClient
+import app.cash.zipline.loader.ZiplineLoader
+import kotlin.native.ObjCName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
+import okio.FileSystem
+import okio.Path
+
+@ObjCName("RealTreehouseApp", exact = true)
+public class RealTreehouseApp<A : AppService> private constructor(
+  private val factory: Factory,
+  private val appScope: CoroutineScope,
+  private val spec: TreehouseApp.Spec<A>,
+) : TreehouseApp<A> {
+  public val dispatchers: TreehouseDispatchers = factory.dispatchers
+
+  private val codeHost = object : CodeHost<A>(
+    dispatchers = dispatchers,
+    appScope = appScope,
+    frameClockFactory = factory.frameClockFactory,
+    stateStore = factory.stateStore,
+  ) {
+    override fun codeUpdatesFlow(): Flow<CodeSession<A>> {
+      return ziplineFlow().mapNotNull { loadResult ->
+        when (loadResult) {
+          is LoadResult.Failure -> {
+            null // EventListener already notified.
+          }
+
+          is LoadResult.Success -> {
+            createCodeSession(loadResult.zipline)
+          }
+        }
+      }
+    }
+  }
+
+  public override val zipline: Zipline?
+    get() = (codeHost.codeSession as? ZiplineCodeSession)?.zipline
+
+  public override fun createContent(
+    source: TreehouseContentSource<A>,
+    codeListener: CodeListener,
+  ): Content {
+    start()
+    return TreehouseAppContent(
+      codeHost = codeHost,
+      dispatchers = dispatchers,
+      codeEventPublisher = RealCodeEventPublisher(codeListener, this),
+      source = source,
+    )
+  }
+
+  public override fun start() {
+    codeHost.start()
+  }
+
+  public override fun stop() {
+    codeHost.stop()
+  }
+
+  public override fun restart() {
+    codeHost.restart()
+  }
+
+  /**
+   * Continuously polls for updated code, and emits a new [LoadResult] instance when new code is
+   * found.
+   */
+  private fun ziplineFlow(): Flow<LoadResult> {
+    var loader = ZiplineLoader(
+      dispatcher = dispatchers.zipline,
+      manifestVerifier = factory.manifestVerifier,
+      httpClient = factory.httpClient,
+    )
+
+    loader.concurrentDownloads = factory.concurrentDownloads
+
+    // Adapt [EventListener.Factory] to a [ZiplineEventListener.Factory]
+    val ziplineEventListenerFactory = ZiplineEventListener.Factory { _, manifestUrl ->
+      val eventListener = factory.eventListenerFactory.create(this@RealTreehouseApp, manifestUrl)
+      RealEventPublisher(eventListener).ziplineEventListener
+    }
+    loader = loader.withEventListenerFactory(ziplineEventListenerFactory)
+
+    if (!spec.loadCodeFromNetworkOnly) {
+      loader = loader.withCache(
+        cache = factory.cache,
+      )
+
+      if (factory.embeddedDir != null && factory.embeddedFileSystem != null) {
+        loader = loader.withEmbedded(
+          embeddedDir = factory.embeddedDir,
+          embeddedFileSystem = factory.embeddedFileSystem,
+        )
+      }
+    }
+
+    return loader.load(
+      applicationName = spec.name,
+      manifestUrlFlow = spec.manifestUrl,
+      serializersModule = spec.serializersModule,
+    ) { zipline ->
+      spec.bindServices(zipline)
+    }
+  }
+
+  private fun createCodeSession(zipline: Zipline): ZiplineCodeSession<A> {
+    val appService = spec.create(zipline)
+
+    // Extract the RealEventPublisher() created in ziplineFlow().
+    val eventListener = zipline.eventListener as RealEventPublisher.ZiplineEventListener
+    val eventPublisher = eventListener.eventPublisher
+
+    return ZiplineCodeSession(
+      dispatchers = dispatchers,
+      eventPublisher = eventPublisher,
+      frameClockFactory = factory.frameClockFactory,
+      appService = appService,
+      zipline = zipline,
+      appScope = appScope,
+    )
+  }
+  @ObjCName("RealTreehouseAppFactory", exact = true)
+  public class Factory internal constructor(
+    private val platform: TreehousePlatform,
+    public val dispatchers: TreehouseDispatchers,
+    internal val eventListenerFactory: EventListener.Factory,
+    internal val httpClient: ZiplineHttpClient,
+    internal val frameClockFactory: FrameClock.Factory,
+    internal val manifestVerifier: ManifestVerifier,
+    internal val embeddedDir: Path?,
+    internal val embeddedFileSystem: FileSystem?,
+    private val cacheName: String,
+    private val cacheMaxSizeInBytes: Long,
+    internal val concurrentDownloads: Int,
+    internal val stateStore: StateStore,
+  ) : TreehouseApp.Factory {
+    /** This is lazy to avoid initializing the cache on the thread that creates this launcher. */
+    internal val cache: ZiplineCache by lazy {
+      platform.newCache(name = cacheName, maxSizeInBytes = cacheMaxSizeInBytes)
+    }
+
+    public override fun <A : AppService> create(
+      appScope: CoroutineScope,
+      spec: TreehouseApp.Spec<A>,
+    ): TreehouseApp<A> = RealTreehouseApp(this, appScope, spec)
+
+    override fun close() {
+      cache.close()
+    }
+  }
+}

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Square, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,53 +15,17 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.zipline.EventListener as ZiplineEventListener
 import app.cash.zipline.Zipline
-import app.cash.zipline.loader.LoadResult
-import app.cash.zipline.loader.ManifestVerifier
-import app.cash.zipline.loader.ZiplineCache
-import app.cash.zipline.loader.ZiplineHttpClient
-import app.cash.zipline.loader.ZiplineLoader
-import kotlin.native.ObjCName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 import okio.Closeable
-import okio.FileSystem
-import okio.Path
 
 /**
  * This class binds downloaded code to on-screen views.
  */
-@ObjCName("TreehouseApp", exact = true)
-public class TreehouseApp<A : AppService> private constructor(
-  private val factory: Factory,
-  private val appScope: CoroutineScope,
-  public val spec: Spec<A>,
-) {
-  public val dispatchers: TreehouseDispatchers = factory.dispatchers
-
-  private val codeHost = object : CodeHost<A>(
-    dispatchers = dispatchers,
-    appScope = appScope,
-    frameClockFactory = factory.frameClockFactory,
-    stateStore = factory.stateStore,
-  ) {
-    override fun codeUpdatesFlow(): Flow<CodeSession<A>> {
-      return ziplineFlow().mapNotNull { loadResult ->
-        when (loadResult) {
-          is LoadResult.Failure -> {
-            null // EventListener already notified.
-          }
-          is LoadResult.Success -> {
-            createCodeSession(loadResult.zipline)
-          }
-        }
-      }
-    }
-  }
+public interface TreehouseApp<A : AppService> {
 
   /**
    * Returns the current zipline attached to this host, or null if Zipline hasn't loaded yet. The
@@ -71,7 +35,6 @@ public class TreehouseApp<A : AppService> private constructor(
    * instance may be replaced if new code is loaded.
    */
   public val zipline: Zipline?
-    get() = (codeHost.codeSession as? ZiplineCodeSession)?.zipline
 
   /**
    * Create content for [source].
@@ -81,16 +44,7 @@ public class TreehouseApp<A : AppService> private constructor(
   public fun createContent(
     source: TreehouseContentSource<A>,
     codeListener: CodeListener = CodeListener(),
-  ): Content {
-    start()
-
-    return TreehouseAppContent(
-      codeHost = codeHost,
-      dispatchers = dispatchers,
-      codeEventPublisher = RealCodeEventPublisher(codeListener, this),
-      source = source,
-    )
-  }
+  ): Content
 
   /**
    * Initiate the initial code download and load, and start driving the views that are rendered by
@@ -100,86 +54,21 @@ public class TreehouseApp<A : AppService> private constructor(
    *
    * This function may only be invoked on [TreehouseDispatchers.ui].
    */
-  public fun start() {
-    codeHost.start()
-  }
+  public fun start()
 
   /**
    * Stop any currently-running code and stop receiving new code.
    *
    * This function may only be invoked on [TreehouseDispatchers.ui].
    */
-  public fun stop() {
-    codeHost.stop()
-  }
+  public fun stop()
 
   /**
    * Stop the currently-running application (if any) and start it again.
    *
    * This function may only be invoked on [TreehouseDispatchers.ui].
    */
-  public fun restart() {
-    codeHost.restart()
-  }
-
-  /**
-   * Continuously polls for updated code, and emits a new [LoadResult] instance when new code is
-   * found.
-   */
-  private fun ziplineFlow(): Flow<LoadResult> {
-    var loader = ZiplineLoader(
-      dispatcher = dispatchers.zipline,
-      manifestVerifier = factory.manifestVerifier,
-      httpClient = factory.httpClient,
-    )
-
-    loader.concurrentDownloads = factory.concurrentDownloads
-
-    // Adapt [EventListener.Factory] to a [ZiplineEventListener.Factory]
-    val ziplineEventListenerFactory = ZiplineEventListener.Factory { _, manifestUrl ->
-      val eventListener = factory.eventListenerFactory.create(this@TreehouseApp, manifestUrl)
-      RealEventPublisher(eventListener).ziplineEventListener
-    }
-    loader = loader.withEventListenerFactory(ziplineEventListenerFactory)
-
-    if (!spec.loadCodeFromNetworkOnly) {
-      loader = loader.withCache(
-        cache = factory.cache,
-      )
-
-      if (factory.embeddedDir != null && factory.embeddedFileSystem != null) {
-        loader = loader.withEmbedded(
-          embeddedDir = factory.embeddedDir,
-          embeddedFileSystem = factory.embeddedFileSystem,
-        )
-      }
-    }
-
-    return loader.load(
-      applicationName = spec.name,
-      manifestUrlFlow = spec.manifestUrl,
-      serializersModule = spec.serializersModule,
-    ) { zipline ->
-      spec.bindServices(zipline)
-    }
-  }
-
-  private fun createCodeSession(zipline: Zipline): ZiplineCodeSession<A> {
-    val appService = spec.create(zipline)
-
-    // Extract the RealEventPublisher() created in ziplineFlow().
-    val eventListener = zipline.eventListener as RealEventPublisher.ZiplineEventListener
-    val eventPublisher = eventListener.eventPublisher
-
-    return ZiplineCodeSession(
-      dispatchers = dispatchers,
-      eventPublisher = eventPublisher,
-      frameClockFactory = factory.frameClockFactory,
-      appService = appService,
-      zipline = zipline,
-      appScope = appScope,
-    )
-  }
+  public fun restart()
 
   /**
    * This manages a cache that should be shared by all launched applications.
@@ -187,34 +76,11 @@ public class TreehouseApp<A : AppService> private constructor(
    * This class holds a stateful disk cache. At most one instance with each [cacheName] should be
    * open at any time. Most callers should use a single [Factory] for best caching.
    */
-  @ObjCName("TreehouseAppFactory", exact = true)
-  public class Factory internal constructor(
-    private val platform: TreehousePlatform,
-    public val dispatchers: TreehouseDispatchers,
-    internal val eventListenerFactory: EventListener.Factory,
-    internal val httpClient: ZiplineHttpClient,
-    internal val frameClockFactory: FrameClock.Factory,
-    internal val manifestVerifier: ManifestVerifier,
-    internal val embeddedDir: Path?,
-    internal val embeddedFileSystem: FileSystem?,
-    private val cacheName: String,
-    private val cacheMaxSizeInBytes: Long,
-    internal val concurrentDownloads: Int,
-    internal val stateStore: StateStore,
-  ) : Closeable {
-    /** This is lazy to avoid initializing the cache on the thread that creates this launcher. */
-    internal val cache: ZiplineCache by lazy {
-      platform.newCache(name = cacheName, maxSizeInBytes = cacheMaxSizeInBytes)
-    }
-
+  public interface Factory : Closeable {
     public fun <A : AppService> create(
       appScope: CoroutineScope,
       spec: Spec<A>,
-    ): TreehouseApp<A> = TreehouseApp(this, appScope, spec)
-
-    override fun close() {
-      cache.close()
-    }
+    ): TreehouseApp<A>
   }
 
   /**


### PR DESCRIPTION
This makes it easier to mock `TreehouseApp` for testing in downstream repo(s).