### PR TITLE
Change TreehouseUIKitView's size as necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Fixed:
 - Fix `Margin` not being applied to the `UIView` implementation of `Box`.
 - The `View` implementation of `Box` now applies start/end margins correctly in RTL, and does not crash if set before the native view was attached.
 - Fix the backgroundColor for `UIViewLazyList` to be transparent. This matches the behavior of the other `LazyList` platform implementations.
+- Fix `TreehouseUIView` to size itself according to the size of its subview.
 
 
 ## [0.9.0] - 2024-02-28

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -71,7 +71,8 @@ internal class UIViewFlexContainer(
   }
 
   override fun onEndChanges() {
-    value.setNeedsLayout()
+    value.invalidateIntrinsicContentSize() // Tell the enclosing view that our size changed.
+    value.setNeedsLayout() // Update layout of subviews.
   }
 }
 

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIView.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/TreehouseUIView.kt
@@ -20,6 +20,10 @@ import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.widget.RedwoodUIView
 import kotlinx.cinterop.cValue
 import platform.CoreGraphics.CGRectZero
+import platform.UIKit.UILayoutConstraintAxisVertical
+import platform.UIKit.UIStackView
+import platform.UIKit.UIStackViewAlignmentFill
+import platform.UIKit.UIStackViewDistributionFillEqually
 import platform.UIKit.UITraitCollection
 import platform.UIKit.UIView
 
@@ -33,7 +37,7 @@ public typealias TreehouseUIKitView = TreehouseUIView
 @ObjCName("TreehouseUIView", exact = true)
 public class TreehouseUIView private constructor(
   override val widgetSystem: WidgetSystem<UIView>,
-  view: UIView,
+  view: RootUiView,
 ) : TreehouseView<UIView>, RedwoodUIView(view) {
   override var saveCallback: TreehouseView.SaveCallback? = null
   override var stateSnapshotId: StateSnapshot.Id = StateSnapshot.Id(null)
@@ -50,26 +54,41 @@ public class TreehouseUIView private constructor(
   public constructor(widgetSystem: WidgetSystem<UIView>) : this(widgetSystem, RootUiView())
 
   init {
-    (view as RootUiView).treehouseView = this
+    view.treehouseView = this
   }
 
   private fun superviewChanged() {
     readyForContentChangeListener?.onReadyForContentChanged(this)
   }
 
-  private class RootUiView : UIView(cValue { CGRectZero }) {
+  /**
+   * The root view is just a vertical stack.
+   *
+   * In practice we expect this to contain either zero child subviews (especially when
+   * newly-initialized) or one child subview, which will usually be a layout container.
+   *
+   * This could just as easily be a horizontal stack. A box would be even better, but there's no
+   * such built-in component and implementing it manually is difficult if we want to react to
+   * content resizes.
+   */
+  private class RootUiView : UIStackView(cValue { CGRectZero }) {
     lateinit var treehouseView: TreehouseUIView
 
+    init {
+      this.axis = UILayoutConstraintAxisVertical
+      this.alignment = UIStackViewAlignmentFill // Fill horizontal.
+      this.distribution = UIStackViewDistributionFillEqually // Fill vertical.
+    }
+
     override fun layoutSubviews() {
+      super.layoutSubviews()
+
       // Bounds likely changed. Report new size.
       treehouseView.updateUiConfiguration()
-
-      subviews.forEach {
-        (it as UIView).setFrame(bounds)
-      }
     }
 
     override fun didMoveToSuperview() {
+      super.didMoveToSuperview()
       treehouseView.superviewChanged()
     }
 

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/LayoutTester.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/LayoutTester.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import app.cash.redwood.widget.UIViewChildren
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UILayoutConstraintAxisVertical
+import platform.UIKit.UIStackView
+import platform.UIKit.UIStackViewAlignmentCenter
+import platform.UIKit.UIStackViewAlignmentFill
+import platform.UIKit.UIStackViewDistributionEqualSpacing
+import platform.UIKit.UIStackViewDistributionFillEqually
+import platform.UIKit.UIView
+
+/**
+ * This layout puts 3 children in a 120 x 120 vertical stackview.
+ *
+ * Each child has initial intrinsic dimensions of 60 x 20.
+ *
+ * ```
+ * .-------------------------.
+ * |                         |
+ * |    .---------------.    |
+ * |    |      top      |    |
+ * |    '---------------'    |
+ * |                         |
+ * |    .---------------.    |
+ * |    |    middle     |    |
+ * |    '---------------'    |
+ * |                         |
+ * |    .---------------.    |
+ * |    |    bottom     |    |
+ * |    '---------------'    |
+ * |                         |
+ * '-------------------------'
+ * ```
+ *
+ * Then we wrap the middle child in a TreehouseView and confirm the layouts all work as expected.
+ * The presence of the TreehouseView wrapper shouldn't impact the layout.
+ *
+ * We confirm that we can handle resizes of the content by shrinking the content to 30 x 10 and
+ * growing it to 90 x 30.
+ */
+class LayoutTester(
+  subject: Subject,
+  horizontalConstraint: Constraint,
+  verticalConstraint: Constraint,
+) {
+  private val referenceView = RectangleUIView(60.0, 20.0)
+
+  val top: UIView = RectangleUIView(60.0, 20.0)
+
+  val middle: UIView = run {
+    when (subject) {
+      Subject.Reference -> referenceView
+
+      Subject.TreehouseView -> TreehouseUIView(throwingWidgetSystem)
+        .apply {
+          (this.children as UIViewChildren).insert(0, viewWidget(referenceView))
+        }
+        .view
+    }
+  }
+
+  val bottom: UIView = RectangleUIView(60.0, 20.0)
+
+  val screen = UIStackView()
+    .apply {
+      axis = UILayoutConstraintAxisVertical
+      alignment = when (horizontalConstraint) {
+        Constraint.Fill -> UIStackViewAlignmentFill
+        Constraint.Center -> UIStackViewAlignmentCenter
+      }
+      distribution = when (verticalConstraint) {
+        Constraint.Fill -> UIStackViewDistributionFillEqually
+        Constraint.Center -> UIStackViewDistributionEqualSpacing
+      }
+
+      setFrame(CGRectMake(0.0, 0.0, 120.0, 120.0))
+      addArrangedSubview(top)
+      addArrangedSubview(middle)
+      addArrangedSubview(bottom)
+    }
+
+  fun subjectFrame(): Rectangle {
+    screen.layoutIfNeeded()
+    return middle.frameRectangle
+  }
+
+  fun shrinkSubject() {
+    referenceView.width = 30.0
+    referenceView.height = 10.0
+  }
+
+  fun growSubject() {
+    referenceView.width = 90.0
+    referenceView.height = 30.0
+  }
+
+  enum class Constraint(
+    val initialX: Double,
+    val initialY: Double,
+    val initialWidth: Double,
+    val initialHeight: Double,
+    val shrunkX: Double = initialX,
+    val shrunkY: Double = initialY,
+    val shrunkWidth: Double = initialWidth,
+    val shrunkHeight: Double = initialHeight,
+    val grownX: Double = initialX,
+    val grownY: Double = initialY,
+    val grownWidth: Double = initialWidth,
+    val grownHeight: Double = initialHeight,
+  ) {
+    Fill(
+      // 120 x 40, centered at (60, 60)
+      initialX = 0.0,
+      initialY = 40.0,
+      initialWidth = 120.0,
+      initialHeight = 40.0,
+    ),
+
+    Center(
+      // 60 x 20, centered at (60, 60)
+      initialX = 30.0,
+      initialY = 50.0,
+      initialWidth = 60.0,
+      initialHeight = 20.0,
+
+      // 30 x 10, centered at (60, 60)
+      shrunkX = 45.0,
+      shrunkY = 55.0,
+      shrunkWidth = 30.0,
+      shrunkHeight = 10.0,
+
+      // 90 x 30, centered at (60, 60)
+      grownX = 15.0,
+      grownY = 45.0,
+      grownWidth = 90.0,
+      grownHeight = 30.0,
+    )
+  }
+
+  enum class Subject {
+    Reference, TreehouseView
+  }
+}

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/LayoutTester.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/LayoutTester.kt
@@ -150,10 +150,11 @@ class LayoutTester(
       grownY = 45.0,
       grownWidth = 90.0,
       grownHeight = 30.0,
-    )
+    ),
   }
 
   enum class Subject {
-    Reference, TreehouseView
+    Reference,
+    TreehouseView,
   }
 }

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
@@ -46,7 +46,7 @@ class TreehouseUIViewLayoutTest {
       )
 
     tester.shrinkSubject()
-    assertThat(tester.subjectFrame())
+    assertThat(tester.subjectFrame(), "$horizontal $vertical")
       .isEqualTo(
         Rectangle(
           x = horizontal.shrunkX,

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import app.cash.redwood.treehouse.LayoutTester.Constraint
+import app.cash.redwood.treehouse.LayoutTester.Subject
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class TreehouseUIViewLayoutTest {
+  /** Confirm that the layout with the treehouse view is the same as the layout without it. */
+  @Test
+  fun layoutIsPassThrough() {
+    for (horizontal in Constraint.entries) {
+      for (vertical in Constraint.entries) {
+        layoutIsPassThrough(Subject.Reference, horizontal, vertical)
+        layoutIsPassThrough(Subject.TreehouseView, horizontal, vertical)
+      }
+    }
+  }
+
+  private fun layoutIsPassThrough(subject: Subject, horizontal: Constraint, vertical: Constraint) {
+    val tester = LayoutTester(subject, horizontal, vertical)
+    assertThat(tester.subjectFrame())
+      .isEqualTo(
+        Rectangle(
+          x = horizontal.initialX,
+          y = vertical.initialY,
+          width = horizontal.initialWidth,
+          height = vertical.initialHeight,
+        ),
+      )
+
+    tester.shrinkSubject()
+    assertThat(tester.subjectFrame())
+      .isEqualTo(
+        Rectangle(
+          x = horizontal.shrunkX,
+          y = vertical.shrunkY,
+          width = horizontal.shrunkWidth,
+          height = vertical.shrunkHeight,
+        ),
+      )
+
+    tester.growSubject()
+    assertThat(tester.subjectFrame())
+      .isEqualTo(
+        Rectangle(
+          x = horizontal.grownX,
+          y = vertical.grownY,
+          width = horizontal.grownWidth,
+          height = vertical.grownHeight,
+        ),
+      )
+  }
+}

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
@@ -35,7 +35,7 @@ class TreehouseUIViewLayoutTest {
 
   private fun layoutIsPassThrough(subject: Subject, horizontal: Constraint, vertical: Constraint) {
     val tester = LayoutTester(subject, horizontal, vertical)
-    assertThat(tester.subjectFrame())
+    assertThat(tester.subjectFrame(), "$horizontal $vertical")
       .isEqualTo(
         Rectangle(
           x = horizontal.initialX,

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewLayoutTest.kt
@@ -57,7 +57,7 @@ class TreehouseUIViewLayoutTest {
       )
 
     tester.growSubject()
-    assertThat(tester.subjectFrame())
+    assertThat(tester.subjectFrame(), "$horizontal $vertical")
       .isEqualTo(
         Rectangle(
           x = horizontal.grownX,

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/TreehouseUIViewTest.kt
@@ -15,14 +15,11 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.Modifier
-import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.ui.Default
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.widget.UIViewChildren
-import app.cash.redwood.widget.Widget
 import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.hasSize
@@ -131,12 +128,4 @@ class TreehouseUIViewTest {
     assertThat(layout.uiConfiguration.value)
       .isEqualTo(UiConfiguration(safeAreaInsets = expectedInsets))
   }
-
-  private fun viewWidget(view: UIView) = object : Widget<UIView> {
-    override val value: UIView get() = view
-    override var modifier: Modifier = Modifier
-  }
-
-  private val throwingWidgetSystem =
-    WidgetSystem<UIView> { _, _ -> throw UnsupportedOperationException() }
 }

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/UIViews.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/UIViews.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import app.cash.redwood.Modifier
+import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
+import app.cash.redwood.widget.Widget
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.cValue
+import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGRectZero
+import platform.CoreGraphics.CGSize
+import platform.CoreGraphics.CGSizeMake
+import platform.UIKit.UIView
+
+fun viewWidget(view: UIView): Widget<UIView> = object : Widget<UIView> {
+  override val value: UIView get() = view
+  override var modifier: Modifier = Modifier
+}
+
+val throwingWidgetSystem = WidgetSystem<UIView> { _, _ -> throw UnsupportedOperationException() }
+
+val UIView.frameRectangle: Rectangle
+  get() = frame.useContents { Rectangle(origin.x, origin.y, size.width, size.height) }
+
+data class Rectangle(
+  val x: Double,
+  val y: Double,
+  val width: Double,
+  val height: Double,
+)
+
+/** This view exists only to be participate in layout testing. */
+class RectangleUIView(
+  width: Double,
+  height: Double,
+) : UIView(cValue { CGRectZero }) {
+  var width = width
+    set(value) {
+      field = value
+      invalidateIntrinsicContentSize()
+    }
+  var height = height
+    set(value) {
+      field = value
+      invalidateIntrinsicContentSize()
+    }
+
+  override fun sizeThatFits(size: CValue<CGSize>) = CGSizeMake(width, height)
+
+  override fun intrinsicContentSize(): CValue<CGSize> = CGSizeMake(width, height)
+}


### PR DESCRIPTION
If the content grows or shrinks, this reflects that.

I really didn't want to delegate to UIStackView here because this layout isn't a column at all. But after fighting it for hours and hours I gave up because I couldn't figure out how to react to my child views' size changes. I suspect the fix may be to add a listener on the bounds of the child views; nothing in the docs recommends this however. I'd love to know how UIStackView implements it!

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
