### PR TITLE
Scope EventListener.Factory to TreehouseApp

### DIFF
--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -27,7 +27,6 @@ public fun TreehouseAppFactory(
   context: Context,
   httpClient: OkHttpClient,
   manifestVerifier: ManifestVerifier,
-  eventListenerFactory: EventListener.Factory = EventListener.NONE,
   embeddedDir: Path? = null,
   embeddedFileSystem: FileSystem? = null,
   cacheName: String = "zipline",
@@ -37,7 +36,6 @@ public fun TreehouseAppFactory(
 ): TreehouseApp.Factory = TreehouseApp.Factory(
   platform = AndroidTreehousePlatform(context),
   dispatchers = AndroidTreehouseDispatchers(),
-  eventListenerFactory = eventListenerFactory,
   httpClient = httpClient.asZiplineHttpClient(),
   frameClockFactory = AndroidChoreographerFrameClock.Factory(),
   manifestVerifier = manifestVerifier,

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -42,6 +42,7 @@ public class TreehouseApp<A : AppService> private constructor(
   private val factory: Factory,
   private val appScope: CoroutineScope,
   public val spec: Spec<A>,
+  private val eventListenerFactory: EventListener.Factory,
 ) {
   public val dispatchers: TreehouseDispatchers = factory.dispatchers
 
@@ -139,7 +140,7 @@ public class TreehouseApp<A : AppService> private constructor(
 
     // Adapt [EventListener.Factory] to a [ZiplineEventListener.Factory]
     val ziplineEventListenerFactory = ZiplineEventListener.Factory { _, manifestUrl ->
-      val eventListener = factory.eventListenerFactory.create(this@TreehouseApp, manifestUrl)
+      val eventListener = eventListenerFactory.create(this@TreehouseApp, manifestUrl)
       RealEventPublisher(eventListener).ziplineEventListener
     }
     loader = loader.withEventListenerFactory(ziplineEventListenerFactory)
@@ -194,7 +195,6 @@ public class TreehouseApp<A : AppService> private constructor(
   public class Factory internal constructor(
     private val platform: TreehousePlatform,
     public val dispatchers: TreehouseDispatchers,
-    internal val eventListenerFactory: EventListener.Factory,
     internal val httpClient: ZiplineHttpClient,
     internal val frameClockFactory: FrameClock.Factory,
     internal val manifestVerifier: ManifestVerifier,
@@ -213,7 +213,8 @@ public class TreehouseApp<A : AppService> private constructor(
     public fun <A : AppService> create(
       appScope: CoroutineScope,
       spec: Spec<A>,
-    ): TreehouseApp<A> = TreehouseApp(this, appScope, spec)
+      eventListenerFactory: EventListener.Factory = EventListener.NONE,
+    ): TreehouseApp<A> = TreehouseApp(this, appScope, spec, eventListenerFactory)
 
     override fun close() {
       cache.close()

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
@@ -24,7 +24,6 @@ import okio.Path
 public fun TreehouseAppFactory(
   httpClient: ZiplineHttpClient,
   manifestVerifier: ManifestVerifier,
-  eventListenerFactory: EventListener.Factory = EventListener.NONE,
   embeddedDir: Path? = null,
   embeddedFileSystem: FileSystem? = null,
   cacheName: String = "zipline",
@@ -34,7 +33,6 @@ public fun TreehouseAppFactory(
 ): TreehouseApp.Factory = TreehouseApp.Factory(
   platform = IosTreehousePlatform(),
   dispatchers = IosTreehouseDispatchers(),
-  eventListenerFactory = eventListenerFactory,
   httpClient = httpClient,
   frameClockFactory = IosDisplayLinkClock,
   manifestVerifier = manifestVerifier,

--- a/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
@@ -129,7 +129,6 @@ class EmojiSearchActivity : ComponentActivity() {
       context = applicationContext,
       httpClient = httpClient,
       manifestVerifier = ManifestVerifier.Companion.NO_SIGNATURE_CHECKS,
-      eventListenerFactory = { app, manifestUrl -> appEventListener },
       embeddedDir = "/".toPath(),
       embeddedFileSystem = applicationContext.assets.asFileSystem(),
     )
@@ -143,6 +142,7 @@ class EmojiSearchActivity : ComponentActivity() {
         manifestUrl = manifestUrlFlow,
         hostApi = RealHostApi(this@EmojiSearchActivity, httpClient),
       ),
+      eventListenerFactory = { app, manifestUrl -> appEventListener },
     )
 
     treehouseApp.start()

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -142,7 +142,6 @@ class EmojiSearchActivity : ComponentActivity() {
       context = applicationContext,
       httpClient = httpClient,
       manifestVerifier = ManifestVerifier.NO_SIGNATURE_CHECKS,
-      eventListenerFactory = { app, manifestUrl -> appEventListener },
       embeddedDir = "/".toPath(),
       embeddedFileSystem = applicationContext.assets.asFileSystem(),
       stateStore = FileStateStore(
@@ -164,6 +163,7 @@ class EmojiSearchActivity : ComponentActivity() {
         manifestUrl = manifestUrlFlow,
         hostApi = RealHostApi(this@EmojiSearchActivity, httpClient),
       ),
+      eventListenerFactory = { app, manifestUrl -> appEventListener },
     )
 
     treehouseApp.start()

--- a/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/EmojiSearchLauncher.kt
+++ b/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/EmojiSearchLauncher.kt
@@ -63,7 +63,6 @@ class EmojiSearchLauncher(
     val treehouseAppFactory = TreehouseAppFactory(
       httpClient = ziplineHttpClient,
       manifestVerifier = ManifestVerifier.Companion.NO_SIGNATURE_CHECKS,
-      eventListenerFactory = { app, manifestUrl -> eventListener },
     )
 
     val manifestUrlFlow = flowOf(manifestUrl)
@@ -75,6 +74,7 @@ class EmojiSearchLauncher(
         manifestUrl = manifestUrlFlow,
         hostApi = hostApi,
       ),
+      eventListenerFactory = { app, manifestUrl -> eventListener },
     )
 
     treehouseApp.start()

--- a/test-app/ios-shared/src/commonMain/kotlin/com/example/redwood/testing/ios/TestAppLauncher.kt
+++ b/test-app/ios-shared/src/commonMain/kotlin/com/example/redwood/testing/ios/TestAppLauncher.kt
@@ -56,7 +56,6 @@ class TestAppLauncher(
     val treehouseAppFactory = TreehouseAppFactory(
       httpClient = ziplineHttpClient,
       manifestVerifier = NO_SIGNATURE_CHECKS,
-      eventListenerFactory = { app, manifestUrl -> eventListener },
     )
 
     val manifestUrlFlow = flowOf(manifestUrl)
@@ -68,6 +67,7 @@ class TestAppLauncher(
         manifestUrl = manifestUrlFlow,
         hostApi = hostApi,
       ),
+      eventListenerFactory = { app, manifestUrl -> eventListener },
     )
 
     treehouseApp.start()


### PR DESCRIPTION
Previously this was scoped to TreehouseApp.Factory, so we couldn't share a Zipline cache without also sharing an EventListener.Factory. This turns out to be quite annoying if we want to customize behavior in the event listener for each app we launch.