### PR TITLE
Split and rename generated "factories" and "provider"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 - `onModifierChanged` callback in `Widget.Children` now receives the index and the `Widget` instance affected by the change.
 - Revert: Don't block touch events to non-subviews below a `Row`, `Column`, or `Box` in the iOS `UIView` implementation. This matches the behavior of the Android View and Compose UI implementations.
+- The generated "widget factories" type (e.g., `MySchemaWidgetFactories`) is now called a "widget system" (e.g., `MySchemaWidgetSystem`). Sometimes it was also referred to as a "provider" in parameter names. A `@Deprecated typealias` is generated for now, but will be removed in the future.
 
 Fixed:
 - JVM targets now correctly link against Java 8 APIs. Previously they produced Java 8 bytecode, but linked against the compile JDK's APIs (21). This allowed linking against newer APIs that might not exist on older runtimes, which is no longer possible. Android targets which also produce Java 8 bytecode were not affected.

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
@@ -21,6 +21,7 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.WidgetSystem
 import kotlin.math.max
 import kotlin.math.min
 
@@ -51,7 +52,7 @@ import kotlin.math.min
  */
 @OptIn(RedwoodCodegenApi::class)
 internal class NodeApplier<W : Any>(
-  override val provider: Widget.Provider<W>,
+  override val widgetSystem: WidgetSystem<W>,
   root: Widget.Children<W>,
   private val onEndChanges: () -> Unit,
 ) : AbstractApplier<Node<W>>(ChildrenNode(root)), RedwoodApplier<W> {

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChildrenNodeIndexTest.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChildrenNodeIndexTest.kt
@@ -127,6 +127,6 @@ private class StringWidget(override val value: String) : Widget<String> {
 
 @OptIn(RedwoodCodegenApi::class)
 private object NoOpRedwoodApplier : RedwoodApplier<String> {
-  override val provider get() = throw UnsupportedOperationException()
+  override val widgetSystem get() = throw UnsupportedOperationException()
   override fun recordChanged(widget: Widget<String>) = Unit
 }

--- a/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/RedwoodContent.kt
+++ b/redwood-composeui/src/commonMain/kotlin/app/cash/redwood/composeui/RedwoodContent.kt
@@ -35,19 +35,19 @@ import app.cash.redwood.ui.OnBackPressedDispatcher
 import app.cash.redwood.ui.Size
 import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.ui.dp as redwoodDp
-import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.WidgetSystem
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /** Render a Redwood composition inside of Compose UI. */
 @Composable
 public fun RedwoodContent(
-  provider: Widget.Provider<@Composable () -> Unit>,
+  widgetSystem: WidgetSystem<@Composable () -> Unit>,
   modifier: Modifier = Modifier,
   content: @Composable () -> Unit,
 ) {
   // If the provider or content change, reset any assumption about the rendered size.
-  var viewportSize by remember(provider, content) { mutableStateOf(Size.Zero) }
+  var viewportSize by remember(widgetSystem, content) { mutableStateOf(Size.Zero) }
 
   val density = LocalDensity.current
   val uiConfiguration = UiConfiguration(
@@ -66,11 +66,11 @@ public fun RedwoodContent(
   val saveableStateRegistry = LocalSaveableStateRegistry.current
 
   // For simplicity, a new provider or content lambda gets an entirely new composition and children.
-  val children = remember(provider, content) { ComposeWidgetChildren() }
-  DisposableEffect(provider, content) {
+  val children = remember(widgetSystem, content) { ComposeWidgetChildren() }
+  DisposableEffect(widgetSystem, content) {
     val composition = RedwoodComposition(
       scope = scope,
-      provider = provider,
+      widgetSystem = widgetSystem,
       container = children,
       onBackPressedDispatcher = onBackPressedDispatcher,
       saveableStateRegistry = saveableStateRegistry,

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolBridge.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolBridge.kt
@@ -21,16 +21,17 @@ import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.WidgetSystem
 import kotlinx.serialization.json.Json
 
 /**
- * Exposes a [Widget.Children] and [Widget.Provider] whose changes can be captured as a list
+ * Exposes a [Widget.Children] and [WidgetSystem] whose changes can be captured as a list
  * of [Change]s to send to a remote frontend. Incoming [Event]s can also be sent to this instance
  * and will be routed to the appropriate handler.
  */
 public interface ProtocolBridge : EventSink {
   /**
-   * The root of the widget tree onto which [provider]-produced widgets can be added. Changes to
+   * The root of the widget tree onto which [widgetSystem]-produced widgets can be added. Changes to
    * this instance are recorded as changes to [Id.Root] and [ChildrenTag.Root].
    */
   public val root: Widget.Children<Nothing>
@@ -40,11 +41,11 @@ public interface ProtocolBridge : EventSink {
    * are also recorded. You **must** attach returned widgets to [root] or the children of a widget
    * in the tree beneath [root] in order for it to be tracked.
    */
-  public val provider: Widget.Provider<Nothing>
+  public val widgetSystem: WidgetSystem<Nothing>
 
   /**
-   * Returns any changes to [root] or [provider]-produced widgets since the last time this function
-   * was called. Returns null if no changes occurred.
+   * Returns any changes to [root] or [widgetSystem]-produced widgets since the last time this
+   * function was called. Returns null if no changes occurred.
    */
   public fun getChangesOrNull(): List<Change>?
 

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolRedwoodComposition.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolRedwoodComposition.kt
@@ -47,7 +47,7 @@ public fun ProtocolRedwoodComposition(
     onBackPressedDispatcher = onBackPressedDispatcher,
     saveableStateRegistry = saveableStateRegistry,
     uiConfigurations = uiConfigurations,
-    provider = bridge.provider,
+    widgetSystem = bridge.widgetSystem,
   ) {
     bridge.getChangesOrNull()?.let(changesSink::sendChanges)
   }

--- a/redwood-protocol-guest/src/commonTest/kotlin/app/cash/redwood/protocol/guest/GeneratedProtocolBridgeTest.kt
+++ b/redwood-protocol-guest/src/commonTest/kotlin/app/cash/redwood/protocol/guest/GeneratedProtocolBridgeTest.kt
@@ -48,7 +48,7 @@ class GeneratedProtocolBridgeTest {
       }
     }
     val bridge = TestSchemaProtocolBridge.create(json)
-    val textInput = bridge.provider.TestSchema.TextInput()
+    val textInput = bridge.widgetSystem.TestSchema.TextInput()
 
     textInput.customType(10.seconds)
 
@@ -66,7 +66,7 @@ class GeneratedProtocolBridgeTest {
       }
     }
     val bridge = TestSchemaProtocolBridge.create(json)
-    val button = bridge.provider.TestSchema.Button()
+    val button = bridge.widgetSystem.TestSchema.Button()
 
     button.modifier = with(object : TestScope {}) {
       Modifier.customType(10.seconds)
@@ -96,7 +96,7 @@ class GeneratedProtocolBridgeTest {
       }
     }
     val bridge = TestSchemaProtocolBridge.create(json)
-    val button = bridge.provider.TestSchema.Button()
+    val button = bridge.widgetSystem.TestSchema.Button()
 
     button.modifier = with(object : TestScope {}) {
       Modifier.customTypeWithDefault(10.seconds, "sup")
@@ -126,7 +126,7 @@ class GeneratedProtocolBridgeTest {
       }
     }
     val bridge = TestSchemaProtocolBridge.create(json)
-    val textInput = bridge.provider.TestSchema.TextInput()
+    val textInput = bridge.widgetSystem.TestSchema.TextInput()
 
     val protocolWidget = textInput as ProtocolWidget
 
@@ -142,7 +142,7 @@ class GeneratedProtocolBridgeTest {
 
   @Test fun unknownEventThrowsDefault() {
     val bridge = TestSchemaProtocolBridge.create()
-    val button = bridge.provider.TestSchema.Button() as ProtocolWidget
+    val button = bridge.widgetSystem.TestSchema.Button() as ProtocolWidget
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.sendEvent(Event(Id(1), EventTag(3456543)))
@@ -154,7 +154,7 @@ class GeneratedProtocolBridgeTest {
   @Test fun unknownEventCallsHandler() {
     val handler = RecordingProtocolMismatchHandler()
     val bridge = TestSchemaProtocolBridge.create(mismatchHandler = handler)
-    val button = bridge.provider.TestSchema.Button() as ProtocolWidget
+    val button = bridge.widgetSystem.TestSchema.Button() as ProtocolWidget
 
     button.sendEvent(Event(Id(1), EventTag(3456543)))
 

--- a/redwood-protocol-guest/src/commonTest/kotlin/app/cash/redwood/protocol/guest/ProtocolTest.kt
+++ b/redwood-protocol-guest/src/commonTest/kotlin/app/cash/redwood/protocol/guest/ProtocolTest.kt
@@ -280,7 +280,7 @@ class ProtocolTest {
   private fun TestScope.testProtocolComposition(): TestRedwoodComposition<List<Change>> {
     val composition = TestRedwoodComposition(
       scope = backgroundScope,
-      provider = bridge.provider,
+      widgetSystem = bridge.widgetSystem,
       container = bridge.root,
     ) {
       bridge.getChangesOrNull() ?: emptyList()

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolBridgeTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolBridgeTest.kt
@@ -29,7 +29,7 @@ import assertk.assertThat
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import com.example.redwood.testing.widget.TestSchemaProtocolFactory
-import com.example.redwood.testing.widget.TestSchemaWidgetFactories
+import com.example.redwood.testing.widget.TestSchemaWidgetSystem
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlinx.serialization.json.JsonPrimitive
@@ -39,7 +39,7 @@ class ProtocolBridgeTest {
     val bridge = ProtocolBridge(
       container = MutableListChildren(),
       factory = TestSchemaProtocolFactory(
-        provider = TestSchemaWidgetFactories(
+        widgetSystem = TestSchemaWidgetSystem(
           TestSchema = EmptyTestSchemaWidgetFactory(),
           RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
           RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -64,7 +64,7 @@ class ProtocolBridgeTest {
     val bridge = ProtocolBridge(
       container = MutableListChildren(),
       factory = TestSchemaProtocolFactory(
-        provider = TestSchemaWidgetFactories(
+        widgetSystem = TestSchemaWidgetSystem(
           TestSchema = EmptyTestSchemaWidgetFactory(),
           RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
           RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -90,7 +90,7 @@ class ProtocolBridgeTest {
     val bridge = ProtocolBridge(
       container = MutableListChildren(),
       factory = TestSchemaProtocolFactory(
-        provider = TestSchemaWidgetFactories(
+        widgetSystem = TestSchemaWidgetSystem(
           TestSchema = EmptyTestSchemaWidgetFactory(),
           RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
           RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -149,7 +149,7 @@ class ProtocolBridgeTest {
     val bridge = ProtocolBridge(
       container = MutableListChildren(modifierUpdated = { modifierUpdateCount++ }),
       factory = TestSchemaProtocolFactory(
-        provider = TestSchemaWidgetFactories(
+        widgetSystem = TestSchemaWidgetSystem(
           TestSchema = EmptyTestSchemaWidgetFactory(),
           RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
           RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolFactoryTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolFactoryTest.kt
@@ -33,7 +33,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import com.example.redwood.testing.compose.TestScope
 import com.example.redwood.testing.widget.TestSchemaProtocolFactory
-import com.example.redwood.testing.widget.TestSchemaWidgetFactories
+import com.example.redwood.testing.widget.TestSchemaWidgetSystem
 import com.example.redwood.testing.widget.TextInput
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -50,7 +50,7 @@ import kotlinx.serialization.modules.SerializersModule
 class ProtocolFactoryTest {
   @Test fun unknownWidgetThrowsDefault() {
     val factory = TestSchemaProtocolFactory(
-      TestSchemaWidgetFactories(
+      TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -66,7 +66,7 @@ class ProtocolFactoryTest {
   @Test fun unknownWidgetCallsHandler() {
     val handler = RecordingProtocolMismatchHandler()
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -86,7 +86,7 @@ class ProtocolFactoryTest {
       }
     }
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -115,7 +115,7 @@ class ProtocolFactoryTest {
       }
     }
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -144,7 +144,7 @@ class ProtocolFactoryTest {
 
   @Test fun unknownModifierThrowsDefault() {
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -170,7 +170,7 @@ class ProtocolFactoryTest {
     }
     val handler = RecordingProtocolMismatchHandler()
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -208,7 +208,7 @@ class ProtocolFactoryTest {
 
   @Test fun unknownChildrenThrowsDefault() {
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -225,7 +225,7 @@ class ProtocolFactoryTest {
   @Test fun unknownChildrenCallsHandler() {
     val handler = RecordingProtocolMismatchHandler()
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -247,7 +247,7 @@ class ProtocolFactoryTest {
     }
     val recordingTextInput = RecordingTextInput()
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = object : EmptyTestSchemaWidgetFactory() {
           override fun TextInput() = recordingTextInput
         },
@@ -266,7 +266,7 @@ class ProtocolFactoryTest {
 
   @Test fun unknownPropertyThrowsDefaults() {
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -285,7 +285,7 @@ class ProtocolFactoryTest {
   @Test fun unknownPropertyCallsHandler() {
     val handler = RecordingProtocolMismatchHandler()
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = EmptyTestSchemaWidgetFactory(),
         RedwoodLayout = EmptyRedwoodLayoutWidgetFactory(),
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
@@ -307,7 +307,7 @@ class ProtocolFactoryTest {
     }
     val recordingTextInput = RecordingTextInput()
     val factory = TestSchemaProtocolFactory(
-      provider = TestSchemaWidgetFactories(
+      widgetSystem = TestSchemaWidgetSystem(
         TestSchema = object : EmptyTestSchemaWidgetFactory() {
           override fun TextInput() = recordingTextInput
         },

--- a/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/TestRedwoodComposition.kt
+++ b/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/TestRedwoodComposition.kt
@@ -25,6 +25,7 @@ import app.cash.redwood.ui.OnBackPressedCallback
 import app.cash.redwood.ui.OnBackPressedDispatcher
 import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.WidgetSystem
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -40,11 +41,10 @@ import kotlinx.coroutines.withTimeout
 /**
  * Performs Redwood composition strictly for testing.
  */
-
 @Suppress("FunctionName") // ktlint bug
 public fun <W : Any, S> TestRedwoodComposition(
   scope: CoroutineScope,
-  provider: Widget.Provider<W>,
+  widgetSystem: WidgetSystem<W>,
   container: Widget.Children<W>,
   onBackPressedDispatcher: OnBackPressedDispatcher = NoOpOnBackPressedDispatcher,
   savedState: TestSavedState? = null,
@@ -53,7 +53,7 @@ public fun <W : Any, S> TestRedwoodComposition(
 ): TestRedwoodComposition<S> {
   return RealTestRedwoodComposition(
     scope,
-    provider,
+    widgetSystem,
     container,
     onBackPressedDispatcher,
     savedState,
@@ -89,7 +89,7 @@ private class MapBasedTestSavedState(
 /** Performs Redwood composition strictly for testing. */
 private class RealTestRedwoodComposition<W : Any, S>(
   scope: CoroutineScope,
-  provider: Widget.Provider<W>,
+  widgetSystem: WidgetSystem<W>,
   container: Widget.Children<W>,
   onBackPressedDispatcher: OnBackPressedDispatcher,
   savedState: TestSavedState?,
@@ -124,7 +124,7 @@ private class RealTestRedwoodComposition<W : Any, S>(
     onBackPressedDispatcher = onBackPressedDispatcher,
     saveableStateRegistry = savedStateRegistry,
     uiConfigurations = uiConfigurations,
-    provider = provider,
+    widgetSystem = widgetSystem,
     onEndChanges = {
       val newSnapshot = createSnapshot()
 

--- a/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/WidgetValue.kt
+++ b/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/WidgetValue.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.testing
 
 import app.cash.redwood.Modifier
 import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.WidgetSystem
 
 /**
  * A widget that's implemented as a value class, appropriate for use in tests.
@@ -31,7 +32,7 @@ public interface WidgetValue {
   public val childrenLists: List<List<WidgetValue>>
     get() = listOf()
 
-  public fun <W : Any> toWidget(provider: Widget.Provider<W>): Widget<W>
+  public fun <W : Any> toWidget(widgetSystem: WidgetSystem<W>): Widget<W>
 }
 
 /**

--- a/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/toChangeList.kt
+++ b/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/toChangeList.kt
@@ -29,7 +29,7 @@ public fun List<WidgetValue>.toChangeList(
 ): SnapshotChangeList {
   val bridge = factory.create(json)
   for ((index, child) in withIndex()) {
-    bridge.root.insert(index, child.toWidget(bridge.provider))
+    bridge.root.insert(index, child.toWidget(bridge.widgetSystem))
   }
   return SnapshotChangeList(bridge.getChangesOrNull() ?: emptyList())
 }

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
@@ -46,7 +46,7 @@ import com.example.redwood.testing.compose.Text
 import com.example.redwood.testing.widget.TestSchemaProtocolFactory
 import com.example.redwood.testing.widget.TestSchemaTester
 import com.example.redwood.testing.widget.TestSchemaTestingWidgetFactory
-import com.example.redwood.testing.widget.TestSchemaWidgetFactories
+import com.example.redwood.testing.widget.TestSchemaWidgetSystem
 import com.example.redwood.testing.widget.TextValue
 import kotlin.test.Test
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -132,12 +132,12 @@ class ViewTreesTest {
     assertThat(protocolChanges).isEqualTo(expected)
 
     // Ensure when the changes are applied with the widget protocol we get equivalent values.
-    val mutableFactories = TestSchemaWidgetFactories(
+    val widgetSystem = TestSchemaWidgetSystem(
       TestSchema = TestSchemaTestingWidgetFactory(),
       RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
       RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
-    val protocolNodes = TestSchemaProtocolFactory(mutableFactories)
+    val protocolNodes = TestSchemaProtocolFactory(widgetSystem)
     val widgetContainer = MutableListChildren<WidgetValue>()
     val widgetBridge = ProtocolBridge(widgetContainer, protocolNodes) {
       throw AssertionError()

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/WidgetValueTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/WidgetValueTest.kt
@@ -17,7 +17,7 @@ package app.cash.redwood.testing
 
 import app.cash.redwood.Modifier
 import app.cash.redwood.widget.Widget
-import app.cash.redwood.widget.Widget.Provider
+import app.cash.redwood.widget.WidgetSystem
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
@@ -67,7 +67,7 @@ class WidgetValueTest {
     override val modifier: Modifier = Modifier,
     override val childrenLists: List<List<WidgetValue>> = listOf(),
   ) : WidgetValue {
-    override fun <W : Any> toWidget(provider: Provider<W>): Widget<W> {
+    override fun <W : Any> toWidget(widgetSystem: WidgetSystem<W>): Widget<W> {
       throw AssertionError()
     }
   }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/codegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/codegen.kt
@@ -65,7 +65,7 @@ internal fun SchemaSet.generateFileSpecs(type: CodegenType): List<FileSpec> {
       }
 
       Widget -> {
-        add(generateWidgetFactories(this@generateFileSpecs))
+        add(generateWidgetSystem(this@generateFileSpecs))
         add(generateWidgetFactory(schema))
         for (widget in schema.widgets) {
           add(generateWidget(schema, widget))

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/composeGeneration.kt
@@ -173,7 +173,7 @@ internal fun generateComposable(
           addStatement(
             "%M<%T, %T, %T>(%L)",
             RedwoodCompose.RedwoodComposeNode,
-            schema.getWidgetFactoryProviderType().parameterizedBy(ANY),
+            schema.getWidgetFactoryOwnerType().parameterizedBy(ANY),
             widgetType,
             ANY,
             arguments.joinToCode(",\n", "\n", ",\n"),

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -39,7 +39,7 @@ import com.squareup.kotlinpoet.joinToCode
 /*
 @ObjCName("ExampleProtocolFactory", exact = true)
 public class ExampleProtocolFactory<W : Any>(
-  private val provider: ExampleWidgetFactoryProvider<W>,
+  private val widgetSystem: ExampleWidgetSystem<W>,
   private val json: Json = Json.Default,
   private val mismatchHandler: ProtocolMismatchHandler = ProtocolMismatchHandler.Throwing,
 ) : GeneratedProtocolFactory<W> {
@@ -70,7 +70,7 @@ internal fun generateProtocolFactory(
   schemaSet: ProtocolSchemaSet,
 ): FileSpec {
   val schema = schemaSet.schema
-  val provider = schema.getWidgetFactoryProviderType().parameterizedBy(typeVariableW)
+  val widgetSystem = schema.getWidgetSystemType().parameterizedBy(typeVariableW)
   val type = schema.protocolFactoryType()
   return FileSpec.builder(type)
     .addAnnotation(suppressDeprecations)
@@ -87,7 +87,7 @@ internal fun generateProtocolFactory(
         )
         .primaryConstructor(
           FunSpec.constructorBuilder()
-            .addParameter("provider", provider)
+            .addParameter("widgetSystem", widgetSystem)
             .addParameter(
               ParameterSpec.builder("json", KotlinxSerialization.Json)
                 .defaultValue("%T", KotlinxSerialization.JsonDefault)
@@ -101,8 +101,8 @@ internal fun generateProtocolFactory(
             .build(),
         )
         .addProperty(
-          PropertySpec.builder("provider", provider, PRIVATE)
-            .initializer("provider")
+          PropertySpec.builder("widgetSystem", widgetSystem, PRIVATE)
+            .initializer("widgetSystem")
             .build(),
         )
         .addProperty(
@@ -129,7 +129,7 @@ internal fun generateProtocolFactory(
               for (dependency in schemaSet.all.sortedBy { it.widgets.firstOrNull()?.tag ?: 0 }) {
                 for (widget in dependency.widgets.sortedBy { it.tag }) {
                   addStatement(
-                    "%L -> %T(provider.%N.%N(), json, mismatchHandler)",
+                    "%L -> %T(widgetSystem.%N.%N(), json, mismatchHandler)",
                     widget.tag,
                     dependency.protocolNodeType(widget, schema),
                     dependency.type.flatName,

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -109,12 +109,12 @@ internal fun Schema.widgetValueType(widget: Widget): ClassName {
   return ClassName(widgetPackage(), "${widget.type.flatName}Value")
 }
 
-internal fun Schema.getWidgetFactoryProviderType(): ClassName {
-  return ClassName(widgetPackage(), "${type.flatName}WidgetFactoryProvider")
+internal fun Schema.getWidgetFactoryOwnerType(): ClassName {
+  return ClassName(widgetPackage(), "${type.flatName}WidgetFactoryOwner")
 }
 
-internal fun Schema.getWidgetFactoriesType(): ClassName {
-  return ClassName(widgetPackage(), "${type.flatName}WidgetFactories")
+internal fun Schema.getWidgetSystemType(): ClassName {
+  return ClassName(widgetPackage(), "${type.flatName}WidgetSystem")
 }
 
 internal fun Schema.widgetPackage(host: Schema? = null): String {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -78,7 +78,8 @@ internal object RedwoodWidget {
   val Widget = ClassName("app.cash.redwood.widget", "Widget")
   val WidgetChildren = Widget.nestedClass("Children")
   val WidgetChildrenOfW = WidgetChildren.parameterizedBy(typeVariableW)
-  val WidgetProvider = Widget.nestedClass("Provider")
+  val WidgetSystem = ClassName("app.cash.redwood.widget", "WidgetSystem")
+  val WidgetFactoryOwner = ClassName("app.cash.redwood.widget", "WidgetFactoryOwner")
   val MutableListChildren = ClassName("app.cash.redwood.widget", "MutableListChildren")
 }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseView.kt
@@ -41,6 +41,8 @@ public interface TreehouseView<W : Any> : RedwoodView<W> {
     public fun performSave(id: String)
   }
 
+  // TODO Rename this type to something else, along with ProtocolFactory which needs a rewrite
+  //  to behave more like the guest-side ProtocolBridge and its companion.
   @ObjCName("TreehouseViewWidgetSystem", exact = true)
   public fun interface WidgetSystem<W : Any> {
     /** Returns a widget factory for encoding and decoding changes to the contents of [view]. */

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -38,10 +38,6 @@ public interface Widget<W : Any> {
    */
   public var modifier: Modifier
 
-  /** Marker interface for types whose properties expose factories of [Widget]s. */
-  @Suppress("unused") // This type parameter used to match against other types like Children.
-  public interface Provider<W : Any>
-
   /**
    * An interface for manipulating a widget's list of children.
    *

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/WidgetFactoryOwner.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/WidgetFactoryOwner.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.widget
+
+import app.cash.redwood.RedwoodCodegenApi
+
+/**
+ * Marker interface for types with a property that exposes a factory for a schema.
+ *
+ * @suppress For generated code usage only.
+ */
+@RedwoodCodegenApi
+public interface WidgetFactoryOwner<W : Any>

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/WidgetSystem.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/WidgetSystem.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.widget
+
+/**
+ * Marker interface for types whose properties expose factories for a schema and all its
+ * transitive dependencies.
+ */
+public interface WidgetSystem<W : Any>

--- a/samples/counter/android-composeui/src/main/kotlin/com/example/redwood/counter/android/composeui/MainActivity.kt
+++ b/samples/counter/android-composeui/src/main/kotlin/com/example/redwood/counter/android/composeui/MainActivity.kt
@@ -23,20 +23,20 @@ import app.cash.redwood.layout.composeui.ComposeUiRedwoodLayoutWidgetFactory
 import com.example.redwood.counter.composeui.ComposeUiWidgetFactory
 import com.example.redwood.counter.composeui.CounterTheme
 import com.example.redwood.counter.presenter.Counter
-import com.example.redwood.counter.widget.SchemaWidgetFactories
+import com.example.redwood.counter.widget.SchemaWidgetSystem
 
 class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val factories = SchemaWidgetFactories(
+    val widgetSystem = SchemaWidgetSystem(
       Schema = ComposeUiWidgetFactory,
       RedwoodLayout = ComposeUiRedwoodLayoutWidgetFactory(),
     )
 
     setContent {
       CounterTheme {
-        RedwoodContent(factories) {
+        RedwoodContent(widgetSystem) {
           Counter()
         }
       }

--- a/samples/counter/android-views/src/main/kotlin/com/example/redwood/counter/android/views/MainActivity.kt
+++ b/samples/counter/android-views/src/main/kotlin/com/example/redwood/counter/android/views/MainActivity.kt
@@ -22,7 +22,7 @@ import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.layout.view.ViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.widget.RedwoodLayout
 import com.example.redwood.counter.presenter.Counter
-import com.example.redwood.counter.widget.SchemaWidgetFactories
+import com.example.redwood.counter.widget.SchemaWidgetSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 
@@ -38,7 +38,7 @@ class MainActivity : AppCompatActivity() {
     val composition = RedwoodComposition(
       scope = scope,
       view = redwoodView,
-      provider = SchemaWidgetFactories(
+      widgetSystem = SchemaWidgetSystem(
         Schema = AndroidWidgetFactory(this),
         RedwoodLayout = ViewRedwoodLayoutWidgetFactory(this),
       ),

--- a/samples/counter/browser/src/commonMain/kotlin/com/example/redwood/counter/browser/main.kt
+++ b/samples/counter/browser/src/commonMain/kotlin/com/example/redwood/counter/browser/main.kt
@@ -20,7 +20,7 @@ import app.cash.redwood.compose.WindowAnimationFrameClock
 import app.cash.redwood.layout.dom.HTMLElementRedwoodLayoutWidgetFactory
 import app.cash.redwood.widget.asRedwoodView
 import com.example.redwood.counter.presenter.Counter
-import com.example.redwood.counter.widget.SchemaWidgetFactories
+import com.example.redwood.counter.widget.SchemaWidgetSystem
 import kotlinx.browser.document
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -34,7 +34,7 @@ fun main() {
   val composition = RedwoodComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
     view = content.asRedwoodView(),
-    provider = SchemaWidgetFactories(
+    widgetSystem = SchemaWidgetSystem(
       Schema = HtmlWidgetFactory(document),
       RedwoodLayout = HTMLElementRedwoodLayoutWidgetFactory(document),
     ),

--- a/samples/counter/desktop-composeui/src/main/kotlin/com/example/redwood/counter/desktop/main.kt
+++ b/samples/counter/desktop-composeui/src/main/kotlin/com/example/redwood/counter/desktop/main.kt
@@ -28,10 +28,10 @@ import app.cash.redwood.layout.composeui.ComposeUiRedwoodLayoutWidgetFactory
 import com.example.redwood.counter.composeui.ComposeUiWidgetFactory
 import com.example.redwood.counter.composeui.CounterTheme
 import com.example.redwood.counter.presenter.Counter
-import com.example.redwood.counter.widget.SchemaWidgetFactories
+import com.example.redwood.counter.widget.SchemaWidgetSystem
 
 fun main() {
-  val factories = SchemaWidgetFactories(
+  val widgetSystem = SchemaWidgetSystem(
     Schema = ComposeUiWidgetFactory,
     RedwoodLayout = ComposeUiRedwoodLayoutWidgetFactory(),
   )
@@ -43,7 +43,7 @@ fun main() {
       state = rememberWindowState(width = 300.dp, height = 300.dp),
     ) {
       CounterTheme {
-        RedwoodContent(factories, modifier = Modifier.padding(16.dp)) {
+        RedwoodContent(widgetSystem, modifier = Modifier.padding(16.dp)) {
           Counter()
         }
       }

--- a/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
+++ b/samples/counter/ios-shared/src/commonMain/kotlin/com/example/redwood/counter/ios/CounterViewControllerDelegate.kt
@@ -20,7 +20,7 @@ import app.cash.redwood.compose.RedwoodComposition
 import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.widget.RedwoodUIView
 import com.example.redwood.counter.presenter.Counter
-import com.example.redwood.counter.widget.SchemaWidgetFactories
+import com.example.redwood.counter.widget.SchemaWidgetSystem
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.plus
@@ -36,7 +36,7 @@ class CounterViewControllerDelegate(
     val composition = RedwoodComposition(
       scope = scope,
       view = RedwoodUIView(root),
-      provider = SchemaWidgetFactories(
+      widgetSystem = SchemaWidgetSystem(
         Schema = IosWidgetFactory,
         RedwoodLayout = UIViewRedwoodLayoutWidgetFactory(),
       ),

--- a/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
@@ -52,7 +52,7 @@ import com.example.redwood.emojisearch.composeui.EmojiSearchTheme
 import com.example.redwood.emojisearch.launcher.EmojiSearchAppSpec
 import com.example.redwood.emojisearch.treehouse.EmojiSearchPresenter
 import com.example.redwood.emojisearch.widget.EmojiSearchProtocolFactory
-import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
+import com.example.redwood.emojisearch.widget.EmojiSearchWidgetSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -84,7 +84,7 @@ class EmojiSearchActivity : ComponentActivity() {
 
     val widgetSystem = WidgetSystem { json, protocolMismatchHandler ->
       EmojiSearchProtocolFactory<@Composable () -> Unit>(
-        provider = EmojiSearchWidgetFactories(
+        widgetSystem = EmojiSearchWidgetSystem(
           EmojiSearch = ComposeUiEmojiSearchWidgetFactory(imageLoader),
           RedwoodLayout = ComposeUiRedwoodLayoutWidgetFactory(),
           RedwoodLazyLayout = ComposeUiRedwoodLazyLayoutWidgetFactory(),

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -42,7 +42,7 @@ import com.example.redwood.emojisearch.launcher.EmojiSearchAppSpec
 import com.example.redwood.emojisearch.treehouse.EmojiSearchPresenter
 import com.example.redwood.emojisearch.treehouse.emojiSearchSerializersModule
 import com.example.redwood.emojisearch.widget.EmojiSearchProtocolFactory
-import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
+import com.example.redwood.emojisearch.widget.EmojiSearchWidgetSystem
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.LENGTH_INDEFINITE
 import kotlinx.coroutines.CoroutineScope
@@ -70,7 +70,7 @@ class EmojiSearchActivity : ComponentActivity() {
 
     val widgetSystem = TreehouseView.WidgetSystem { json, protocolMismatchHandler ->
       EmojiSearchProtocolFactory(
-        provider = EmojiSearchWidgetFactories(
+        widgetSystem = EmojiSearchWidgetSystem(
           EmojiSearch = AndroidEmojiSearchWidgetFactory(context),
           RedwoodLayout = ViewRedwoodLayoutWidgetFactory(context),
           RedwoodLazyLayout = ViewRedwoodLazyLayoutWidgetFactory(context),

--- a/samples/emoji-search/browser/src/commonMain/kotlin/com/example/redwood/emojisearch/browser/main.kt
+++ b/samples/emoji-search/browser/src/commonMain/kotlin/com/example/redwood/emojisearch/browser/main.kt
@@ -23,7 +23,7 @@ import app.cash.redwood.widget.asRedwoodView
 import com.example.redwood.emojisearch.presenter.EmojiSearch
 import com.example.redwood.emojisearch.presenter.HttpClient
 import com.example.redwood.emojisearch.presenter.Navigator
-import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
+import com.example.redwood.emojisearch.widget.EmojiSearchWidgetSystem
 import kotlin.js.json
 import kotlinx.browser.document
 import kotlinx.browser.window
@@ -47,7 +47,7 @@ fun main() {
   val composition = RedwoodComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
     view = content.asRedwoodView(),
-    provider = EmojiSearchWidgetFactories(
+    widgetSystem = EmojiSearchWidgetSystem(
       EmojiSearch = HTMLElementEmojiSearchWidgetFactory(document),
       RedwoodLayout = HTMLElementRedwoodLayoutWidgetFactory(document),
       RedwoodLazyLayout = HTMLElementRedwoodLazyLayoutWidgetFactory(document),

--- a/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/main.kt
+++ b/samples/emoji-search/desktop-composeui/src/main/kotlin/com/example/redwood/emojisearch/desktop/main.kt
@@ -33,7 +33,7 @@ import coil3.serviceLoaderEnabled
 import com.example.redwood.emojisearch.composeui.ComposeUiEmojiSearchWidgetFactory
 import com.example.redwood.emojisearch.composeui.EmojiSearchTheme
 import com.example.redwood.emojisearch.presenter.EmojiSearch
-import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
+import com.example.redwood.emojisearch.widget.EmojiSearchWidgetSystem
 import okhttp3.OkHttpClient
 
 fun main() {
@@ -45,7 +45,7 @@ fun main() {
       add(OkHttpNetworkFetcherFactory(client))
     }
     .build()
-  val factories = EmojiSearchWidgetFactories(
+  val widgetSystem = EmojiSearchWidgetSystem(
     EmojiSearch = ComposeUiEmojiSearchWidgetFactory(imageLoader),
     RedwoodLayout = ComposeUiRedwoodLayoutWidgetFactory(),
     RedwoodLazyLayout = ComposeUiRedwoodLazyLayoutWidgetFactory(),
@@ -58,7 +58,7 @@ fun main() {
     ) {
       EmojiSearchTheme {
         Scaffold { contentPadding ->
-          RedwoodContent(factories, modifier = Modifier.padding(contentPadding)) {
+          RedwoodContent(widgetSystem, modifier = Modifier.padding(contentPadding)) {
             EmojiSearch(
               httpClient = httpClient,
               navigator = DesktopNavigator,

--- a/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
+++ b/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/exposed.kt
@@ -27,8 +27,8 @@ import app.cash.redwood.treehouse.TreehouseView
 import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import com.example.redwood.emojisearch.widget.EmojiSearchProtocolFactory
-import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactories
 import com.example.redwood.emojisearch.widget.EmojiSearchWidgetFactory
+import com.example.redwood.emojisearch.widget.EmojiSearchWidgetSystem
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import okio.Closeable
@@ -42,8 +42,8 @@ fun exposedTypes(
   treehouseUIView: TreehouseUIView,
   uiViewRedwoodLayoutWidgetFactory: UIViewRedwoodLayoutWidgetFactory,
   uiViewRedwoodLazyLayoutWidgetFactory: UIViewRedwoodLazyLayoutWidgetFactory,
-  widgetSystem: WidgetSystem<*>,
-  widgetFactories: EmojiSearchWidgetFactories<*>,
+  treehouseWidgetSystem: WidgetSystem<*>,
+  widgetSystem: EmojiSearchWidgetSystem<*>,
 ) {
   throw AssertionError()
 }

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -37,7 +37,7 @@ class EmojiSearchViewController : UIViewController, EmojiSearchEventListener {
     override func loadView() {
         let emojiSearchLauncher = EmojiSearchLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
         let treehouseApp = emojiSearchLauncher.createTreehouseApp(listener: self)
-        let widgetSystem = EmojiSearchWidgetSystem(treehouseApp: treehouseApp)
+        let widgetSystem = EmojiSearchTreehouseWidgetSystem(treehouseApp: treehouseApp)
         let treehouseView = TreehouseUIView(widgetSystem: widgetSystem)
         let content = treehouseApp.createContent(
             source: EmojiSearchContent(),
@@ -100,7 +100,7 @@ class EmojiSearchContent : TreehouseContentSource {
     }
 }
 
-class EmojiSearchWidgetSystem : TreehouseViewWidgetSystem {
+class EmojiSearchTreehouseWidgetSystem : TreehouseViewWidgetSystem {
     let treehouseApp: TreehouseApp<EmojiSearchPresenter>
 
     init(treehouseApp: TreehouseApp<EmojiSearchPresenter>) {
@@ -112,7 +112,7 @@ class EmojiSearchWidgetSystem : TreehouseViewWidgetSystem {
         protocolMismatchHandler: ProtocolMismatchHandler
     ) -> ProtocolFactory {
         return EmojiSearchProtocolFactory<UIView>(
-            provider: EmojiSearchWidgetFactories<UIView>(
+            widgetSystem: EmojiSearchWidgetSystem<UIView>(
                 EmojiSearch: IosEmojiSearchWidgetFactory(treehouseApp: treehouseApp, widgetSystem: self),
                 RedwoodLayout: UIViewRedwoodLayoutWidgetFactory(),
                 RedwoodLazyLayout: UIViewRedwoodLazyLayoutWidgetFactory()

--- a/test-app/android-views/src/main/kotlin/com/example/redwood/testing/android/views/TestAppActivity.kt
+++ b/test-app/android-views/src/main/kotlin/com/example/redwood/testing/android/views/TestAppActivity.kt
@@ -38,7 +38,7 @@ import app.cash.zipline.loader.withDevelopmentServerPush
 import com.example.redwood.testing.launcher.TestAppSpec
 import com.example.redwood.testing.treehouse.TestAppPresenter
 import com.example.redwood.testing.widget.TestSchemaProtocolFactory
-import com.example.redwood.testing.widget.TestSchemaWidgetFactories
+import com.example.redwood.testing.widget.TestSchemaWidgetSystem
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.LENGTH_INDEFINITE
 import kotlinx.coroutines.CoroutineScope
@@ -67,7 +67,7 @@ class TestAppActivity : ComponentActivity() {
         json: Json,
         protocolMismatchHandler: ProtocolMismatchHandler,
       ) = TestSchemaProtocolFactory(
-        provider = TestSchemaWidgetFactories(
+        widgetSystem = TestSchemaWidgetSystem(
           TestSchema = AndroidTestSchemaWidgetFactory(context),
           RedwoodLayout = ViewRedwoodLayoutWidgetFactory(context),
           RedwoodLazyLayout = ViewRedwoodLazyLayoutWidgetFactory(context),

--- a/test-app/browser/src/commonMain/kotlin/com/example/redwood/testing/browser/main.kt
+++ b/test-app/browser/src/commonMain/kotlin/com/example/redwood/testing/browser/main.kt
@@ -23,7 +23,7 @@ import app.cash.redwood.widget.asRedwoodView
 import com.example.redwood.testing.presenter.HttpClient
 import com.example.redwood.testing.presenter.TestApp
 import com.example.redwood.testing.presenter.TestContext
-import com.example.redwood.testing.widget.TestSchemaWidgetFactories
+import com.example.redwood.testing.widget.TestSchemaWidgetSystem
 import kotlin.js.json
 import kotlinx.browser.document
 import kotlinx.browser.window
@@ -41,7 +41,7 @@ fun main() {
   val composition = RedwoodComposition(
     scope = GlobalScope + WindowAnimationFrameClock,
     view = content.asRedwoodView(),
-    provider = TestSchemaWidgetFactories(
+    widgetSystem = TestSchemaWidgetSystem(
       TestSchema = HtmlWidgetFactory(document),
       RedwoodLayout = HTMLElementRedwoodLayoutWidgetFactory(document),
       RedwoodLazyLayout = HTMLElementRedwoodLazyLayoutWidgetFactory(document),

--- a/test-app/ios-shared/src/commonMain/kotlin/com/example/redwood/testing/ios/exposed.kt
+++ b/test-app/ios-shared/src/commonMain/kotlin/com/example/redwood/testing/ios/exposed.kt
@@ -28,8 +28,8 @@ import app.cash.redwood.treehouse.TreehouseView.WidgetSystem
 import app.cash.redwood.treehouse.bindWhenReady
 import com.example.redwood.testing.treehouse.TestAppPresenter
 import com.example.redwood.testing.widget.TestSchemaProtocolFactory
-import com.example.redwood.testing.widget.TestSchemaWidgetFactories
 import com.example.redwood.testing.widget.TestSchemaWidgetFactory
+import com.example.redwood.testing.widget.TestSchemaWidgetSystem
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import okio.Closeable
@@ -44,8 +44,8 @@ fun exposedTypes(
   treehouseUIView: TreehouseUIView,
   uiViewRedwoodLayoutWidgetFactory: UIViewRedwoodLayoutWidgetFactory,
   uiViewRedwoodLazyLayoutWidgetFactory: UIViewRedwoodLazyLayoutWidgetFactory,
-  widgetSystem: WidgetSystem<*>,
-  widgetFactories: TestSchemaWidgetFactories<*>,
+  treehouseWidgetSystem: WidgetSystem<*>,
+  widgetSystem: TestSchemaWidgetSystem<*>,
 ) {
   throw AssertionError()
 }

--- a/test-app/ios-uikit/TestApp/TestAppViewController.swift
+++ b/test-app/ios-uikit/TestApp/TestAppViewController.swift
@@ -33,7 +33,7 @@ class TestAppViewController : UIViewController {
 
         let testAppLauncher = TestAppLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
         let treehouseApp = testAppLauncher.createTreehouseApp()
-        let widgetSystem = TestSchemaWidgetSystem()
+        let widgetSystem = TestSchemaTreehouseWidgetSystem()
         let treehouseView = TreehouseUIView(widgetSystem: widgetSystem)
         let content = treehouseApp.createContent(
             source: TestAppContent(),
@@ -59,13 +59,13 @@ class TestAppContent : TreehouseContentSource {
     }
 }
 
-class TestSchemaWidgetSystem : TreehouseViewWidgetSystem {
+class TestSchemaTreehouseWidgetSystem : TreehouseViewWidgetSystem {
     func widgetFactory(
         json: Kotlinx_serialization_jsonJson,
         protocolMismatchHandler: ProtocolMismatchHandler
     ) -> ProtocolFactory {
         return TestSchemaProtocolFactory<UIView>(
-            provider: TestSchemaWidgetFactories<UIView>(
+            widgetSystem: TestSchemaWidgetSystem<UIView>(
                 TestSchema: IosTestSchemaWidgetFactory(),
                 RedwoodLayout: UIViewRedwoodLayoutWidgetFactory(),
                 RedwoodLazyLayout: UIViewRedwoodLazyLayoutWidgetFactory()


### PR DESCRIPTION
In order to support global modifiers, we need make changes to these types in a way that does not work with their current setup. In anticipation of that, rename them to give distinct behavior.

🤞 this is the last change pulled out/ahead of #1084

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
