### PR TITLE
Set JDK APIs for JVM targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 
 Fixed:
+- JVM targets now correctly link against Java 8 APIs. Previously they produced Java 8 bytecode, but linked against the compile JDK's APIs (21). This allowed linking against newer APIs that might not exist on older runtimes, which is no longer possible. Android targets which also produce Java 8 bytecode were not affected.
 - Fix the `View` implementation of `Box` to wrap its width and height by default. This matches the behavior of the `UIView` implementation and all other layout widgets.
 - Fix the `UIView` implementation of `Box` not updating when some of its parameters are changed.
 - Fix `Modifier.size` not being applied to children inside a `Box`.

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -44,6 +44,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 import org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -241,6 +242,17 @@ class RedwoodBuildPlugin : Plugin<Project> {
           it.languageSettings.optIn("kotlin.experimental.ExperimentalObjCName")
           it.languageSettings.optIn("kotlinx.cinterop.BetaInteropApi")
           it.languageSettings.optIn("kotlinx.cinterop.ExperimentalForeignApi")
+        }
+      }
+
+      // We set the JVM target (the bytecode version) above for all Kotlin-based Java bytecode
+      // compilations, but we also need to set the JDK API version for the Kotlin JVM targets to
+      // prevent linking against newer JDK APIs (the Android targets link against the android.jar).
+      kotlin.targets.withType(KotlinJvmTarget::class.java) { target ->
+        target.compilations.configureEach {
+          it.kotlinOptions.freeCompilerArgs += listOf(
+            "-Xjdk-release=$javaVersion"
+          )
         }
       }
 

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -251,7 +251,7 @@ class RedwoodBuildPlugin : Plugin<Project> {
       kotlin.targets.withType(KotlinJvmTarget::class.java) { target ->
         target.compilations.configureEach {
           it.kotlinOptions.freeCompilerArgs += listOf(
-            "-Xjdk-release=$javaVersion"
+            "-Xjdk-release=$javaVersion",
           )
         }
       }


### PR DESCRIPTION
We set the JVM target (the bytecode version) above for all Kotlin-based Java bytecode compilations, but we also need to set the JDK API version for the Kotlin JVM targets to prevent linking against newer JDK APIs (the Android targets link against the android.jar).

Before:

    405: checkcast     #101                // class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Edit$Insert
    408: invokevirtual #107                // Method app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Edit$Insert.getWidgets:()Ljava/util/List;
    411: invokeinterface #151,  1          // InterfaceMethod java/util/List.removeFirst:()Ljava/lang/Object;
    416: checkcast     #121                // class app/cash/redwood/widget/Widget
    419: astore        6

After:

    405: checkcast     #101                // class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Edit$Insert
    408: invokevirtual #107                // Method app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Edit$Insert.getWidgets:()Ljava/util/List;
    411: invokestatic  #152                // Method kotlin/collections/CollectionsKt.removeFirst:(Ljava/util/List;)Ljava/lang/Object;
    414: checkcast     #121                // class app/cash/redwood/widget/Widget
    417: astore        6

Closes #1863

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
