### PR TITLE
Fix blocking touch events to non-subviews below Row/Column/Box on iOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changed:
 - The render function of `ComposeWidgetChildren` has been renamed to `Render` to reflect Compose best practices (https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-api-guidelines.md#naming-unit-composable-functions-as-entities).
 
 Fixed:
-
+- Don't block touch events to non-subviews below a `Row`, `Column`, or `Box` in the iOS `UIView` implementation. This matches the behavior of the Android View and Compose UI implementations.
 
 
 ## [0.8.0] - 2024-02-22

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -220,14 +220,9 @@ internal class UIViewBox : Box<UIView> {
 
     override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
       // Don't consume touch events that don't hit a subview.
-      for (subview in typedSubviews) {
-        val localPoint = subview.convertPoint(point, fromView = this)
-        val touchedView = subview.hitTest(localPoint, withEvent)
-        if (touchedView != null) {
-          return touchedView
-        }
+      return typedSubviews.firstNotNullOfOrNull { subview ->
+        subview.hitTest(subview.convertPoint(point, fromView = this), withEvent)
       }
-      return null
     }
   }
 }

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -13,10 +13,12 @@ import app.cash.redwood.yoga.Size
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.cValue
 import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
+import platform.UIKit.UIEvent
 import platform.UIKit.UIScrollView
 import platform.UIKit.UIScrollViewContentInsetAdjustmentBehavior.UIScrollViewContentInsetAdjustmentNever
 import platform.UIKit.UIView
@@ -123,6 +125,18 @@ internal class YogaUIView(
   override fun setScrollEnabled(scrollEnabled: Boolean) {
     super.setScrollEnabled(scrollEnabled)
     setNeedsLayout()
+  }
+
+  override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
+    // Don't consume touch events that don't hit a subview.
+    for (subview in typedSubviews) {
+      val localPoint = subview.convertPoint(point, fromView = this)
+      val touchedView = subview.hitTest(localPoint, withEvent)
+      if (touchedView != null) {
+        return touchedView
+      }
+    }
+    return null
   }
 }
 

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -129,14 +129,9 @@ internal class YogaUIView(
 
   override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
     // Don't consume touch events that don't hit a subview.
-    for (subview in typedSubviews) {
-      val localPoint = subview.convertPoint(point, fromView = this)
-      val touchedView = subview.hitTest(localPoint, withEvent)
-      if (touchedView != null) {
-        return touchedView
-      }
+    return typedSubviews.firstNotNullOfOrNull { subview ->
+      subview.hitTest(subview.convertPoint(point, fromView = this), withEvent)
     }
-    return null
   }
 }
 


### PR DESCRIPTION
Fixes a case where `Column`/`Row`/`Box` on iOS would consume all touch events within its bounds even if it's empty space. [More context](https://cash.slack.com/archives/C01MNSK38DB/p1708718623388729). For example:

```kotlin
Box(
    width = Constraint.Fill,
    height = Constraint.Fill,
    horizontalAlignment = CrossAxisAlignment.Center,
    verticalAlignment = CrossAxisAlignment.Center,
  ) {
    Button("-1", onClick = { count-- })
    Column(
        horizontalAlignment = CrossAxisAlignment.Center,
        verticalAlignment = MainAxisAlignment.Center,
        modifier = Modifier.size(300.dp, 300.dp),
    ) {
        Spacer(height = 100.dp)
        Text("Count: $count")
        Button("+1", onClick = { count++ })
    }
}
```

In the above case the `-1` button wouldn't be clickable without this fix.

Android Views/Compose UI already have this touch handling behaviour by default.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
