### PR TITLE
Supply the index and widget when modifier changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ New:
 
 Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
+- `onModifierChanged` callback in `Widget.Children` now receives the index and the `Widget` instance affected by the change.
 
 Fixed:
 - JVM targets now correctly link against Java 8 APIs. Previously they produced Java 8 bytecode, but linked against the compile JDK's APIs (21). This allowed linking against newer APIs that might not exist on older runtimes, which is no longer possible. Android targets which also produce Java 8 bytecode were not affected.

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
@@ -185,9 +185,9 @@ public interface RedwoodApplier<W : Any> {
  */
 @Composable
 @RedwoodCodegenApi
-public inline fun <P : Widget.Provider<*>, W : Widget<*>> RedwoodComposeNode(
+public inline fun <P : Widget.Provider<V>, W : Widget<V>, V : Any> RedwoodComposeNode(
   crossinline factory: (P) -> W,
-  update: @DisallowComposableCalls Updater<WidgetNode<W, *>>.() -> Unit,
+  update: @DisallowComposableCalls Updater<WidgetNode<W, V>>.() -> Unit,
   content: @Composable RedwoodComposeContent<W>.() -> Unit,
 ) {
   // NOTE: You MUST keep the implementation of this function (or more specifically, the interaction
@@ -202,18 +202,18 @@ public inline fun <P : Widget.Provider<*>, W : Widget<*>> RedwoodComposeNode(
       "UNCHECKED_CAST",
       "UNNECESSARY_NOT_NULL_ASSERTION",
     )
-    val applier = currentComposer.applier!! as RedwoodApplier<Any>
+    val applier = currentComposer.applier!! as RedwoodApplier<V>
 
     currentComposer.createNode {
       // Safe so long as you use generated composition function.
       @Suppress("UNCHECKED_CAST")
-      WidgetNode(applier, factory(applier.provider as P) as Widget<Any>)
+      WidgetNode(applier, factory(applier.provider as P))
     }
   } else {
     currentComposer.useNode()
   }
 
-  Updater<WidgetNode<W, *>>(currentComposer).update()
+  Updater<WidgetNode<W, V>>(currentComposer).update()
   RedwoodComposeContent.Instance.content()
 
   currentComposer.endNode()

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
@@ -148,10 +148,10 @@ public class WidgetNode<out W : Widget<V>, V : Any>(
   public var index: Int = -1
 
   public companion object {
-    public val SetModifiers: WidgetNode<*, *>.(Modifier) -> Unit = {
+    public val SetModifiers: WidgetNode<Widget<Any>, Any>.(Modifier) -> Unit = {
       recordChanged()
       widget.modifier = it
-      container?.onModifierUpdated()
+      container?.onModifierUpdated(index, widget)
     }
   }
 }

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
@@ -42,7 +42,7 @@ class ListeningTestRow : TestRow<WidgetValue>, ChangeListener {
       changes += "children remove"
     }
 
-    override fun onModifierUpdated() {
+    override fun onModifierUpdated(index: Int, widget: Widget<WidgetValue>) {
     }
   }
 

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
@@ -76,7 +76,7 @@ public abstract class LazyListUpdateProcessor<V : Any, W : Any> {
       error("unexpected call")
     }
 
-    override fun onModifierUpdated() {
+    override fun onModifierUpdated(index: Int, widget: Widget<W>) {
     }
   }
 
@@ -107,7 +107,7 @@ public abstract class LazyListUpdateProcessor<V : Any, W : Any> {
       }
     }
 
-    override fun onModifierUpdated() {
+    override fun onModifierUpdated(index: Int, widget: Widget<W>) {
     }
   }
 

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
@@ -51,6 +51,6 @@ internal class ProtocolWidgetChildren(
     state.append(ChildrenChange.Move(id, tag, fromIndex, toIndex, count))
   }
 
-  override fun onModifierUpdated() {
+  override fun onModifierUpdated(index: Int, widget: Widget<Nothing>) {
   }
 }

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNode.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolNode.kt
@@ -42,7 +42,7 @@ public abstract class ProtocolNode<W : Any> {
 
   public fun updateModifier(modifier: Modifier) {
     widget.modifier = modifier
-    container?.onModifierUpdated()
+    container?.onModifierUpdated(index, widget)
   }
 
   /**

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
@@ -23,6 +23,7 @@ import app.cash.redwood.tooling.schema.Widget
 import app.cash.redwood.tooling.schema.Widget.Children
 import app.cash.redwood.tooling.schema.Widget.Event
 import app.cash.redwood.tooling.schema.Widget.Property
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -32,7 +33,6 @@ import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.joinToCode
 
@@ -46,7 +46,7 @@ fun Row(
   modifier: Modifier = Modifier,
   children: @Composable @SunspotComposable RowScope.() -> Unit,
 ): Unit {
-  RedwoodComposeNode<SunspotWidgetFactoryProvider<*>, Row<*>>(
+  RedwoodComposeNode<SunspotWidgetFactoryProvider<Any>, Row<Any>, Any>(
     factory = { it.RedwoodLayout.Row() },
     update = {
       set(modifier, WidgetNode.SetModifiers)
@@ -54,7 +54,7 @@ fun Row(
       set(overflow) { recordChanged(); widget.overflow(it) }
     },
     content = {
-      Children(Row<*>::children) {
+      Children(Row<Any>::children) {
         RowScopeImpl.children()
       }
     },
@@ -65,7 +65,7 @@ internal fun generateComposable(
   schema: Schema,
   widget: Widget,
 ): FileSpec {
-  val widgetType = schema.widgetType(widget).parameterizedBy(STAR)
+  val widgetType = schema.widgetType(widget).parameterizedBy(ANY)
   val flatName = widget.type.flatName
   return FileSpec.builder(schema.composePackage(), flatName)
     .addAnnotation(suppressDeprecations)
@@ -171,10 +171,11 @@ internal fun generateComposable(
           )
 
           addStatement(
-            "%M<%T, %T>(%L)",
+            "%M<%T, %T, %T>(%L)",
             RedwoodCompose.RedwoodComposeNode,
-            schema.getWidgetFactoryProviderType().parameterizedBy(STAR),
+            schema.getWidgetFactoryProviderType().parameterizedBy(ANY),
             widgetType,
+            ANY,
             arguments.joinToCode(",\n", "\n", ",\n"),
           )
         }

--- a/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
+++ b/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
@@ -53,7 +53,7 @@ public class ComposeWidgetChildren @JvmOverloads constructor(
     _widgets.remove(index, count)
   }
 
-  override fun onModifierUpdated() {
+  override fun onModifierUpdated(index: Int, widget: Widget<@Composable () -> Unit>) {
     modifierTick++
     onModifierUpdated.invoke()
   }

--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
@@ -58,7 +58,7 @@ public class ViewGroupChildren(
     remove.invoke(index, count)
   }
 
-  override fun onModifierUpdated() {
+  override fun onModifierUpdated(index: Int, widget: Widget<View>) {
     container.requestLayout()
   }
 }

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
@@ -39,7 +39,7 @@ public class MutableListChildren<W : Any>(
     container.remove(index, count)
   }
 
-  override fun onModifierUpdated() {
+  override fun onModifierUpdated(index: Int, widget: Widget<W>) {
     modifierUpdated()
   }
 }

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -66,6 +66,6 @@ public interface Widget<W : Any> {
     public fun remove(index: Int, count: Int)
 
     /** Indicates that [Modifier]s for the child widgets have changed. */
-    public fun onModifierUpdated()
+    public fun onModifierUpdated(index: Int, widget: Widget<W>)
   }
 }

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -64,7 +64,7 @@ public class UIViewChildren(
     invalidate()
   }
 
-  override fun onModifierUpdated() {
+  override fun onModifierUpdated(index: Int, widget: Widget<UIView>) {
     invalidate()
   }
 

--- a/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
+++ b/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
@@ -61,7 +61,7 @@ public class HTMLElementChildren(
     }
   }
 
-  override fun onModifierUpdated() {
+  override fun onModifierUpdated(index: Int, widget: Widget<HTMLElement>) {
     // If this function is being invoked we are guaranteed to have at least one child.
 
     val element = container.children[0] as HTMLElement


### PR DESCRIPTION
This will enable replacing the underlying view in the tree if future interceptor modifiers change the instance.

Refs #1084

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
