### PR TITLE
Use Apple silicon images on CI.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,6 +96,8 @@ jobs:
 
       - run: ./gradlew -p samples/counter build
 
+      - run: ./scripts/write_entitlements.sh
+
       - name: Build Counter iOS (UIKit)
         run: xcodebuild -project samples/counter/ios-uikit/CounterApp.xcodeproj -scheme CounterApp -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest'
 
@@ -133,6 +135,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       - run: ./gradlew -p samples/emoji-search build
+
+      - run: ./scripts/write_entitlements.sh
 
       - name: Build Emoji Search iOS (UIKit)
         run: xcodebuild -project samples/emoji-search/ios-uikit/EmojiSearchApp.xcodeproj -scheme EmojiSearchApp -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
           if-no-files-found: error
 
   screenshot-tests:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,7 +85,7 @@ jobs:
       - run: xcodebuild -project redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj -scheme RedwoodLayoutUIViewTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' test
 
   sample-counter:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -122,7 +122,7 @@ jobs:
           script: ./gradlew -p samples/counter connectedCheck
 
   sample-emoji:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -159,7 +159,7 @@ jobs:
           script: ./gradlew -p samples/emoji-search connectedCheck
 
   test-app:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -174,7 +174,7 @@ jobs:
         run: xcodebuild -project test-app/ios-uikit/TestApp.xcodeproj -scheme TestApp -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest'
 
   publish:
-    runs-on: macos-latest
+    runs-on: macos-14
     if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/redwood' }}
     needs:
       - build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,6 +118,7 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          arch: arm64-v8a
           emulator-boot-timeout: 20000
           script: ./gradlew -p samples/counter connectedCheck
 
@@ -155,6 +156,7 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          arch: arm64-v8a
           emulator-boot-timeout: 20000
           script: ./gradlew -p samples/emoji-search connectedCheck
 

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj/project.pbxproj
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj/project.pbxproj
@@ -312,8 +312,9 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 					"$(PROJECT_DIR)/build/xcode-frameworks",
@@ -337,6 +338,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = app.cash.redwood.layout.uiview.testing;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "RedwoodLayoutUIViewTests/RedwoodLayoutUIViewTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -350,8 +352,9 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 					"$(PROJECT_DIR)/build/xcode-frameworks",
@@ -375,6 +378,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = app.cash.redwood.layout.uiview.testing;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "RedwoodLayoutUIViewTests/RedwoodLayoutUIViewTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/scripts/write_entitlements.sh
+++ b/scripts/write_entitlements.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Modified from:
+# https://stackoverflow.com/questions/67264212/android-emulator-crash-when-start-hvf-error-hv-error
+
+original_dir=$(pwd)
+target_dir=~/Library/Android/sdk/emulator/qemu/darwin-aarch64
+file_path=entitlements.xml
+
+xml_content='<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+</dict>
+</plist>'
+
+cd "$target_dir"
+echo "$xml_content" > "$file_path"
+codesign -s - --entitlements entitlements.xml --force ./qemu-system-aarch64
+cd "$original_dir"


### PR DESCRIPTION
[Released today](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/): speeds up test time by ~50% in my tests