### PR TITLE
Revert "Fix blocking touch events to non-subviews below Row/Column/Box on iOS. (#1823)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Changed:
 - Disable decoy generation for JS target to make compatible with JetBrains Compose 1.6. This is an ABI-breaking change, so all Compose-based libraries targeting JS will also need to have been recompiled.
 
 Fixed:
-
+- Don't block touch events to non-subviews below a `Row`, `Column`, or `Box` in the iOS `UIView` implementation. This matches the behavior of the Android View and Compose UI implementations.
 
 This version works with Kotlin 1.9.22 by default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New:
 Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 - `onModifierChanged` callback in `Widget.Children` now receives the index and the `Widget` instance affected by the change.
+- Revert: Don't block touch events to non-subviews below a `Row`, `Column`, or `Box` in the iOS `UIView` implementation. This matches the behavior of the Android View and Compose UI implementations.
 
 Fixed:
 - JVM targets now correctly link against Java 8 APIs. Previously they produced Java 8 bytecode, but linked against the compile JDK's APIs (21). This allowed linking against newer APIs that might not exist on older runtimes, which is no longer possible. Android targets which also produce Java 8 bytecode were not affected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Changed:
 - Disable decoy generation for JS target to make compatible with JetBrains Compose 1.6. This is an ABI-breaking change, so all Compose-based libraries targeting JS will also need to have been recompiled.
 
 Fixed:
-- Don't block touch events to non-subviews below a `Row`, `Column`, or `Box` in the iOS `UIView` implementation. This matches the behavior of the Android View and Compose UI implementations.
+
 
 This version works with Kotlin 1.9.22 by default.
 

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -46,7 +46,7 @@ internal class UIViewBox : Box<UIView> {
 
   override var modifier: Modifier = Modifier
 
-  override val children = value.children
+  override val children get() = value.children
 
   override fun width(width: Constraint) {
     value.widthConstraint = width
@@ -80,7 +80,7 @@ internal class UIViewBox : Box<UIView> {
     value.setNeedsLayout()
   }
 
-  internal class View() : UIView(CGRectZero.readValue()) {
+  internal class View : UIView(CGRectZero.readValue()) {
     var widthConstraint = Constraint.Wrap
     var heightConstraint = Constraint.Wrap
     var horizontalAlignment = CrossAxisAlignment.Start

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -33,13 +33,11 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGFloat
-import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIEdgeInsetsMake
-import platform.UIKit.UIEvent
 import platform.UIKit.UIView
 import platform.darwin.NSInteger
 
@@ -48,7 +46,7 @@ internal class UIViewBox : Box<UIView> {
 
   override var modifier: Modifier = Modifier
 
-  override val children get() = value.children
+  override val children = value.children
 
   override fun width(width: Constraint) {
     value.widthConstraint = width
@@ -82,7 +80,7 @@ internal class UIViewBox : Box<UIView> {
     value.setNeedsLayout()
   }
 
-  internal class View : UIView(CGRectZero.readValue()) {
+  internal class View() : UIView(CGRectZero.readValue()) {
     var widthConstraint = Constraint.Wrap
     var heightConstraint = Constraint.Wrap
     var horizontalAlignment = CrossAxisAlignment.Start
@@ -257,13 +255,6 @@ internal class UIViewBox : Box<UIView> {
         width = maxOf(maxRequestedWidth, maxItemWidth),
         height = maxOf(maxRequestedHeight, maxItemHeight),
       )
-    }
-
-    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
-      // Don't consume touch events that don't hit a subview.
-      return typedSubviews.firstNotNullOfOrNull { subview ->
-        subview.hitTest(subview.convertPoint(point, fromView = this), withEvent)
-      }
     }
   }
 }

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -13,12 +13,10 @@ import app.cash.redwood.yoga.Size
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.cValue
 import kotlinx.cinterop.useContents
-import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
-import platform.UIKit.UIEvent
 import platform.UIKit.UIScrollView
 import platform.UIKit.UIScrollViewContentInsetAdjustmentBehavior.UIScrollViewContentInsetAdjustmentNever
 import platform.UIKit.UIView
@@ -125,13 +123,6 @@ internal class YogaUIView(
   override fun setScrollEnabled(scrollEnabled: Boolean) {
     super.setScrollEnabled(scrollEnabled)
     setNeedsLayout()
-  }
-
-  override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
-    // Don't consume touch events that don't hit a subview.
-    return typedSubviews.firstNotNullOfOrNull { subview ->
-      subview.hitTest(subview.convertPoint(point, fromView = this), withEvent)
-    }
   }
 }
 


### PR DESCRIPTION
Temporarily reverting this as it conflicts with custom touch handlers (which one of our tabs use).

This reverts commit 877bbe5050fe343108d17004b6dc83be52f4d2b3.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
