### PR TITLE
Disable klib signature clash checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New:
 -
 
 Changed:
--
+- Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 
 Fixed:
 -

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ComposePlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/ComposePlugin.kt
@@ -18,6 +18,8 @@ package app.cash.redwood.buildsupport
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.js
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.wasm
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
@@ -35,6 +37,21 @@ internal class ComposePlugin : KotlinCompilerPluginSupportPlugin {
   override fun applyToCompilation(
     kotlinCompilation: KotlinCompilation<*>,
   ): Provider<List<SubpluginOption>> {
+    when (kotlinCompilation.platformType) {
+      js, wasm -> {
+        // The Compose compiler sometimes chooses to emit a duplicate signature rather than looking
+        // for an existing one. This occurs on all targets, but JS and WASM (which currently uses
+        // the JS compiler) have an explicit check for this. We disable this check which is deemed
+        // safe as the first-party JB Compose plugin does the same thing.
+        // https://github.com/JetBrains/compose-multiplatform/issues/3418#issuecomment-1971555314
+        kotlinCompilation.compilerOptions.configure {
+          freeCompilerArgs.add("-Xklib-enable-signature-clash-checks=false")
+        }
+      }
+
+      else -> {}
+    }
+
     return kotlinCompilation.target.project.provider { emptyList() }
   }
 }


### PR DESCRIPTION
These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).

Closes #1831 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
