### PR TITLE
Use KVM to run emulator tests on Linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,8 +31,14 @@ jobs:
       - run: ./gradlew kotlinUpgradeYarnLock build -PredwoodNoApps
 
   connected:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4.0.0
         with:


### PR DESCRIPTION
See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/

The emulator tests for the samples are still on the macOS hosts as we currently rely on them for Xcode building as well.