### PR TITLE
Make LazyList background clear for UIKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Fixed:
 - Fix `Modifier.size` not being applied to children inside a `Box`.
 - Fix `Margin` not being applied to the `UIView` implementation of `Box`.
 - The `View` implementation of `Box` now applies start/end margins correctly in RTL, and does not crash if set before the native view was attached.
+- Fix the backgroundColor for `UIViewLazyList` to be transparent. This matches the behavior of the other `LazyList` platform implementations.
 
 
 ## [0.9.0] - 2024-02-28

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -185,6 +185,7 @@ internal open class UIViewLazyList(
       delegate = tableViewDelegate
       rowHeight = UITableViewAutomaticDimension
       separatorStyle = UITableViewCellSeparatorStyleNone
+      backgroundColor = UIColor.clearColor
 
       registerClass(
         cellClass = LazyListContainerCell(UITableViewCellStyle.UITableViewCellStyleDefault, REUSE_IDENTIFIER)
@@ -270,6 +271,8 @@ internal class LazyListContainerCell(
 
   override fun willMoveToSuperview(newSuperview: UIView?) {
     super.willMoveToSuperview(newSuperview)
+
+    backgroundColor = UIColor.clearColor
 
     // Confirm the cell is bound when it's about to be displayed.
     if (superview == null && newSuperview != null) {


### PR DESCRIPTION
- UITableView and it’s cells default to white which is different from how the lazy list behaves on other platforms. This allows the parent of the lazy list to define it’s background color and lazy list is only concerned about layout.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
