### PR TITLE
Embed the test app

### DIFF
--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -163,7 +163,7 @@ class EmojiSearchActivity : ComponentActivity() {
         manifestUrl = manifestUrlFlow,
         hostApi = RealHostApi(this@EmojiSearchActivity, httpClient),
       ),
-      eventListenerFactory = { app, manifestUrl -> appEventListener },
+      eventListenerFactory = { _, _ -> appEventListener },
     )
 
     treehouseApp.start()

--- a/samples/emoji-search/launcher/src/commonMain/kotlin/com/example/redwood/emojisearch/launcher/EmojiSearchAppSpec.kt
+++ b/samples/emoji-search/launcher/src/commonMain/kotlin/com/example/redwood/emojisearch/launcher/EmojiSearchAppSpec.kt
@@ -28,13 +28,12 @@ class EmojiSearchAppSpec(
   override val manifestUrl: Flow<String>,
   private val hostApi: HostApi,
 ) : TreehouseApp.Spec<EmojiSearchPresenter>() {
-  override val name = "emoji-search"
-  override val serializersModule = emojiSearchSerializersModule
+  override val name get() = "emoji-search"
+  override val serializersModule get() = emojiSearchSerializersModule
 
-  override val freshnessChecker: FreshnessChecker
-    get() = object : FreshnessChecker {
-      override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long) = true
-    }
+  override val freshnessChecker = object : FreshnessChecker {
+    override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long) = true
+  }
 
   override fun bindServices(zipline: Zipline) {
     zipline.bind<HostApi>("HostApi", hostApi)

--- a/test-app/android-views/build.gradle
+++ b/test-app/android-views/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
+redwoodBuild {
+  embedZiplineApplication(projects.testApp.presenterTreehouse)
+}
+
 android {
   namespace "com.example.redwood.testing.android.views"
 }
@@ -14,4 +18,5 @@ dependencies {
   implementation libs.androidx.appCompat
   implementation libs.androidx.core
   implementation libs.google.material
+  implementation libs.okio.assetfilesystem
 }

--- a/test-app/launcher/src/commonMain/kotlin/com/example/redwood/testing/launcher/TestAppSpec.kt
+++ b/test-app/launcher/src/commonMain/kotlin/com/example/redwood/testing/launcher/TestAppSpec.kt
@@ -17,6 +17,8 @@ package com.example.redwood.testing.launcher
 
 import app.cash.redwood.treehouse.TreehouseApp
 import app.cash.zipline.Zipline
+import app.cash.zipline.ZiplineManifest
+import app.cash.zipline.loader.FreshnessChecker
 import com.example.redwood.testing.treehouse.HostApi
 import com.example.redwood.testing.treehouse.TestAppPresenter
 import kotlinx.coroutines.flow.Flow
@@ -25,7 +27,11 @@ class TestAppSpec(
   override val manifestUrl: Flow<String>,
   private val hostApi: HostApi,
 ) : TreehouseApp.Spec<TestAppPresenter>() {
-  override val name = "test-app"
+  override val name get() = "test-app"
+
+  override val freshnessChecker = object : FreshnessChecker {
+    override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long) = true
+  }
 
   override fun bindServices(zipline: Zipline) {
     zipline.bind<HostApi>("HostApi", hostApi)

--- a/test-app/presenter-treehouse/build.gradle
+++ b/test-app/presenter-treehouse/build.gradle
@@ -3,6 +3,10 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'app.cash.zipline'
 apply plugin: 'app.cash.redwood'
 
+redwoodBuild {
+  ziplineApplication('test-app')
+}
+
 kotlin {
   iosArm64()
   iosX64()


### PR DESCRIPTION
This allows development without running the server separately.

Note: This is kinda broken because of #1820 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
