### PR TITLE
Added `Modifier` parameter to `RedwoodContent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/redwood/compare/0.8.0...HEAD
 
+New:
+
+Changed:
+- Added `Modifier` parameter to `RedwoodContent` which is applied to the root `Box` into which content is rendered.
+
+Fixed:
 
 
 

--- a/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/RedwoodContent.kt
+++ b/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/RedwoodContent.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @Composable
 public fun RedwoodContent(
   provider: Widget.Provider<@Composable () -> Unit>,
+  modifier: Modifier = Modifier,
   content: @Composable () -> Unit,
 ) {
   // If the provider or content change, reset any assumption about the rendered size.
@@ -83,7 +84,7 @@ public fun RedwoodContent(
   }
 
   Box(
-    modifier = Modifier.onSizeChanged { size ->
+    modifier = modifier.onSizeChanged { size ->
       viewportSize = with(Density(density.density.toDouble())) {
         Size(size.width.toDp().value.redwoodDp, size.height.toDp().value.redwoodDp)
       }

--- a/samples/counter/desktop-composeui/src/main/kotlin/com/example/redwood/counter/desktop/main.kt
+++ b/samples/counter/desktop-composeui/src/main/kotlin/com/example/redwood/counter/desktop/main.kt
@@ -17,7 +17,6 @@
 
 package com.example.redwood.counter.desktop
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -44,10 +43,8 @@ fun main() {
       state = rememberWindowState(width = 300.dp, height = 300.dp),
     ) {
       CounterTheme {
-        Box(Modifier.padding(16.dp)) {
-          RedwoodContent(factories) {
-            Counter()
-          }
+        RedwoodContent(factories, modifier = Modifier.padding(16.dp)) {
+          Counter()
         }
       }
     }

--- a/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/main.kt
+++ b/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/main.kt
@@ -17,7 +17,6 @@
 
 package com.example.redwood.emojisearch.desktop
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.ui.Modifier
@@ -49,16 +48,12 @@ fun main() {
     ) {
       EmojiSearchTheme {
         Scaffold { contentPadding ->
-          Box(
-            modifier = Modifier.padding(contentPadding),
-          ) {
-            RedwoodContent(factories) {
-              EmojiSearch(
-                httpClient = httpClient,
-                navigator = navigator,
-                safeAreaInsets = Margin.Zero,
-              )
-            }
+          RedwoodContent(factories, modifier = Modifier.padding(contentPadding)) {
+            EmojiSearch(
+              httpClient = httpClient,
+              navigator = navigator,
+              safeAreaInsets = Margin.Zero,
+            )
           }
         }
       }


### PR DESCRIPTION
This is applied to its `Box` into which content is rendered, avoiding the need for a redundant one enclosing it solely to apply things like padding.

`TreehouseContent` already had this.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
