### PR TITLE
Change children wrapper subject to `container`

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -89,7 +89,7 @@ internal class UIViewBox : Box<UIView> {
     var verticalAlignment = CrossAxisAlignment.Start
 
     val children = UIViewChildren(
-      parent = this,
+      container = this,
       insert = { view, index ->
         insertSubview(view, index.convert<NSInteger>())
         view.setNeedsLayout()

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -40,7 +40,7 @@ internal class UIViewFlexContainer(
   override val density: Density get() = Density.Default
   override val value: UIView get() = yogaView
   override val children = UIViewChildren(
-    parent = value,
+    container = value,
     insert = { view, index ->
       yogaView.rootNode.children.add(index, view.asNode())
       value.insertSubview(view, index.convert<NSInteger>())

--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
@@ -19,12 +19,12 @@ import android.view.View
 import android.view.ViewGroup
 
 public class ViewGroupChildren(
-  private val parent: ViewGroup,
+  private val container: ViewGroup,
   private val insert: (index: Int, view: View) -> Unit = { index, view ->
-    parent.addView(view, index)
+    container.addView(view, index)
   },
   private val remove: (index: Int, count: Int) -> Unit = { index, count ->
-    parent.removeViews(index, count)
+    container.removeViews(index, count)
   },
 ) : Widget.Children<View> {
   private val _widgets = ArrayList<Widget<View>>()
@@ -39,7 +39,7 @@ public class ViewGroupChildren(
     _widgets.move(fromIndex, toIndex, count)
 
     val views = Array(count) { offset ->
-      parent.getChildAt(fromIndex + offset)
+      container.getChildAt(fromIndex + offset)
     }
     remove.invoke(fromIndex, count)
 
@@ -59,6 +59,6 @@ public class ViewGroupChildren(
   }
 
   override fun onModifierUpdated() {
-    parent.requestLayout()
+    container.requestLayout()
   }
 }

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
@@ -20,23 +20,23 @@ import kotlin.native.ObjCName
 /**
  * A [MutableList] that is also a [Widget.Children].
  *
- * @param list Optional existing [MutableList] instance to wrap.
+ * @param container Optional existing [MutableList] instance to wrap.
  */
 @ObjCName("MutableListChildren", exact = true)
 public class MutableListChildren<W : Any>(
-  private val list: MutableList<Widget<W>> = mutableListOf(),
+  private val container: MutableList<Widget<W>> = mutableListOf(),
   private val modifierUpdated: () -> Unit = {},
-) : Widget.Children<W>, MutableList<Widget<W>> by list {
+) : Widget.Children<W>, MutableList<Widget<W>> by container {
   override fun insert(index: Int, widget: Widget<W>) {
-    list.add(index, widget)
+    container.add(index, widget)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {
-    list.move(fromIndex, toIndex, count)
+    container.move(fromIndex, toIndex, count)
   }
 
   override fun remove(index: Int, count: Int) {
-    list.remove(index, count)
+    container.remove(index, count)
   }
 
   override fun onModifierUpdated() {

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -22,14 +22,14 @@ import platform.darwin.NSInteger
 
 @ObjCName("UIViewChildren", exact = true)
 public class UIViewChildren(
-  private val parent: UIView,
-  private val insert: (UIView, Int) -> Unit = when (parent) {
-    is UIStackView -> { view, index -> parent.insertArrangedSubview(view, index.convert()) }
-    else -> { view, index -> parent.insertSubview(view, index.convert<NSInteger>()) }
+  private val container: UIView,
+  private val insert: (UIView, Int) -> Unit = when (container) {
+    is UIStackView -> { view, index -> container.insertArrangedSubview(view, index.convert()) }
+    else -> { view, index -> container.insertSubview(view, index.convert<NSInteger>()) }
   },
-  private val remove: (index: Int, count: Int) -> Array<UIView> = when (parent) {
-    is UIStackView -> { index, count -> parent.typedArrangedSubviews.remove(index, count) }
-    else -> { index, count -> parent.typedSubviews.remove(index, count) }
+  private val remove: (index: Int, count: Int) -> Array<UIView> = when (container) {
+    is UIStackView -> { index, count -> container.typedArrangedSubviews.remove(index, count) }
+    else -> { index, count -> container.typedSubviews.remove(index, count) }
   },
 ) : Widget.Children<UIView> {
   private val _widgets = ArrayList<Widget<UIView>>()
@@ -69,7 +69,7 @@ public class UIViewChildren(
   }
 
   private fun invalidate() {
-    (parent.superview ?: parent).setNeedsLayout()
+    (container.superview ?: container).setNeedsLayout()
   }
 }
 

--- a/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
+++ b/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
@@ -19,7 +19,7 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
 
 public class HTMLElementChildren(
-  private val parent: HTMLElement,
+  private val container: HTMLElement,
 ) : Widget.Children<HTMLElement> {
   private val _widgets = ArrayList<Widget<HTMLElement>>()
   public val widgets: List<Widget<HTMLElement>> get() = _widgets
@@ -28,16 +28,16 @@ public class HTMLElementChildren(
     _widgets.add(index, widget)
 
     // Null element returned when index == childCount causes insertion at end.
-    val current = parent.children[index]
-    parent.insertBefore(widget.value, current)
+    val current = container.children[index]
+    container.insertBefore(widget.value, current)
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {
     _widgets.move(fromIndex, toIndex, count)
 
     val elements = Array(count) {
-      val element = parent.children[fromIndex] as HTMLElement
-      parent.removeChild(element)
+      val element = container.children[fromIndex] as HTMLElement
+      container.removeChild(element)
       element
     }
 
@@ -48,8 +48,8 @@ public class HTMLElementChildren(
     }
     elements.forEachIndexed { offset, element ->
       // Null element returned when newIndex + offset == childCount causes insertion at end.
-      val current = parent.children[newIndex + offset]
-      parent.insertBefore(element, current)
+      val current = container.children[newIndex + offset]
+      container.insertBefore(element, current)
     }
   }
 
@@ -57,15 +57,15 @@ public class HTMLElementChildren(
     _widgets.remove(index, count)
 
     repeat(count) {
-      parent.removeChild(parent.children[index]!!)
+      container.removeChild(container.children[index]!!)
     }
   }
 
   override fun onModifierUpdated() {
     // If this function is being invoked we are guaranteed to have at least one child.
 
-    val element = parent.children[0] as HTMLElement
-    parent.removeChild(element)
-    parent.insertBefore(element, parent.children[0])
+    val element = container.children[0] as HTMLElement
+    container.removeChild(element)
+    container.insertBefore(element, container.children[0])
   }
 }


### PR DESCRIPTION
When reading `parent` it was unclear if it was referring to the parent of the children container, or the container itself as a parent of children.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
