### PR TITLE
Run main build on Apple silicon

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4.0.0


### PR DESCRIPTION
We know this one passes, at least. And it's the slowest of them all.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
