### PR TITLE
Mark Yoga as unstable API, drop from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New:
 Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 - `onModifierChanged` callback in `Widget.Children` now receives the index and the `Widget` instance affected by the change.
+- The entire `redwood-yoga` artifact's public API has been annotated with an opt-in annotation indicating that it's only for Redwood internal use and is not stable.
 - Revert: Don't block touch events to non-subviews below a `Row`, `Column`, or `Box` in the iOS `UIView` implementation. This matches the behavior of the Android View and Compose UI implementations.
 - The generated "widget factories" type (e.g., `MySchemaWidgetFactories`) is now called a "widget system" (e.g., `MySchemaWidgetSystem`). Sometimes it was also referred to as a "provider" in parameter names. A `@Deprecated typealias` is generated for now, but will be removed in the future.
 

--- a/redwood-yoga/build.gradle
+++ b/redwood-yoga/build.gradle
@@ -26,3 +26,8 @@ spotless {
     targetExclude("src/**/kotlin/app/cash/redwood/yoga/internal/**")
   }
 }
+
+tasks.named("dokkaHtmlPartial") {
+  // Don't document this module as it's entirely implementation detail.
+  enabled = false
+}

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/Node.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/Node.kt
@@ -19,6 +19,7 @@ import app.cash.redwood.yoga.internal.YGNode
 import app.cash.redwood.yoga.internal.Yoga
 import app.cash.redwood.yoga.internal.enums.YGEdge
 
+@RedwoodYogaApi
 public class Node internal constructor(
   internal val native: YGNode,
 ) {

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/RedwoodYogaApi.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/RedwoodYogaApi.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.yoga
+
+/**
+ * Denote an API which should only be used by Redwood implementation details and is not considered
+ * stable across any version.
+ */
+@RedwoodYogaApi
+@RequiresOptIn("This API is unstable and for Redwood internal use only")
+public annotation class RedwoodYogaApi

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/enums.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/enums.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.yoga
 
 import kotlin.jvm.JvmInline
 
+@RedwoodYogaApi
 @JvmInline
 public value class Direction private constructor(private val ordinal: Int) {
 
@@ -38,6 +39,7 @@ public value class Direction private constructor(private val ordinal: Int) {
  * The direction children items are placed inside the flex container, it determines the
  * direction of the main axis (and the cross axis, perpendicular to the main axis).
  */
+@RedwoodYogaApi
 @JvmInline
 public value class FlexDirection private constructor(private val ordinal: Int) {
 
@@ -60,18 +62,21 @@ public value class FlexDirection private constructor(private val ordinal: Int) {
 /**
  * Returns `true` if this direction's main axis is horizontal.
  */
+@RedwoodYogaApi
 public val FlexDirection.isHorizontal: Boolean
   get() = this == FlexDirection.Row || this == FlexDirection.RowReverse
 
 /**
  * Returns `true` if this direction's main axis is vertical.
  */
+@RedwoodYogaApi
 public val FlexDirection.isVertical: Boolean
   get() = this == FlexDirection.Column || this == FlexDirection.ColumnReverse
 
 /**
  * This attribute controls the alignment along the main axis.
  */
+@RedwoodYogaApi
 @JvmInline
 public value class JustifyContent private constructor(private val ordinal: Int) {
 
@@ -98,6 +103,7 @@ public value class JustifyContent private constructor(private val ordinal: Int) 
 /**
  * This attribute controls the alignment along the cross axis.
  */
+@RedwoodYogaApi
 @JvmInline
 public value class AlignItems private constructor(private val ordinal: Int) {
 
@@ -126,6 +132,7 @@ public value class AlignItems private constructor(private val ordinal: Int) {
  * other than [AlignSelf.Auto], the cross axis alignment is
  * overridden for this child.
  */
+@RedwoodYogaApi
 @JvmInline
 public value class AlignSelf private constructor(private val ordinal: Int) {
 

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/measure.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/measure.kt
@@ -19,6 +19,7 @@ import app.cash.redwood.yoga.internal.Yoga
 import dev.drewhamilton.poko.Poko
 import kotlin.jvm.JvmInline
 
+@RedwoodYogaApi
 public fun interface MeasureCallback {
   public fun measure(
     node: Node,
@@ -29,6 +30,7 @@ public fun interface MeasureCallback {
   ): Size
 }
 
+@RedwoodYogaApi
 @Poko public class Size(
   public val width: Float,
   public val height: Float,
@@ -38,6 +40,7 @@ public fun interface MeasureCallback {
   }
 }
 
+@RedwoodYogaApi
 @JvmInline
 public value class MeasureMode private constructor(private val ordinal: Int) {
 


### PR DESCRIPTION
This is a published module, but the API it exposes is implementation detail for our modules.

The experimental annotation will also exclude it from future API dumps.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
