### PR TITLE
Adding begin/endUpdates calls to insert/deleteRows hooks in UIViewLazyList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixed:
 - The `View` implementation of `Box` now applies start/end margins correctly in RTL, and does not crash if set before the native view was attached.
 - Fix the backgroundColor for `UIViewLazyList` to be transparent. This matches the behavior of the other `LazyList` platform implementations.
 - Fix `TreehouseUIView` to size itself according to the size of its subview.
+- In `UiViewLazyList`, added `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows` to improve animations.
 
 
 ## [0.9.0] - 2024-02-28

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -81,18 +81,22 @@ internal open class UIViewLazyList(
 
     override fun insertRows(index: Int, count: Int) {
       // TODO(jwilson): pass a range somehow when 'count' is large?
+      tableView.beginUpdates()
       tableView.insertRowsAtIndexPaths(
         (index until index + count).map { NSIndexPath.indexPathForItem(it.convert(), 0) },
         UITableViewRowAnimationNone,
       )
+      tableView.endUpdates()
     }
 
     override fun deleteRows(index: Int, count: Int) {
       // TODO(jwilson): pass a range somehow when 'count' is large?
+      tableView.beginUpdates()
       tableView.deleteRowsAtIndexPaths(
         (index until index + count).map { NSIndexPath.indexPathForItem(it.convert(), 0) },
         UITableViewRowAnimationNone,
       )
+      tableView.endUpdates()
     }
 
     override fun setContent(view: LazyListContainerCell, content: Widget<UIView>?) {


### PR DESCRIPTION
As per [Apple's docs](https://developer.apple.com/documentation/uikit/uitableview/1614908-beginupdates), this allows the insertion/deletion animations to occur simultaneously across multiple rows.

This is "step 0" of addressing issue #1840.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
