### PR TITLE
In UIViewLazyList, wrap insert/deleteRows calls in UIView.performWithoutAnimation blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Fixed:
 - The `View` implementation of `Box` now applies start/end margins correctly in RTL, and does not crash if set before the native view was attached.
 - Fix the backgroundColor for `UIViewLazyList` to be transparent. This matches the behavior of the other `LazyList` platform implementations.
 - Fix `TreehouseUIView` to size itself according to the size of its subview.
-- In `UiViewLazyList`, added `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows` to improve animations.
+- In `UIViewLazyList`, adding `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows`, and wrapping changes in `UIView.performWithoutAnimation` blocks.
 
 
 ## [0.9.0] - 2024-02-28

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -82,20 +82,24 @@ internal open class UIViewLazyList(
     override fun insertRows(index: Int, count: Int) {
       // TODO(jwilson): pass a range somehow when 'count' is large?
       tableView.beginUpdates()
-      tableView.insertRowsAtIndexPaths(
-        (index until index + count).map { NSIndexPath.indexPathForItem(it.convert(), 0) },
-        UITableViewRowAnimationNone,
-      )
+      UIView.performWithoutAnimation {
+        tableView.insertRowsAtIndexPaths(
+          (index until index + count).map { NSIndexPath.indexPathForItem(it.convert(), 0) },
+          UITableViewRowAnimationNone,
+        )
+      }
       tableView.endUpdates()
     }
 
     override fun deleteRows(index: Int, count: Int) {
       // TODO(jwilson): pass a range somehow when 'count' is large?
       tableView.beginUpdates()
-      tableView.deleteRowsAtIndexPaths(
-        (index until index + count).map { NSIndexPath.indexPathForItem(it.convert(), 0) },
-        UITableViewRowAnimationNone,
-      )
+      UIView.performWithoutAnimation {
+        tableView.deleteRowsAtIndexPaths(
+          (index until index + count).map { NSIndexPath.indexPathForItem(it.convert(), 0) },
+          UITableViewRowAnimationNone,
+        )
+      }
       tableView.endUpdates()
     }
 


### PR DESCRIPTION
Follow-up to PR #1866

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
