### PR TITLE
Add some quick KotlinPoet helpers

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/modifierGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/modifierGeneration.kt
@@ -28,18 +28,12 @@ internal fun generateModifierInterface(schema: Schema, modifier: Modifier): File
     .addType(
       TypeSpec.interfaceBuilder(type)
         .addSuperinterface(Redwood.ModifierElement)
+        .maybeAddDeprecation(modifier.deprecation)
         .apply {
-          modifier.deprecation?.let { deprecation ->
-            addAnnotation(deprecation.toAnnotationSpec())
-          }
           for (property in modifier.properties) {
             addProperty(
               PropertySpec.builder(property.name, property.type.asTypeName())
-                .apply {
-                  property.deprecation?.let { deprecation ->
-                    addAnnotation(deprecation.toAnnotationSpec())
-                  }
-                }
+                .maybeAddDeprecation(property.deprecation)
                 .build(),
             )
           }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
@@ -114,23 +114,16 @@ internal fun generateWidgetFactory(schema: Schema): FileSpec {
             .addMember("exact = true")
             .build(),
         )
+        .maybeAddKDoc(schema.documentation)
         .apply {
-          schema.documentation?.let { documentation ->
-            addKdoc(documentation)
-          }
-
           for (widget in schema.widgets) {
             addFunction(
               FunSpec.builder(widget.type.flatName)
                 .addModifiers(ABSTRACT)
                 .returns(schema.widgetType(widget).parameterizedBy(typeVariableW))
+                .maybeAddDeprecation(widget.deprecation)
+                .maybeAddKDoc(widget.documentation)
                 .apply {
-                  widget.deprecation?.let { deprecation ->
-                    addAnnotation(deprecation.toAnnotationSpec())
-                  }
-                  widget.documentation?.let { documentation ->
-                    addKdoc(documentation)
-                  }
                   if (widget is ProtocolWidget) {
                     addKdoc("{tag=${widget.tag}}")
                   }
@@ -171,14 +164,9 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
             .addMember("exact = true")
             .build(),
         )
+        .maybeAddDeprecation(widget.deprecation)
+        .maybeAddKDoc(widget.documentation)
         .apply {
-          widget.deprecation?.let { deprecation ->
-            addAnnotation(deprecation.toAnnotationSpec())
-          }
-
-          widget.documentation?.let { documentation ->
-            addKdoc(documentation)
-          }
           if (widget is ProtocolWidget) {
             addKdoc("{tag=${widget.tag}}")
           }
@@ -190,13 +178,9 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
                   FunSpec.builder(trait.name)
                     .addModifiers(ABSTRACT)
                     .addParameter(trait.name, trait.type.asTypeName())
+                    .maybeAddDeprecation(trait.deprecation)
+                    .maybeAddKDoc(trait.documentation)
                     .apply {
-                      trait.deprecation?.let { deprecation ->
-                        addAnnotation(deprecation.toAnnotationSpec())
-                      }
-                      trait.documentation?.let { documentation ->
-                        addKdoc(documentation)
-                      }
                       if (trait is ProtocolTrait) {
                         addKdoc("{tag=${trait.tag}}")
                       }
@@ -210,13 +194,9 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
                   FunSpec.builder(trait.name)
                     .addModifiers(ABSTRACT)
                     .addParameter(trait.name, trait.lambdaType)
+                    .maybeAddDeprecation(trait.deprecation)
+                    .maybeAddKDoc(trait.documentation)
                     .apply {
-                      trait.deprecation?.let { deprecation ->
-                        addAnnotation(deprecation.toAnnotationSpec())
-                      }
-                      trait.documentation?.let { documentation ->
-                        addKdoc(documentation)
-                      }
                       if (trait is ProtocolTrait) {
                         addKdoc("{tag=${trait.tag}}")
                       }
@@ -229,13 +209,9 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
                 addProperty(
                   PropertySpec.builder(trait.name, RedwoodWidget.WidgetChildrenOfW)
                     .addModifiers(ABSTRACT)
+                    .maybeAddDeprecation(trait.deprecation)
+                    .maybeAddKDoc(trait.documentation)
                     .apply {
-                      trait.deprecation?.let { deprecation ->
-                        addAnnotation(deprecation.toAnnotationSpec())
-                      }
-                      trait.documentation?.let { documentation ->
-                        addKdoc(documentation)
-                      }
                       if (trait is ProtocolTrait) {
                         addKdoc("{tag=${trait.tag}}")
                       }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetProtocolGeneration.kt
@@ -431,9 +431,7 @@ internal fun generateProtocolModifierImpls(
 
                 primaryConstructor.addParameter(
                   ParameterSpec.builder(property.name, propertyType)
-                    .apply {
-                      property.defaultExpression?.let { defaultValue(it) }
-                    }
+                    .maybeDefaultValue(property.defaultExpression)
                     .build(),
                 )
 


### PR DESCRIPTION
These long-since passed the rule of three, and are supported by KP's recent `Documentable` and `Annotatable` interfaces.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
