### PR TITLE
Some Emoji sample cleanups after adding desktop

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,7 +76,7 @@ zipline-gradlePlugin = { module = "app.cash.zipline:zipline-gradle-plugin", vers
 zipline-loader = { module = "app.cash.zipline:zipline-loader", version.ref = "zipline" }
 paparazzi-gradlePlugin = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version = "1.3.1" }
 jimfs = "com.google.jimfs:jimfs:1.3.0"
-coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-core = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 turbine = "app.cash.turbine:turbine:1.0.0"

--- a/samples/emoji-search/android-composeui/build.gradle
+++ b/samples/emoji-search/android-composeui/build.gradle
@@ -21,6 +21,7 @@ android {
 
 dependencies {
   implementation libs.coil.network.okhttp
+  implementation libs.okhttp
   implementation libs.google.material
   implementation libs.kotlinx.coroutines.android
   implementation projects.samples.emojiSearch.launcher

--- a/samples/emoji-search/desktop-composeui/build.gradle
+++ b/samples/emoji-search/desktop-composeui/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation projects.redwoodTreehouseHostComposeui
   implementation projects.redwoodWidgetCompose
   implementation libs.coil.network.okhttp
+  implementation libs.okhttp
   implementation libs.zipline.loader
   implementation libs.kotlinx.coroutines.swing
 }

--- a/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/JvmHttpClient.kt
+++ b/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/JvmHttpClient.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.redwood.emojisearch.composeui
+package com.example.redwood.emojisearch.desktop
 
 import com.example.redwood.emojisearch.presenter.HttpClient
 import kotlin.coroutines.resume
@@ -30,7 +30,7 @@ import okhttp3.Response
 import okio.IOException
 
 class JvmHttpClient(
-  private val okHttpClient: OkHttpClient = OkHttpClient(),
+  private val okHttpClient: OkHttpClient,
 ) : HttpClient {
 
   override suspend fun call(url: String, headers: Map<String, String>): String {

--- a/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/main.kt
+++ b/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/main.kt
@@ -26,17 +26,27 @@ import app.cash.redwood.composeui.RedwoodContent
 import app.cash.redwood.layout.composeui.ComposeUiRedwoodLayoutWidgetFactory
 import app.cash.redwood.lazylayout.composeui.ComposeUiRedwoodLazyLayoutWidgetFactory
 import app.cash.redwood.ui.Margin
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.serviceLoaderEnabled
 import com.example.redwood.emojisearch.composeui.ComposeUiEmojiSearchWidgetFactory
 import com.example.redwood.emojisearch.composeui.EmojiSearchTheme
-import com.example.redwood.emojisearch.composeui.JvmHttpClient
 import com.example.redwood.emojisearch.presenter.EmojiSearch
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
+import okhttp3.OkHttpClient
 
 fun main() {
-  val httpClient = JvmHttpClient()
-  val navigator = DesktopNavigator
+  val client = OkHttpClient()
+  val httpClient = JvmHttpClient(client)
+  val imageLoader = ImageLoader.Builder(PlatformContext.INSTANCE)
+    .serviceLoaderEnabled(false)
+    .components {
+      add(OkHttpNetworkFetcherFactory(client))
+    }
+    .build()
   val factories = EmojiSearchWidgetFactories(
-    EmojiSearch = ComposeUiEmojiSearchWidgetFactory(),
+    EmojiSearch = ComposeUiEmojiSearchWidgetFactory(imageLoader),
     RedwoodLayout = ComposeUiRedwoodLayoutWidgetFactory(),
     RedwoodLazyLayout = ComposeUiRedwoodLazyLayoutWidgetFactory(),
   )
@@ -51,7 +61,7 @@ fun main() {
           RedwoodContent(factories, modifier = Modifier.padding(contentPadding)) {
             EmojiSearch(
               httpClient = httpClient,
-              navigator = navigator,
+              navigator = DesktopNavigator,
               safeAreaInsets = Margin.Zero,
             )
           }

--- a/samples/emoji-search/shared-composeui/src/main/kotlin/com/example/redwood/emojisearch/composeui/ComposeUiEmojiSearchWidgetFactory.kt
+++ b/samples/emoji-search/shared-composeui/src/main/kotlin/com/example/redwood/emojisearch/composeui/ComposeUiEmojiSearchWidgetFactory.kt
@@ -16,13 +16,16 @@
 package com.example.redwood.emojisearch.composeui
 
 import androidx.compose.runtime.Composable
+import coil3.ImageLoader
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactory
 import com.example.redwood.emojisearch.widget.Image
 import com.example.redwood.emojisearch.widget.Text
 import com.example.redwood.emojisearch.widget.TextInput
 
-class ComposeUiEmojiSearchWidgetFactory : EmojiSearchWidgetFactory<@Composable () -> Unit> {
+class ComposeUiEmojiSearchWidgetFactory(
+  private val imageLoader: ImageLoader,
+) : EmojiSearchWidgetFactory<@Composable () -> Unit> {
   override fun TextInput(): TextInput<@Composable () -> Unit> = ComposeUiTextInput()
   override fun Text(): Text<@Composable () -> Unit> = ComposeUiText()
-  override fun Image(): Image<@Composable () -> Unit> = ComposeUiImage()
+  override fun Image(): Image<@Composable () -> Unit> = ComposeUiImage(imageLoader)
 }

--- a/samples/emoji-search/shared-composeui/src/main/kotlin/com/example/redwood/emojisearch/composeui/ComposeUiImage.kt
+++ b/samples/emoji-search/shared-composeui/src/main/kotlin/com/example/redwood/emojisearch/composeui/ComposeUiImage.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.cash.redwood.Modifier as RedwoodModifier
+import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import com.example.redwood.emojisearch.widget.Image
 
-internal class ComposeUiImage : Image<@Composable () -> Unit> {
+internal class ComposeUiImage(
+  private val imageLoader: ImageLoader,
+) : Image<@Composable () -> Unit> {
   private var url by mutableStateOf("")
   private var onClick by mutableStateOf({})
 
@@ -36,6 +39,7 @@ internal class ComposeUiImage : Image<@Composable () -> Unit> {
   override val value = @Composable {
     AsyncImage(
       model = url,
+      imageLoader = imageLoader,
       contentDescription = null,
       modifier = Modifier
         .size(48.dp)


### PR DESCRIPTION
- Fix a bad package name
- Share an `OkHttpClient` instance between HTTP client and image loader
- Explicitly pass in an image loader
