### PR TITLE
Don't crash if we exhaust placeholders

### DIFF
--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -43,7 +43,7 @@ internal fun LazyList(
   val itemCount = itemProvider.itemCount
   val itemsBefore = (state.firstIndex - state.preloadBeforeItemCount).coerceAtLeast(0)
   val itemsAfter = (itemCount - (state.lastIndex + state.preloadAfterItemCount).coerceAtMost(itemCount)).coerceAtLeast(0)
-  val placeholderPoolSize = 30
+  val placeholderPoolSize = 20
   LazyList(
     isVertical = isVertical,
     onViewportChanged = { localFirstVisibleItemIndex, localLastVisibleItemIndex ->
@@ -87,7 +87,7 @@ internal fun RefreshableLazyList(
   val itemCount = itemProvider.itemCount
   val itemsBefore = (state.firstIndex - state.preloadBeforeItemCount).coerceAtLeast(0)
   val itemsAfter = (itemCount - (state.lastIndex + state.preloadAfterItemCount).coerceAtMost(itemCount)).coerceAtLeast(0)
-  val placeholderPoolSize = 30
+  val placeholderPoolSize = 20
   RefreshableLazyList(
     isVertical,
     itemsBefore = itemsBefore,

--- a/redwood-lazylayout-compose/src/commonTest/kotlin/app/cash/redwood/lazylayout/compose/LazyListTest.kt
+++ b/redwood-lazylayout-compose/src/commonTest/kotlin/app/cash/redwood/lazylayout/compose/LazyListTest.kt
@@ -41,7 +41,7 @@ class LazyListTest {
         assertThat(lazyList.itemsAfter).isEqualTo(0)
         assertThat(lazyList.items).isEmpty()
         assertThat(lazyList.placeholder)
-          .isEqualTo(List(30) { TextValue(Modifier, "Placeholder") })
+          .isEqualTo(List(20) { TextValue(Modifier, "Placeholder") })
       }
     }
   }
@@ -76,7 +76,7 @@ class LazyListTest {
         assertThat(lazyList.itemsBefore).isEqualTo(0)
         assertThat(lazyList.itemsAfter).isEqualTo(expectedItemsAfter)
         assertThat(lazyList.placeholder)
-          .isEqualTo(List(30) { TextValue(Modifier, "Placeholder") })
+          .isEqualTo(List(20) { TextValue(Modifier, "Placeholder") })
         assertThat(lazyList.items)
           .isEqualTo(List(expectedItemCount) { TextValue(Modifier, it.toString()) })
       }
@@ -104,7 +104,7 @@ class LazyListTest {
         assertThat(lazyList.itemsBefore).isEqualTo(35)
         assertThat(lazyList.itemsAfter).isEqualTo(25)
         assertThat(lazyList.placeholder)
-          .isEqualTo(List(30) { TextValue(Modifier, "Placeholder") })
+          .isEqualTo(List(20) { TextValue(Modifier, "Placeholder") })
         assertThat(lazyList.items)
           .isEqualTo(List(40) { TextValue(Modifier, (it + 35).toString()) })
       }

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -73,6 +73,12 @@ internal open class UIViewLazyList(
     get() = tableView
 
   private val updateProcessor = object : LazyListUpdateProcessor<LazyListContainerCell, UIView>() {
+    override fun createPlaceholder(original: UIView): UIView? {
+      return object : UIView(CGRectZero.readValue()) {
+        override fun sizeThatFits(size: CValue<CGSize>) = original.sizeThatFits(size)
+      }
+    }
+
     override fun insertRows(index: Int, count: Int) {
       // TODO(jwilson): pass a range somehow when 'count' is large?
       tableView.insertRowsAtIndexPaths(


### PR DESCRIPTION
Instead just show an empty placeholder that's sized by the first placeholder in the pool.

Also change the placeholder pool size from 30 down to 20. It was 30 because we didn't have a solution to this problem, now we do.

