### PR TITLE
API dump published modules

### DIFF
--- a/build-support/build.gradle
+++ b/build-support/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   implementation libs.spotlessPlugin
   implementation libs.androidGradlePlugin
   implementation libs.jetbrains.compose.gradlePlugin
+  implementation libs.kotlinx.binaryCompatibilityValidator
   implementation libs.zipline
 
   // Expose the generated version catalog API to the plugin.

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -20,6 +20,7 @@ import com.android.build.gradle.BaseExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
+import kotlinx.validation.ApiValidationExtension
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Action
 import org.gradle.api.JavaVersion
@@ -385,6 +386,16 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       check(explicit) {
         """Project "${project.path}" has unknown Kotlin plugin which needs explicit API tracking"""
       }
+    }
+
+    // Published modules should track their public API.
+    project.plugins.apply("org.jetbrains.kotlinx.binary-compatibility-validator")
+    val apiValidation = project.extensions.getByName("apiValidation") as ApiValidationExtension
+    apiValidation.apply {
+      nonPublicMarkers += listOf(
+        // The yoga module is an implementation detail of our layouts.
+        "app.cash.redwood.yoga.RedwoodYogaApi",
+      )
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
+kotlinx-binaryCompatibilityValidator = "org.jetbrains.kotlinx:binary-compatibility-validator:0.14.0"
+
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 

--- a/redwood-compose/api/android/redwood-compose.api
+++ b/redwood-compose/api/android/redwood-compose.api
@@ -1,0 +1,87 @@
+public final class app/cash/redwood/compose/AndroidUiDispatcher : kotlinx/coroutines/CoroutineDispatcher {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/compose/AndroidUiDispatcher$Companion;
+	public synthetic fun <init> (Landroid/view/Choreographer;Landroid/os/Handler;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun dispatch (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Runnable;)V
+	public final fun getChoreographer ()Landroid/view/Choreographer;
+	public final fun getFrameClock ()Landroidx/compose/runtime/MonotonicFrameClock;
+}
+
+public final class app/cash/redwood/compose/AndroidUiDispatcher$Companion {
+	public final fun getMain ()Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class app/cash/redwood/compose/AndroidUiFrameClock : androidx/compose/runtime/MonotonicFrameClock {
+	public static final field $stable I
+	public fun <init> (Landroid/view/Choreographer;)V
+	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
+	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
+	public fun plus (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
+	public fun withFrameNanos (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class app/cash/redwood/compose/BackHandlerKt {
+	public static final fun BackHandler (ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun getCurrent (Lapp/cash/redwood/ui/OnBackPressedDispatcher$Companion;Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/OnBackPressedDispatcher;
+	public static final fun getLocalOnBackPressedDispatcher ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class app/cash/redwood/compose/Node {
+}
+
+public abstract interface class app/cash/redwood/compose/RedwoodApplier {
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
+	public abstract fun recordChanged (Lapp/cash/redwood/widget/Widget;)V
+}
+
+public final class app/cash/redwood/compose/RedwoodComposeContent {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/compose/RedwoodComposeContent$Companion;
+	public fun <init> ()V
+	public final fun Children (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class app/cash/redwood/compose/RedwoodComposeContent$Companion {
+	public final fun getInstance ()Lapp/cash/redwood/compose/RedwoodComposeContent;
+}
+
+public abstract interface class app/cash/redwood/compose/RedwoodComposition {
+	public abstract fun cancel ()V
+	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class app/cash/redwood/compose/RedwoodCompositionKt {
+	public static final fun RedwoodComposeNode (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
+	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
+	public static synthetic fun RedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/compose/RedwoodComposition;
+	public static synthetic fun RedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/compose/RedwoodComposition;
+}
+
+public final class app/cash/redwood/compose/UiConfigurationKt {
+	public static final fun getCurrent (Lapp/cash/redwood/ui/UiConfiguration$Companion;Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/UiConfiguration;
+	public static final fun getLocalUiConfiguration ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class app/cash/redwood/compose/WidgetNode : app/cash/redwood/compose/Node {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/compose/WidgetNode$Companion;
+	public fun <init> (Lapp/cash/redwood/compose/RedwoodApplier;Lapp/cash/redwood/widget/Widget;)V
+	public final fun getContainer ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun getIndex ()I
+	public final fun getWidget ()Lapp/cash/redwood/widget/Widget;
+	public final fun recordChanged ()V
+	public final fun setContainer (Lapp/cash/redwood/widget/Widget$Children;)V
+	public final fun setIndex (I)V
+}
+
+public final class app/cash/redwood/compose/WidgetNode$Companion {
+	public final fun getSetModifiers ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class app/cash/redwood/compose/WidgetVersionKt {
+	public static final fun getLocalWidgetVersion ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getWidgetVersion (Landroidx/compose/runtime/Composer;I)I
+}
+

--- a/redwood-compose/api/jvm/redwood-compose.api
+++ b/redwood-compose/api/jvm/redwood-compose.api
@@ -1,0 +1,64 @@
+public final class app/cash/redwood/compose/BackHandlerKt {
+	public static final fun BackHandler (ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun getCurrent (Lapp/cash/redwood/ui/OnBackPressedDispatcher$Companion;Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/OnBackPressedDispatcher;
+	public static final fun getLocalOnBackPressedDispatcher ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class app/cash/redwood/compose/Node {
+}
+
+public abstract interface class app/cash/redwood/compose/RedwoodApplier {
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
+	public abstract fun recordChanged (Lapp/cash/redwood/widget/Widget;)V
+}
+
+public final class app/cash/redwood/compose/RedwoodComposeContent {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/compose/RedwoodComposeContent$Companion;
+	public fun <init> ()V
+	public final fun Children (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class app/cash/redwood/compose/RedwoodComposeContent$Companion {
+	public final fun getInstance ()Lapp/cash/redwood/compose/RedwoodComposeContent;
+}
+
+public abstract interface class app/cash/redwood/compose/RedwoodComposition {
+	public abstract fun cancel ()V
+	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class app/cash/redwood/compose/RedwoodCompositionKt {
+	public static final fun RedwoodComposeNode (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
+	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
+	public static synthetic fun RedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/compose/RedwoodComposition;
+	public static synthetic fun RedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/compose/RedwoodComposition;
+}
+
+public final class app/cash/redwood/compose/UiConfigurationKt {
+	public static final fun getCurrent (Lapp/cash/redwood/ui/UiConfiguration$Companion;Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/UiConfiguration;
+	public static final fun getLocalUiConfiguration ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class app/cash/redwood/compose/WidgetNode : app/cash/redwood/compose/Node {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/compose/WidgetNode$Companion;
+	public fun <init> (Lapp/cash/redwood/compose/RedwoodApplier;Lapp/cash/redwood/widget/Widget;)V
+	public final fun getContainer ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun getIndex ()I
+	public final fun getWidget ()Lapp/cash/redwood/widget/Widget;
+	public final fun recordChanged ()V
+	public final fun setContainer (Lapp/cash/redwood/widget/Widget$Children;)V
+	public final fun setIndex (I)V
+}
+
+public final class app/cash/redwood/compose/WidgetNode$Companion {
+	public final fun getSetModifiers ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class app/cash/redwood/compose/WidgetVersionKt {
+	public static final fun getLocalWidgetVersion ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getWidgetVersion (Landroidx/compose/runtime/Composer;I)I
+}
+

--- a/redwood-composeui/api/android/redwood-composeui.api
+++ b/redwood-composeui/api/android/redwood-composeui.api
@@ -1,0 +1,8 @@
+public final class app/cash/redwood/composeui/RedwoodContentKt {
+	public static final fun RedwoodContent (Lapp/cash/redwood/widget/WidgetSystem;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class app/cash/redwood/composeui/insetsAndroid {
+	public static final fun safeAreaInsets (Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/Margin;
+}
+

--- a/redwood-composeui/api/jvm/redwood-composeui.api
+++ b/redwood-composeui/api/jvm/redwood-composeui.api
@@ -1,0 +1,8 @@
+public final class app/cash/redwood/composeui/RedwoodContentKt {
+	public static final fun RedwoodContent (Lapp/cash/redwood/widget/WidgetSystem;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class app/cash/redwood/composeui/insetsJvm {
+	public static final fun safeAreaInsets (Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/Margin;
+}
+

--- a/redwood-gradle-plugin/api/redwood-gradle-plugin.api
+++ b/redwood-gradle-plugin/api/redwood-gradle-plugin.api
@@ -1,0 +1,86 @@
+public abstract interface class app/cash/redwood/gradle/RedwoodComposeExtension {
+	public abstract fun dangerZone (Lorg/gradle/api/Action;)V
+	public abstract fun getKotlinCompilerPlugin ()Lorg/gradle/api/provider/Property;
+}
+
+public abstract interface class app/cash/redwood/gradle/RedwoodComposeExtension$DangerZone {
+	public abstract fun enableMetrics ()V
+	public abstract fun enableReports ()V
+}
+
+public final class app/cash/redwood/gradle/RedwoodComposeGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+
+public final class app/cash/redwood/gradle/RedwoodComposePlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+	public fun applyToCompilation (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Lorg/gradle/api/provider/Provider;
+	public fun getCompilerPluginId ()Ljava/lang/String;
+	public fun getPluginArtifact ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun getPluginArtifactForNative ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun isApplicable (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
+}
+
+public final class app/cash/redwood/gradle/RedwoodComposeProtocolGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+
+public abstract class app/cash/redwood/gradle/RedwoodGeneratorExtension : app/cash/redwood/gradle/RedwoodSchemaExtension {
+	public fun <init> ()V
+	public abstract fun getSource ()Lorg/gradle/api/provider/Property;
+}
+
+public abstract class app/cash/redwood/gradle/RedwoodGeneratorPlugin : org/gradle/api/Plugin {
+	public fun <init> (Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;)V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public final class app/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy : java/lang/Enum {
+	public static final field Compose Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static final field ComposeProtocol Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static final field Modifiers Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static final field Testing Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static final field Widget Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static final field WidgetProtocol Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static fun values ()[Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+}
+
+public final class app/cash/redwood/gradle/RedwoodLintPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public final class app/cash/redwood/gradle/RedwoodModifiersGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+
+public abstract class app/cash/redwood/gradle/RedwoodSchemaExtension {
+	public fun <init> ()V
+	public abstract fun getApiTracking ()Lorg/gradle/api/provider/Property;
+	public abstract fun getType ()Lorg/gradle/api/provider/Property;
+}
+
+public final class app/cash/redwood/gradle/RedwoodSchemaPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public final class app/cash/redwood/gradle/RedwoodTestingGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+
+public final class app/cash/redwood/gradle/RedwoodWidgetGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+
+public final class app/cash/redwood/gradle/RedwoodWidgetProtocolGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+

--- a/redwood-layout-api/api/redwood-layout-api.api
+++ b/redwood-layout-api/api/redwood-layout-api.api
@@ -1,0 +1,130 @@
+public final class app/cash/redwood/layout/api/Constraint {
+	public static final field Companion Lapp/cash/redwood/layout/api/Constraint$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/layout/api/Constraint;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/layout/api/Constraint$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/layout/api/Constraint$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-wZ9MJrE (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-NlcmwgM (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/layout/api/Constraint$Companion {
+	public final fun getFill-jfchsNQ ()I
+	public final fun getWrap-jfchsNQ ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/layout/api/CrossAxisAlignment {
+	public static final field Companion Lapp/cash/redwood/layout/api/CrossAxisAlignment$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/layout/api/CrossAxisAlignment;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/layout/api/CrossAxisAlignment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/layout/api/CrossAxisAlignment$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-ZTU8t1M (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-9tyzA_o (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/layout/api/CrossAxisAlignment$Companion {
+	public final fun getCenter-eoX4IBc ()I
+	public final fun getEnd-eoX4IBc ()I
+	public final fun getStart-eoX4IBc ()I
+	public final fun getStretch-eoX4IBc ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/layout/api/MainAxisAlignment {
+	public static final field Companion Lapp/cash/redwood/layout/api/MainAxisAlignment$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/layout/api/MainAxisAlignment;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/layout/api/MainAxisAlignment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/layout/api/MainAxisAlignment$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-8E2bK0c (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-x5n47qk (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/layout/api/MainAxisAlignment$Companion {
+	public final fun getCenter-Ng1ngeI ()I
+	public final fun getEnd-Ng1ngeI ()I
+	public final fun getSpaceAround-Ng1ngeI ()I
+	public final fun getSpaceBetween-Ng1ngeI ()I
+	public final fun getSpaceEvenly-Ng1ngeI ()I
+	public final fun getStart-Ng1ngeI ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/layout/api/Overflow {
+	public static final field Companion Lapp/cash/redwood/layout/api/Overflow$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/layout/api/Overflow;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/layout/api/Overflow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/layout/api/Overflow$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-yYV8bQ4 (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-PeVkpMM (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/layout/api/Overflow$Companion {
+	public final fun getClip-Andb1w4 ()I
+	public final fun getScroll-Andb1w4 ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/redwood-layout-compose/api/redwood-layout-compose.api
+++ b/redwood-layout-compose/api/redwood-layout-compose.api
@@ -1,0 +1,51 @@
+public final class app/cash/redwood/layout/compose/BoxKt {
+	public static final fun Box-o2unFmY (IILapp/cash/redwood/ui/Margin;IILapp/cash/redwood/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract interface class app/cash/redwood/layout/compose/BoxScope {
+	public fun height-slHoOYc (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun horizontalAlignment-9tyzA_o (Lapp/cash/redwood/Modifier;I)Lapp/cash/redwood/Modifier;
+	public fun margin (Lapp/cash/redwood/Modifier;Lapp/cash/redwood/ui/Margin;)Lapp/cash/redwood/Modifier;
+	public fun size-j5SIcws (Lapp/cash/redwood/Modifier;DD)Lapp/cash/redwood/Modifier;
+	public fun verticalAlignment-9tyzA_o (Lapp/cash/redwood/Modifier;I)Lapp/cash/redwood/Modifier;
+	public fun width-slHoOYc (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+}
+
+public final class app/cash/redwood/layout/compose/ColumnKt {
+	public static final fun Column-n_TNbJ4 (IILapp/cash/redwood/ui/Margin;IIILapp/cash/redwood/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract interface class app/cash/redwood/layout/compose/ColumnScope {
+	public fun flex (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun grow (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun height-slHoOYc (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun horizontalAlignment-9tyzA_o (Lapp/cash/redwood/Modifier;I)Lapp/cash/redwood/Modifier;
+	public fun margin (Lapp/cash/redwood/Modifier;Lapp/cash/redwood/ui/Margin;)Lapp/cash/redwood/Modifier;
+	public fun shrink (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun size-j5SIcws (Lapp/cash/redwood/Modifier;DD)Lapp/cash/redwood/Modifier;
+	public fun width-slHoOYc (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+}
+
+public final class app/cash/redwood/layout/compose/LayoutScopesKt {
+	public static final fun flex (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+}
+
+public final class app/cash/redwood/layout/compose/RowKt {
+	public static final fun Row-dhzo6EI (IILapp/cash/redwood/ui/Margin;IIILapp/cash/redwood/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract interface class app/cash/redwood/layout/compose/RowScope {
+	public fun flex (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun grow (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun height-slHoOYc (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun margin (Lapp/cash/redwood/Modifier;Lapp/cash/redwood/ui/Margin;)Lapp/cash/redwood/Modifier;
+	public fun shrink (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+	public fun size-j5SIcws (Lapp/cash/redwood/Modifier;DD)Lapp/cash/redwood/Modifier;
+	public fun verticalAlignment-9tyzA_o (Lapp/cash/redwood/Modifier;I)Lapp/cash/redwood/Modifier;
+	public fun width-slHoOYc (Lapp/cash/redwood/Modifier;D)Lapp/cash/redwood/Modifier;
+}
+
+public final class app/cash/redwood/layout/compose/SpacerKt {
+	public static final fun Spacer-t48wi74 (DDLapp/cash/redwood/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/redwood-layout-composeui/api/android/redwood-layout-composeui.api
+++ b/redwood-layout-composeui/api/android/redwood-layout-composeui.api
@@ -1,0 +1,20 @@
+public final class app/cash/redwood/layout/composeui/BoxMeasurePolicy : androidx/compose/ui/layout/MeasurePolicy {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Z)V
+	public final fun copy (Ljava/util/List;Z)Lapp/cash/redwood/layout/composeui/BoxMeasurePolicy;
+	public static synthetic fun copy$default (Lapp/cash/redwood/layout/composeui/BoxMeasurePolicy;Ljava/util/List;ZILjava/lang/Object;)Lapp/cash/redwood/layout/composeui/BoxMeasurePolicy;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun measure-3p2s80s (Landroidx/compose/ui/layout/MeasureScope;Ljava/util/List;J)Landroidx/compose/ui/layout/MeasureResult;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/composeui/ComposeUiRedwoodLayoutWidgetFactory : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun Box ()Lapp/cash/redwood/layout/widget/Box;
+	public fun Column ()Lapp/cash/redwood/layout/widget/Column;
+	public fun Row ()Lapp/cash/redwood/layout/widget/Row;
+	public fun Spacer ()Lapp/cash/redwood/layout/widget/Spacer;
+}
+

--- a/redwood-layout-composeui/api/jvm/redwood-layout-composeui.api
+++ b/redwood-layout-composeui/api/jvm/redwood-layout-composeui.api
@@ -1,0 +1,20 @@
+public final class app/cash/redwood/layout/composeui/BoxMeasurePolicy : androidx/compose/ui/layout/MeasurePolicy {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Z)V
+	public final fun copy (Ljava/util/List;Z)Lapp/cash/redwood/layout/composeui/BoxMeasurePolicy;
+	public static synthetic fun copy$default (Lapp/cash/redwood/layout/composeui/BoxMeasurePolicy;Ljava/util/List;ZILjava/lang/Object;)Lapp/cash/redwood/layout/composeui/BoxMeasurePolicy;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun measure-3p2s80s (Landroidx/compose/ui/layout/MeasureScope;Ljava/util/List;J)Landroidx/compose/ui/layout/MeasureResult;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/composeui/ComposeUiRedwoodLayoutWidgetFactory : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun Box ()Lapp/cash/redwood/layout/widget/Box;
+	public fun Column ()Lapp/cash/redwood/layout/widget/Column;
+	public fun Row ()Lapp/cash/redwood/layout/widget/Row;
+	public fun Spacer ()Lapp/cash/redwood/layout/widget/Spacer;
+}
+

--- a/redwood-layout-modifiers/api/redwood-layout-modifiers.api
+++ b/redwood-layout-modifiers/api/redwood-layout-modifiers.api
@@ -1,0 +1,37 @@
+public abstract interface class app/cash/redwood/layout/modifier/Flex : app/cash/redwood/Modifier$Element {
+	public abstract fun getValue ()D
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/Grow : app/cash/redwood/Modifier$Element {
+	public abstract fun getValue ()D
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/Height : app/cash/redwood/Modifier$Element {
+	public abstract fun getHeight-hdgK9uQ ()D
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/HorizontalAlignment : app/cash/redwood/Modifier$Element {
+	public abstract fun getAlignment-eoX4IBc ()I
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/Margin : app/cash/redwood/Modifier$Element {
+	public abstract fun getMargin ()Lapp/cash/redwood/ui/Margin;
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/Shrink : app/cash/redwood/Modifier$Element {
+	public abstract fun getValue ()D
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/Size : app/cash/redwood/Modifier$Element {
+	public abstract fun getHeight-hdgK9uQ ()D
+	public abstract fun getWidth-hdgK9uQ ()D
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/VerticalAlignment : app/cash/redwood/Modifier$Element {
+	public abstract fun getAlignment-eoX4IBc ()I
+}
+
+public abstract interface class app/cash/redwood/layout/modifier/Width : app/cash/redwood/Modifier$Element {
+	public abstract fun getWidth-hdgK9uQ ()D
+}
+

--- a/redwood-layout-schema/api/redwood-layout-schema.api
+++ b/redwood-layout-schema/api/redwood-layout-schema.api
@@ -1,0 +1,196 @@
+public final class app/cash/redwood/layout/Box {
+	public synthetic fun <init> (IILapp/cash/redwood/ui/Margin;IILkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-jfchsNQ ()I
+	public final fun component2-jfchsNQ ()I
+	public final fun component3 ()Lapp/cash/redwood/ui/Margin;
+	public final fun component4-eoX4IBc ()I
+	public final fun component5-eoX4IBc ()I
+	public final fun component6 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy-iJjxQrc (IILapp/cash/redwood/ui/Margin;IILkotlin/jvm/functions/Function1;)Lapp/cash/redwood/layout/Box;
+	public static synthetic fun copy-iJjxQrc$default (Lapp/cash/redwood/layout/Box;IILapp/cash/redwood/ui/Margin;IILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/cash/redwood/layout/Box;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Lkotlin/jvm/functions/Function1;
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getHorizontalAlignment-eoX4IBc ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public final fun getVerticalAlignment-eoX4IBc ()I
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/BoxScope {
+	public static final field INSTANCE Lapp/cash/redwood/layout/BoxScope;
+}
+
+public final class app/cash/redwood/layout/Column {
+	public synthetic fun <init> (IILapp/cash/redwood/ui/Margin;IIILkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-jfchsNQ ()I
+	public final fun component2-jfchsNQ ()I
+	public final fun component3 ()Lapp/cash/redwood/ui/Margin;
+	public final fun component4-Andb1w4 ()I
+	public final fun component5-eoX4IBc ()I
+	public final fun component6-Ng1ngeI ()I
+	public final fun component7 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy-bVM0h8I (IILapp/cash/redwood/ui/Margin;IIILkotlin/jvm/functions/Function1;)Lapp/cash/redwood/layout/Column;
+	public static synthetic fun copy-bVM0h8I$default (Lapp/cash/redwood/layout/Column;IILapp/cash/redwood/ui/Margin;IIILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/cash/redwood/layout/Column;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Lkotlin/jvm/functions/Function1;
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getHorizontalAlignment-eoX4IBc ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public final fun getOverflow-Andb1w4 ()I
+	public final fun getVerticalAlignment-Ng1ngeI ()I
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/ColumnScope {
+	public static final field INSTANCE Lapp/cash/redwood/layout/ColumnScope;
+}
+
+public final class app/cash/redwood/layout/Flex {
+	public fun <init> (D)V
+	public final fun component1 ()D
+	public final fun copy (D)Lapp/cash/redwood/layout/Flex;
+	public static synthetic fun copy$default (Lapp/cash/redwood/layout/Flex;DILjava/lang/Object;)Lapp/cash/redwood/layout/Flex;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/Grow {
+	public fun <init> (D)V
+	public final fun component1 ()D
+	public final fun copy (D)Lapp/cash/redwood/layout/Grow;
+	public static synthetic fun copy$default (Lapp/cash/redwood/layout/Grow;DILjava/lang/Object;)Lapp/cash/redwood/layout/Grow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/Height {
+	public synthetic fun <init> (DLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-hdgK9uQ ()D
+	public final fun copy-mnpKzHI (D)Lapp/cash/redwood/layout/Height;
+	public static synthetic fun copy-mnpKzHI$default (Lapp/cash/redwood/layout/Height;DILjava/lang/Object;)Lapp/cash/redwood/layout/Height;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/HorizontalAlignment {
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eoX4IBc ()I
+	public final fun copy-njEs0f8 (I)Lapp/cash/redwood/layout/HorizontalAlignment;
+	public static synthetic fun copy-njEs0f8$default (Lapp/cash/redwood/layout/HorizontalAlignment;IILjava/lang/Object;)Lapp/cash/redwood/layout/HorizontalAlignment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlignment-eoX4IBc ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/Margin {
+	public fun <init> (Lapp/cash/redwood/ui/Margin;)V
+	public final fun component1 ()Lapp/cash/redwood/ui/Margin;
+	public final fun copy (Lapp/cash/redwood/ui/Margin;)Lapp/cash/redwood/layout/Margin;
+	public static synthetic fun copy$default (Lapp/cash/redwood/layout/Margin;Lapp/cash/redwood/ui/Margin;ILjava/lang/Object;)Lapp/cash/redwood/layout/Margin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class app/cash/redwood/layout/RedwoodLayout {
+}
+
+public final class app/cash/redwood/layout/Row {
+	public synthetic fun <init> (IILapp/cash/redwood/ui/Margin;IIILkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-jfchsNQ ()I
+	public final fun component2-jfchsNQ ()I
+	public final fun component3 ()Lapp/cash/redwood/ui/Margin;
+	public final fun component4-Andb1w4 ()I
+	public final fun component5-Ng1ngeI ()I
+	public final fun component6-eoX4IBc ()I
+	public final fun component7 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy-DTaUb5E (IILapp/cash/redwood/ui/Margin;IIILkotlin/jvm/functions/Function1;)Lapp/cash/redwood/layout/Row;
+	public static synthetic fun copy-DTaUb5E$default (Lapp/cash/redwood/layout/Row;IILapp/cash/redwood/ui/Margin;IIILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/cash/redwood/layout/Row;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Lkotlin/jvm/functions/Function1;
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getHorizontalAlignment-Ng1ngeI ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public final fun getOverflow-Andb1w4 ()I
+	public final fun getVerticalAlignment-eoX4IBc ()I
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/RowScope {
+	public static final field INSTANCE Lapp/cash/redwood/layout/RowScope;
+}
+
+public final class app/cash/redwood/layout/Shrink {
+	public fun <init> (D)V
+	public final fun component1 ()D
+	public final fun copy (D)Lapp/cash/redwood/layout/Shrink;
+	public static synthetic fun copy$default (Lapp/cash/redwood/layout/Shrink;DILjava/lang/Object;)Lapp/cash/redwood/layout/Shrink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/Size {
+	public synthetic fun <init> (DDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-hdgK9uQ ()D
+	public final fun component2-hdgK9uQ ()D
+	public final fun copy-mH_gOfM (DD)Lapp/cash/redwood/layout/Size;
+	public static synthetic fun copy-mH_gOfM$default (Lapp/cash/redwood/layout/Size;DDILjava/lang/Object;)Lapp/cash/redwood/layout/Size;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight-hdgK9uQ ()D
+	public final fun getWidth-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/Spacer {
+	public synthetic fun <init> (DDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-hdgK9uQ ()D
+	public final fun component2-hdgK9uQ ()D
+	public final fun copy-mH_gOfM (DD)Lapp/cash/redwood/layout/Spacer;
+	public static synthetic fun copy-mH_gOfM$default (Lapp/cash/redwood/layout/Spacer;DDILjava/lang/Object;)Lapp/cash/redwood/layout/Spacer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight-hdgK9uQ ()D
+	public final fun getWidth-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/VerticalAlignment {
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-eoX4IBc ()I
+	public final fun copy-njEs0f8 (I)Lapp/cash/redwood/layout/VerticalAlignment;
+	public static synthetic fun copy-njEs0f8$default (Lapp/cash/redwood/layout/VerticalAlignment;IILjava/lang/Object;)Lapp/cash/redwood/layout/VerticalAlignment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlignment-eoX4IBc ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/layout/Width {
+	public synthetic fun <init> (DLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-hdgK9uQ ()D
+	public final fun copy-mnpKzHI (D)Lapp/cash/redwood/layout/Width;
+	public static synthetic fun copy-mnpKzHI$default (Lapp/cash/redwood/layout/Width;DILjava/lang/Object;)Lapp/cash/redwood/layout/Width;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWidth-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/redwood-layout-testing/api/redwood-layout-testing.api
+++ b/redwood-layout-testing/api/redwood-layout-testing.api
@@ -1,0 +1,79 @@
+public final class app/cash/redwood/layout/widget/BoxValue : app/cash/redwood/testing/WidgetValue {
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;IILapp/cash/redwood/ui/Margin;IILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;IILapp/cash/redwood/ui/Margin;IILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/List;
+	public fun getChildrenLists ()Ljava/util/List;
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getHorizontalAlignment-eoX4IBc ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public fun getModifier ()Lapp/cash/redwood/Modifier;
+	public final fun getVerticalAlignment-eoX4IBc ()I
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+
+public final class app/cash/redwood/layout/widget/ColumnValue : app/cash/redwood/testing/WidgetValue {
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;IILapp/cash/redwood/ui/Margin;IIILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;IILapp/cash/redwood/ui/Margin;IIILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/List;
+	public fun getChildrenLists ()Ljava/util/List;
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getHorizontalAlignment-eoX4IBc ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public fun getModifier ()Lapp/cash/redwood/Modifier;
+	public final fun getOverflow-Andb1w4 ()I
+	public final fun getVerticalAlignment-Ng1ngeI ()I
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+
+public final class app/cash/redwood/layout/widget/RedwoodLayoutTesterKt {
+	public static final fun RedwoodLayoutTester (Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun RedwoodLayoutTester$default (Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class app/cash/redwood/layout/widget/RedwoodLayoutTestingWidgetFactory : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory {
+	public fun <init> ()V
+	public fun Box ()Lapp/cash/redwood/layout/widget/Box;
+	public fun Column ()Lapp/cash/redwood/layout/widget/Column;
+	public fun Row ()Lapp/cash/redwood/layout/widget/Row;
+	public fun Spacer ()Lapp/cash/redwood/layout/widget/Spacer;
+}
+
+public final class app/cash/redwood/layout/widget/RowValue : app/cash/redwood/testing/WidgetValue {
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;IILapp/cash/redwood/ui/Margin;IIILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;IILapp/cash/redwood/ui/Margin;IIILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/List;
+	public fun getChildrenLists ()Ljava/util/List;
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getHorizontalAlignment-Ng1ngeI ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public fun getModifier ()Lapp/cash/redwood/Modifier;
+	public final fun getOverflow-Andb1w4 ()I
+	public final fun getVerticalAlignment-eoX4IBc ()I
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+
+public final class app/cash/redwood/layout/widget/SpacerValue : app/cash/redwood/testing/WidgetValue {
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;DDILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;DDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildrenLists ()Ljava/util/List;
+	public final fun getHeight-hdgK9uQ ()D
+	public fun getModifier ()Lapp/cash/redwood/Modifier;
+	public final fun getWidth-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+

--- a/redwood-layout-view/api/redwood-layout-view.api
+++ b/redwood-layout-view/api/redwood-layout-view.api
@@ -1,0 +1,8 @@
+public final class app/cash/redwood/layout/view/ViewRedwoodLayoutWidgetFactory : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory {
+	public fun <init> (Landroid/content/Context;)V
+	public fun Box ()Lapp/cash/redwood/layout/widget/Box;
+	public fun Column ()Lapp/cash/redwood/layout/widget/Column;
+	public fun Row ()Lapp/cash/redwood/layout/widget/Row;
+	public fun Spacer ()Lapp/cash/redwood/layout/widget/Spacer;
+}
+

--- a/redwood-layout-widget/api/redwood-layout-widget.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.api
@@ -1,0 +1,59 @@
+public abstract interface class app/cash/redwood/layout/widget/Box : app/cash/redwood/widget/Widget {
+	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun height-DyLkt4w (I)V
+	public abstract fun horizontalAlignment-njEs0f8 (I)V
+	public abstract fun margin (Lapp/cash/redwood/ui/Margin;)V
+	public abstract fun verticalAlignment-njEs0f8 (I)V
+	public abstract fun width-DyLkt4w (I)V
+}
+
+public abstract interface class app/cash/redwood/layout/widget/Column : app/cash/redwood/widget/Widget {
+	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun height-DyLkt4w (I)V
+	public abstract fun horizontalAlignment-njEs0f8 (I)V
+	public abstract fun margin (Lapp/cash/redwood/ui/Margin;)V
+	public abstract fun overflow-OcAJ2MY (I)V
+	public abstract fun verticalAlignment-6exqka8 (I)V
+	public abstract fun width-DyLkt4w (I)V
+}
+
+public abstract interface class app/cash/redwood/layout/widget/FlexContainer : app/cash/redwood/layout/widget/Column, app/cash/redwood/layout/widget/Row {
+	public abstract fun crossAxisAlignment-njEs0f8 (I)V
+	public fun horizontalAlignment-6exqka8 (I)V
+	public fun horizontalAlignment-njEs0f8 (I)V
+	public abstract fun mainAxisAlignment-6exqka8 (I)V
+	public fun verticalAlignment-6exqka8 (I)V
+	public fun verticalAlignment-njEs0f8 (I)V
+}
+
+public abstract interface class app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory {
+	public abstract fun Box ()Lapp/cash/redwood/layout/widget/Box;
+	public abstract fun Column ()Lapp/cash/redwood/layout/widget/Column;
+	public abstract fun Row ()Lapp/cash/redwood/layout/widget/Row;
+	public abstract fun Spacer ()Lapp/cash/redwood/layout/widget/Spacer;
+}
+
+public abstract interface class app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner : app/cash/redwood/widget/WidgetFactoryOwner {
+	public abstract fun getRedwoodLayout ()Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;
+}
+
+public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
+	public fun <init> (Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;)V
+	public fun getRedwoodLayout ()Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;
+}
+
+public abstract interface class app/cash/redwood/layout/widget/Row : app/cash/redwood/widget/Widget {
+	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun height-DyLkt4w (I)V
+	public abstract fun horizontalAlignment-6exqka8 (I)V
+	public abstract fun margin (Lapp/cash/redwood/ui/Margin;)V
+	public abstract fun overflow-OcAJ2MY (I)V
+	public abstract fun verticalAlignment-njEs0f8 (I)V
+	public abstract fun width-DyLkt4w (I)V
+}
+
+public abstract interface class app/cash/redwood/layout/widget/Spacer : app/cash/redwood/widget/Widget {
+	public abstract fun height-mnpKzHI (D)V
+	public abstract fun width-mnpKzHI (D)V
+}
+

--- a/redwood-lazylayout-api/api/redwood-lazylayout-api.api
+++ b/redwood-lazylayout-api/api/redwood-lazylayout-api.api
@@ -1,0 +1,29 @@
+public final class app/cash/redwood/lazylayout/api/ScrollItemIndex {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/lazylayout/api/ScrollItemIndex$Companion;
+	public fun <init> (IIZ)V
+	public synthetic fun <init> (IIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnimated ()Z
+	public final fun getId ()I
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/lazylayout/api/ScrollItemIndex$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/lazylayout/api/ScrollItemIndex$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/lazylayout/api/ScrollItemIndex$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/redwood-lazylayout-compose/api/redwood-lazylayout-compose.api
+++ b/redwood-lazylayout-compose/api/redwood-lazylayout-compose.api
@@ -1,0 +1,46 @@
+public abstract interface annotation class app/cash/redwood/lazylayout/compose/ExperimentalRedwoodLazyLayoutApi : java/lang/annotation/Annotation {
+}
+
+public final class app/cash/redwood/lazylayout/compose/LazyDslKt {
+	public static final fun LazyColumn-1Zbu240 (Lkotlin/jvm/functions/Function2;Lapp/cash/redwood/Modifier;Lapp/cash/redwood/lazylayout/compose/LazyListState;IILapp/cash/redwood/ui/Margin;ILkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun LazyColumn-brZIKco (ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lapp/cash/redwood/Modifier;Lapp/cash/redwood/lazylayout/compose/LazyListState;IILapp/cash/redwood/ui/Margin;IILkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+	public static final fun LazyRow-1Zbu240 (Lkotlin/jvm/functions/Function2;Lapp/cash/redwood/Modifier;Lapp/cash/redwood/lazylayout/compose/LazyListState;IILapp/cash/redwood/ui/Margin;ILkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun LazyRow-brZIKco (ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lapp/cash/redwood/Modifier;Lapp/cash/redwood/lazylayout/compose/LazyListState;IILapp/cash/redwood/ui/Margin;IILkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+	public static final fun items (Lapp/cash/redwood/lazylayout/compose/LazyListScope;Ljava/util/List;Lkotlin/jvm/functions/Function3;)V
+	public static final fun items (Lapp/cash/redwood/lazylayout/compose/LazyListScope;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)V
+	public static final fun itemsIndexed (Lapp/cash/redwood/lazylayout/compose/LazyListScope;Ljava/util/List;Lkotlin/jvm/functions/Function4;)V
+	public static final fun itemsIndexed (Lapp/cash/redwood/lazylayout/compose/LazyListScope;[Ljava/lang/Object;Lkotlin/jvm/functions/Function4;)V
+}
+
+public final class app/cash/redwood/lazylayout/compose/LazyListKt {
+	public static final fun LazyList-X7zwUEk (ZLkotlin/jvm/functions/Function2;IIIILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;Lapp/cash/redwood/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+}
+
+public abstract interface class app/cash/redwood/lazylayout/compose/LazyListScope {
+	public abstract fun item (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun items (ILkotlin/jvm/functions/Function3;)V
+}
+
+public class app/cash/redwood/lazylayout/compose/LazyListState {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun getFirstIndex ()I
+	public final fun getLastIndex ()I
+	public final fun getPreloadAfterItemCount ()I
+	public final fun getPreloadBeforeItemCount ()I
+	public final fun getProgrammaticScrollIndex ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public final fun onUserScroll (II)V
+	public final fun programmaticScroll (IZZ)V
+	public static synthetic fun programmaticScroll$default (Lapp/cash/redwood/lazylayout/compose/LazyListState;IZZILjava/lang/Object;)V
+	public final fun setPreloadAfterItemCount (I)V
+	public final fun setPreloadBeforeItemCount (I)V
+}
+
+public final class app/cash/redwood/lazylayout/compose/LazyListStateKt {
+	public static final fun rememberLazyListState (Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/lazylayout/compose/LazyListState;
+}
+
+public final class app/cash/redwood/lazylayout/compose/RefreshableLazyListKt {
+	public static final fun RefreshableLazyList-usczW4I (ZLkotlin/jvm/functions/Function2;IIZLkotlin/jvm/functions/Function0;IILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;ILapp/cash/redwood/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+}
+

--- a/redwood-lazylayout-composeui/api/android/redwood-lazylayout-composeui.api
+++ b/redwood-lazylayout-composeui/api/android/redwood-lazylayout-composeui.api
@@ -1,0 +1,7 @@
+public final class app/cash/redwood/lazylayout/composeui/ComposeUiRedwoodLazyLayoutWidgetFactory : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun LazyList ()Lapp/cash/redwood/lazylayout/widget/LazyList;
+	public fun RefreshableLazyList ()Lapp/cash/redwood/lazylayout/widget/RefreshableLazyList;
+}
+

--- a/redwood-lazylayout-composeui/api/jvm/redwood-lazylayout-composeui.api
+++ b/redwood-lazylayout-composeui/api/jvm/redwood-lazylayout-composeui.api
@@ -1,0 +1,7 @@
+public final class app/cash/redwood/lazylayout/composeui/ComposeUiRedwoodLazyLayoutWidgetFactory : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun LazyList ()Lapp/cash/redwood/lazylayout/widget/LazyList;
+	public fun RefreshableLazyList ()Lapp/cash/redwood/lazylayout/widget/RefreshableLazyList;
+}
+

--- a/redwood-lazylayout-schema/api/redwood-lazylayout-schema.api
+++ b/redwood-lazylayout-schema/api/redwood-lazylayout-schema.api
@@ -1,0 +1,71 @@
+public final class app/cash/redwood/lazylayout/LazyList {
+	public synthetic fun <init> (ZLkotlin/jvm/functions/Function2;IIIILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Lkotlin/jvm/functions/Function0;
+	public final fun component11 ()Lkotlin/jvm/functions/Function0;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5-jfchsNQ ()I
+	public final fun component6-jfchsNQ ()I
+	public final fun component7 ()Lapp/cash/redwood/ui/Margin;
+	public final fun component8-eoX4IBc ()I
+	public final fun component9 ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public final fun copy-fUwMigU (ZLkotlin/jvm/functions/Function2;IIIILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/lazylayout/LazyList;
+	public static synthetic fun copy-fUwMigU$default (Lapp/cash/redwood/lazylayout/LazyList;ZLkotlin/jvm/functions/Function2;IIIILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/lazylayout/LazyList;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCrossAxisAlignment-eoX4IBc ()I
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getItems ()Lkotlin/jvm/functions/Function0;
+	public final fun getItemsAfter ()I
+	public final fun getItemsBefore ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public final fun getOnViewportChanged ()Lkotlin/jvm/functions/Function2;
+	public final fun getPlaceholder ()Lkotlin/jvm/functions/Function0;
+	public final fun getScrollItemIndex ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public final fun isVertical ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class app/cash/redwood/lazylayout/RedwoodLazyLayout {
+}
+
+public final class app/cash/redwood/lazylayout/RefreshableLazyList {
+	public synthetic fun <init> (ZLkotlin/jvm/functions/Function2;IIZLkotlin/jvm/functions/Function0;IILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;ILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10-eoX4IBc ()I
+	public final fun component11 ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public final fun component12-pVg5ArA ()I
+	public final fun component13 ()Lkotlin/jvm/functions/Function0;
+	public final fun component14 ()Lkotlin/jvm/functions/Function0;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()Z
+	public final fun component6 ()Lkotlin/jvm/functions/Function0;
+	public final fun component7-jfchsNQ ()I
+	public final fun component8-jfchsNQ ()I
+	public final fun component9 ()Lapp/cash/redwood/ui/Margin;
+	public final fun copy-_f0ixK8 (ZLkotlin/jvm/functions/Function2;IIZLkotlin/jvm/functions/Function0;IILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;ILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/lazylayout/RefreshableLazyList;
+	public static synthetic fun copy-_f0ixK8$default (Lapp/cash/redwood/lazylayout/RefreshableLazyList;ZLkotlin/jvm/functions/Function2;IIZLkotlin/jvm/functions/Function0;IILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;ILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/lazylayout/RefreshableLazyList;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCrossAxisAlignment-eoX4IBc ()I
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getItems ()Lkotlin/jvm/functions/Function0;
+	public final fun getItemsAfter ()I
+	public final fun getItemsBefore ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public final fun getOnRefresh ()Lkotlin/jvm/functions/Function0;
+	public final fun getOnViewportChanged ()Lkotlin/jvm/functions/Function2;
+	public final fun getPlaceholder ()Lkotlin/jvm/functions/Function0;
+	public final fun getPullRefreshContentColor-pVg5ArA ()I
+	public final fun getRefreshing ()Z
+	public final fun getScrollItemIndex ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public final fun isVertical ()Z
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/redwood-lazylayout-testing/api/redwood-lazylayout-testing.api
+++ b/redwood-lazylayout-testing/api/redwood-lazylayout-testing.api
@@ -1,0 +1,58 @@
+public final class app/cash/redwood/lazylayout/widget/LazyListValue : app/cash/redwood/testing/WidgetValue {
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;ZLkotlin/jvm/functions/Function2;IIIILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;ZLkotlin/jvm/functions/Function2;IIIILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildrenLists ()Ljava/util/List;
+	public final fun getCrossAxisAlignment-eoX4IBc ()I
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getItems ()Ljava/util/List;
+	public final fun getItemsAfter ()I
+	public final fun getItemsBefore ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public fun getModifier ()Lapp/cash/redwood/Modifier;
+	public final fun getOnViewportChanged ()Lkotlin/jvm/functions/Function2;
+	public final fun getPlaceholder ()Ljava/util/List;
+	public final fun getScrollItemIndex ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public final fun isVertical ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+
+public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutTesterKt {
+	public static final fun RedwoodLazyLayoutTester (Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun RedwoodLazyLayoutTester$default (Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutTestingWidgetFactory : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory {
+	public fun <init> ()V
+	public fun LazyList ()Lapp/cash/redwood/lazylayout/widget/LazyList;
+	public fun RefreshableLazyList ()Lapp/cash/redwood/lazylayout/widget/RefreshableLazyList;
+}
+
+public final class app/cash/redwood/lazylayout/widget/RefreshableLazyListValue : app/cash/redwood/testing/WidgetValue {
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;ZLkotlin/jvm/functions/Function2;IIZLkotlin/jvm/functions/Function0;IILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;ILjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lapp/cash/redwood/Modifier;ZLkotlin/jvm/functions/Function2;IIZLkotlin/jvm/functions/Function0;IILapp/cash/redwood/ui/Margin;ILapp/cash/redwood/lazylayout/api/ScrollItemIndex;ILjava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildrenLists ()Ljava/util/List;
+	public final fun getCrossAxisAlignment-eoX4IBc ()I
+	public final fun getHeight-jfchsNQ ()I
+	public final fun getItems ()Ljava/util/List;
+	public final fun getItemsAfter ()I
+	public final fun getItemsBefore ()I
+	public final fun getMargin ()Lapp/cash/redwood/ui/Margin;
+	public fun getModifier ()Lapp/cash/redwood/Modifier;
+	public final fun getOnRefresh ()Lkotlin/jvm/functions/Function0;
+	public final fun getOnViewportChanged ()Lkotlin/jvm/functions/Function2;
+	public final fun getPlaceholder ()Ljava/util/List;
+	public final fun getPullRefreshContentColor-pVg5ArA ()I
+	public final fun getRefreshing ()Z
+	public final fun getScrollItemIndex ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
+	public final fun getWidth-jfchsNQ ()I
+	public fun hashCode ()I
+	public final fun isVertical ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+

--- a/redwood-lazylayout-view/api/redwood-lazylayout-view.api
+++ b/redwood-lazylayout-view/api/redwood-lazylayout-view.api
@@ -1,0 +1,6 @@
+public final class app/cash/redwood/lazylayout/view/ViewRedwoodLazyLayoutWidgetFactory : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory {
+	public fun <init> (Landroid/content/Context;)V
+	public fun LazyList ()Lapp/cash/redwood/lazylayout/widget/LazyList;
+	public fun RefreshableLazyList ()Lapp/cash/redwood/lazylayout/widget/RefreshableLazyList;
+}
+

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -1,0 +1,78 @@
+public abstract interface class app/cash/redwood/lazylayout/widget/LazyList : app/cash/redwood/widget/Widget {
+	public abstract fun crossAxisAlignment-njEs0f8 (I)V
+	public abstract fun getItems ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun getPlaceholder ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun height-DyLkt4w (I)V
+	public abstract fun isVertical (Z)V
+	public abstract fun itemsAfter (I)V
+	public abstract fun itemsBefore (I)V
+	public abstract fun margin (Lapp/cash/redwood/ui/Margin;)V
+	public abstract fun onViewportChanged (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun scrollItemIndex (Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;)V
+	public abstract fun width-DyLkt4w (I)V
+}
+
+public abstract class app/cash/redwood/lazylayout/widget/LazyListScrollProcessor {
+	public fun <init> ()V
+	public abstract fun contentSize ()I
+	public final fun onEndChanges ()V
+	public final fun onUserScroll (II)V
+	public final fun onViewportChanged (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun programmaticScroll (IZ)V
+	public final fun scrollItemIndex (Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;)V
+}
+
+public abstract class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor {
+	public fun <init> ()V
+	public final fun bind (ILjava/lang/Object;)Lapp/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Binding;
+	protected fun createPlaceholder (Ljava/lang/Object;)Ljava/lang/Object;
+	protected abstract fun deleteRows (II)V
+	public final fun getBindings ()Ljava/util/List;
+	public final fun getItems ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun getOrCreateView (ILkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun getPlaceholder ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun getSize ()I
+	protected abstract fun insertRows (II)V
+	public final fun itemsAfter (I)V
+	public final fun itemsBefore (I)V
+	public final fun onEndChanges ()V
+	protected abstract fun setContent (Ljava/lang/Object;Lapp/cash/redwood/widget/Widget;)V
+}
+
+public final class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Binding {
+	public final fun getView ()Ljava/lang/Object;
+	public final fun isBound ()Z
+	public final fun unbind ()V
+}
+
+public abstract interface class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory {
+	public abstract fun LazyList ()Lapp/cash/redwood/lazylayout/widget/LazyList;
+	public abstract fun RefreshableLazyList ()Lapp/cash/redwood/lazylayout/widget/RefreshableLazyList;
+}
+
+public abstract interface class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner : app/cash/redwood/widget/WidgetFactoryOwner {
+	public abstract fun getRedwoodLazyLayout ()Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;
+}
+
+public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSystem : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
+	public fun <init> (Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;)V
+	public fun getRedwoodLazyLayout ()Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;
+}
+
+public abstract interface class app/cash/redwood/lazylayout/widget/RefreshableLazyList : app/cash/redwood/widget/Widget {
+	public abstract fun crossAxisAlignment-njEs0f8 (I)V
+	public abstract fun getItems ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun getPlaceholder ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun height-DyLkt4w (I)V
+	public abstract fun isVertical (Z)V
+	public abstract fun itemsAfter (I)V
+	public abstract fun itemsBefore (I)V
+	public abstract fun margin (Lapp/cash/redwood/ui/Margin;)V
+	public abstract fun onRefresh (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun onViewportChanged (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun pullRefreshContentColor-WZ4Q5Ns (I)V
+	public abstract fun refreshing (Z)V
+	public abstract fun scrollItemIndex (Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;)V
+	public abstract fun width-DyLkt4w (I)V
+}
+

--- a/redwood-protocol-guest/api/android/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/android/redwood-protocol-guest.api
@@ -1,0 +1,45 @@
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolBridge : app/cash/redwood/protocol/EventSink {
+	public abstract fun getChangesOrNull ()Ljava/util/List;
+	public abstract fun getRoot ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
+}
+
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolBridge$Factory {
+	public abstract fun create (Lkotlinx/serialization/json/Json;Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;)Lapp/cash/redwood/protocol/guest/ProtocolBridge;
+	public static synthetic fun create$default (Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;ILjava/lang/Object;)Lapp/cash/redwood/protocol/guest/ProtocolBridge;
+}
+
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolMismatchHandler {
+	public static final field Companion Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler$Companion;
+	public static final field Throwing Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;
+	public abstract fun onUnknownEvent-_LM6m-c (II)V
+	public abstract fun onUnknownEventNode-1ccMwuE (II)V
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolMismatchHandler$Companion {
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolRedwoodCompositionKt {
+	public static final fun ProtocolRedwoodComposition-7J1iaxU (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/protocol/guest/ProtocolBridge;Lapp/cash/redwood/protocol/ChangesSink;ILapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;)Lapp/cash/redwood/compose/RedwoodComposition;
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolState {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun addWidget (Lapp/cash/redwood/protocol/guest/ProtocolWidget;)V
+	public final fun append (Lapp/cash/redwood/protocol/Change;)V
+	public final fun getChangesOrNull ()Ljava/util/List;
+	public final fun getWidget-ou3jOuA (I)Lapp/cash/redwood/protocol/guest/ProtocolWidget;
+	public final fun nextId-0HhLjSo ()I
+	public final fun removeWidget-ou3jOuA (I)V
+	public final fun widgetChildren-AWfp_YY (II)Lapp/cash/redwood/widget/Widget$Children;
+}
+
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget : app/cash/redwood/widget/Widget {
+	public abstract fun getId-0HhLjSo ()I
+	public abstract fun getTag-BlhN7y0 ()I
+	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue ()Ljava/lang/Void;
+	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
+}
+

--- a/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
@@ -1,0 +1,45 @@
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolBridge : app/cash/redwood/protocol/EventSink {
+	public abstract fun getChangesOrNull ()Ljava/util/List;
+	public abstract fun getRoot ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
+}
+
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolBridge$Factory {
+	public abstract fun create (Lkotlinx/serialization/json/Json;Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;)Lapp/cash/redwood/protocol/guest/ProtocolBridge;
+	public static synthetic fun create$default (Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;ILjava/lang/Object;)Lapp/cash/redwood/protocol/guest/ProtocolBridge;
+}
+
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolMismatchHandler {
+	public static final field Companion Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler$Companion;
+	public static final field Throwing Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;
+	public abstract fun onUnknownEvent-_LM6m-c (II)V
+	public abstract fun onUnknownEventNode-1ccMwuE (II)V
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolMismatchHandler$Companion {
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolRedwoodCompositionKt {
+	public static final fun ProtocolRedwoodComposition-7J1iaxU (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/protocol/guest/ProtocolBridge;Lapp/cash/redwood/protocol/ChangesSink;ILapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;)Lapp/cash/redwood/compose/RedwoodComposition;
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolState {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun addWidget (Lapp/cash/redwood/protocol/guest/ProtocolWidget;)V
+	public final fun append (Lapp/cash/redwood/protocol/Change;)V
+	public final fun getChangesOrNull ()Ljava/util/List;
+	public final fun getWidget-ou3jOuA (I)Lapp/cash/redwood/protocol/guest/ProtocolWidget;
+	public final fun nextId-0HhLjSo ()I
+	public final fun removeWidget-ou3jOuA (I)V
+	public final fun widgetChildren-AWfp_YY (II)Lapp/cash/redwood/widget/Widget$Children;
+}
+
+public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget : app/cash/redwood/widget/Widget {
+	public abstract fun getId-0HhLjSo ()I
+	public abstract fun getTag-BlhN7y0 ()I
+	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue ()Ljava/lang/Void;
+	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
+}
+

--- a/redwood-protocol-host/api/android/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/android/redwood-protocol-host.api
@@ -1,0 +1,38 @@
+public abstract interface class app/cash/redwood/protocol/widget/GeneratedProtocolFactory : app/cash/redwood/protocol/widget/ProtocolFactory {
+	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
+	public abstract fun createNode-WCEpcRY (I)Lapp/cash/redwood/protocol/widget/ProtocolNode;
+}
+
+public final class app/cash/redwood/protocol/widget/ProtocolBridge : app/cash/redwood/protocol/ChangesSink {
+	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/protocol/widget/ProtocolFactory;Lapp/cash/redwood/protocol/EventSink;)V
+	public fun sendChanges (Ljava/util/List;)V
+}
+
+public final class app/cash/redwood/protocol/widget/ProtocolChildren {
+	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;)V
+	public final fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+}
+
+public abstract interface class app/cash/redwood/protocol/widget/ProtocolFactory {
+}
+
+public abstract interface class app/cash/redwood/protocol/widget/ProtocolMismatchHandler {
+	public static final field Companion Lapp/cash/redwood/protocol/widget/ProtocolMismatchHandler$Companion;
+	public static final field Throwing Lapp/cash/redwood/protocol/widget/ProtocolMismatchHandler;
+	public abstract fun onUnknownChildren-iETOA3M (II)V
+	public abstract fun onUnknownModifier-nx0wl1g (I)V
+	public abstract fun onUnknownProperty-LKUuuww (II)V
+	public abstract fun onUnknownWidget-WCEpcRY (I)V
+}
+
+public final class app/cash/redwood/protocol/widget/ProtocolMismatchHandler$Companion {
+}
+
+public abstract class app/cash/redwood/protocol/widget/ProtocolNode {
+	public fun <init> ()V
+	public abstract fun apply (Lapp/cash/redwood/protocol/PropertyChange;Lapp/cash/redwood/protocol/EventSink;)V
+	public abstract fun children-dBpC-2Y (I)Lapp/cash/redwood/protocol/widget/ProtocolChildren;
+	public abstract fun getWidget ()Lapp/cash/redwood/widget/Widget;
+	public final fun updateModifier (Lapp/cash/redwood/Modifier;)V
+}
+

--- a/redwood-protocol-host/api/jvm/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/jvm/redwood-protocol-host.api
@@ -1,0 +1,38 @@
+public abstract interface class app/cash/redwood/protocol/widget/GeneratedProtocolFactory : app/cash/redwood/protocol/widget/ProtocolFactory {
+	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
+	public abstract fun createNode-WCEpcRY (I)Lapp/cash/redwood/protocol/widget/ProtocolNode;
+}
+
+public final class app/cash/redwood/protocol/widget/ProtocolBridge : app/cash/redwood/protocol/ChangesSink {
+	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/protocol/widget/ProtocolFactory;Lapp/cash/redwood/protocol/EventSink;)V
+	public fun sendChanges (Ljava/util/List;)V
+}
+
+public final class app/cash/redwood/protocol/widget/ProtocolChildren {
+	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;)V
+	public final fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+}
+
+public abstract interface class app/cash/redwood/protocol/widget/ProtocolFactory {
+}
+
+public abstract interface class app/cash/redwood/protocol/widget/ProtocolMismatchHandler {
+	public static final field Companion Lapp/cash/redwood/protocol/widget/ProtocolMismatchHandler$Companion;
+	public static final field Throwing Lapp/cash/redwood/protocol/widget/ProtocolMismatchHandler;
+	public abstract fun onUnknownChildren-iETOA3M (II)V
+	public abstract fun onUnknownModifier-nx0wl1g (I)V
+	public abstract fun onUnknownProperty-LKUuuww (II)V
+	public abstract fun onUnknownWidget-WCEpcRY (I)V
+}
+
+public final class app/cash/redwood/protocol/widget/ProtocolMismatchHandler$Companion {
+}
+
+public abstract class app/cash/redwood/protocol/widget/ProtocolNode {
+	public fun <init> ()V
+	public abstract fun apply (Lapp/cash/redwood/protocol/PropertyChange;Lapp/cash/redwood/protocol/EventSink;)V
+	public abstract fun children-dBpC-2Y (I)Lapp/cash/redwood/protocol/widget/ProtocolChildren;
+	public abstract fun getWidget ()Lapp/cash/redwood/widget/Widget;
+	public final fun updateModifier (Lapp/cash/redwood/Modifier;)V
+}
+

--- a/redwood-protocol/api/redwood-protocol.api
+++ b/redwood-protocol/api/redwood-protocol.api
@@ -1,0 +1,439 @@
+public abstract interface class app/cash/redwood/protocol/Change {
+	public static final field Companion Lapp/cash/redwood/protocol/Change$Companion;
+	public abstract fun getId-0HhLjSo ()I
+}
+
+public final class app/cash/redwood/protocol/Change$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class app/cash/redwood/protocol/ChangesSink {
+	public abstract fun sendChanges (Ljava/util/List;)V
+}
+
+public abstract interface class app/cash/redwood/protocol/ChildrenChange : app/cash/redwood/protocol/Change {
+	public static final field Companion Lapp/cash/redwood/protocol/ChildrenChange$Companion;
+	public abstract fun getTag-b0W0yNk ()I
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Add : app/cash/redwood/protocol/ChildrenChange {
+	public static final field Companion Lapp/cash/redwood/protocol/ChildrenChange$Add$Companion;
+	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildId-0HhLjSo ()I
+	public fun getId-0HhLjSo ()I
+	public final fun getIndex ()I
+	public fun getTag-b0W0yNk ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Add$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/ChildrenChange$Add$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/protocol/ChildrenChange$Add;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/protocol/ChildrenChange$Add;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Add$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Move : app/cash/redwood/protocol/ChildrenChange {
+	public static final field Companion Lapp/cash/redwood/protocol/ChildrenChange$Move$Companion;
+	public synthetic fun <init> (IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public final fun getFromIndex ()I
+	public fun getId-0HhLjSo ()I
+	public fun getTag-b0W0yNk ()I
+	public final fun getToIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Move$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/ChildrenChange$Move$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/protocol/ChildrenChange$Move;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/protocol/ChildrenChange$Move;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Move$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Remove : app/cash/redwood/protocol/ChildrenChange {
+	public static final field Companion Lapp/cash/redwood/protocol/ChildrenChange$Remove$Companion;
+	public synthetic fun <init> (IIIILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public fun getId-0HhLjSo ()I
+	public final fun getIndex ()I
+	public final fun getRemovedIds ()Ljava/util/List;
+	public fun getTag-b0W0yNk ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Remove$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/ChildrenChange$Remove$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/protocol/ChildrenChange$Remove;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/protocol/ChildrenChange$Remove;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenChange$Remove$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenTag {
+	public static final field Companion Lapp/cash/redwood/protocol/ChildrenTag$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/protocol/ChildrenTag;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/protocol/ChildrenTag$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/ChildrenTag$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-2Nay9eI (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-sM9PXMU (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ChildrenTag$Companion {
+	public final fun getRoot-b0W0yNk ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/Create : app/cash/redwood/protocol/Change {
+	public static final field Companion Lapp/cash/redwood/protocol/Create$Companion;
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId-0HhLjSo ()I
+	public final fun getTag-BlhN7y0 ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/Create$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/Create$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/protocol/Create;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/protocol/Create;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/Create$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/Event {
+	public static final field Companion Lapp/cash/redwood/protocol/Event$Companion;
+	public synthetic fun <init> (IILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/List;
+	public final fun getId-0HhLjSo ()I
+	public final fun getTag-RNF89mI ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/Event$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/Event$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/protocol/Event;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/protocol/Event;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/Event$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class app/cash/redwood/protocol/EventSink {
+	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
+}
+
+public final class app/cash/redwood/protocol/EventTag {
+	public static final field Companion Lapp/cash/redwood/protocol/EventTag$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/protocol/EventTag;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/protocol/EventTag$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/EventTag$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-mDVN7pQ (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-1HQoEpw (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/EventTag$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/Id {
+	public static final field Companion Lapp/cash/redwood/protocol/Id$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/protocol/Id;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/protocol/Id$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/Id$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-6Lqzcoc (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-PGojVM4 (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/Id$Companion {
+	public final fun getRoot-0HhLjSo ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ModifierChange : app/cash/redwood/protocol/ValueChange {
+	public static final field Companion Lapp/cash/redwood/protocol/ModifierChange$Companion;
+	public synthetic fun <init> (ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElements ()Ljava/util/List;
+	public fun getId-0HhLjSo ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/ModifierChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/ModifierChange$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/protocol/ModifierChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/protocol/ModifierChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ModifierChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ModifierElement {
+	public synthetic fun <init> (ILkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTag-4zWdEn8 ()I
+	public final fun getValue ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/ModifierTag {
+	public static final field Companion Lapp/cash/redwood/protocol/ModifierTag$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/protocol/ModifierTag;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/protocol/ModifierTag$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/ModifierTag$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-54iDFIs (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-RV5jnrU (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/ModifierTag$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/PropertyChange : app/cash/redwood/protocol/ValueChange {
+	public static final field Companion Lapp/cash/redwood/protocol/PropertyChange$Companion;
+	public synthetic fun <init> (IILkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IILkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId-0HhLjSo ()I
+	public final fun getTag-VGAaYLs ()I
+	public final fun getValue ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/protocol/PropertyChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/PropertyChange$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/protocol/PropertyChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/protocol/PropertyChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/PropertyChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/PropertyTag {
+	public static final field Companion Lapp/cash/redwood/protocol/PropertyTag$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/protocol/PropertyTag;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/protocol/PropertyTag$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/PropertyTag$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-RTwKcFc (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-DHbFMa4 (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/PropertyTag$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/SnapshotChangeList {
+	public static final field Companion Lapp/cash/redwood/protocol/SnapshotChangeList$Companion;
+	public static final synthetic fun box-impl (Ljava/util/List;)Lapp/cash/redwood/protocol/SnapshotChangeList;
+	public static fun constructor-impl (Ljava/util/List;)Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/util/List;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/util/List;Ljava/util/List;)Z
+	public final fun getChanges ()Ljava/util/List;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/util/List;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/util/List;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/util/List;
+}
+
+public final class app/cash/redwood/protocol/SnapshotChangeList$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/SnapshotChangeList$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-48S5H8M (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-rqC_l18 (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/SnapshotChangeList$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class app/cash/redwood/protocol/ValueChange : app/cash/redwood/protocol/Change {
+}
+
+public final class app/cash/redwood/protocol/WidgetTag {
+	public static final field Companion Lapp/cash/redwood/protocol/WidgetTag$Companion;
+	public static final synthetic fun box-impl (I)Lapp/cash/redwood/protocol/WidgetTag;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class app/cash/redwood/protocol/WidgetTag$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/protocol/WidgetTag$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-iuTp0Po (Lkotlinx/serialization/encoding/Decoder;)I
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-GodUi58 (Lkotlinx/serialization/encoding/Encoder;I)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/protocol/WidgetTag$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/redwood-runtime/api/android/redwood-runtime.api
+++ b/redwood-runtime/api/android/redwood-runtime.api
@@ -1,0 +1,220 @@
+public abstract interface annotation class app/cash/redwood/LayoutScopeMarker : java/lang/annotation/Annotation {
+}
+
+public abstract interface class app/cash/redwood/Modifier {
+	public static final field Companion Lapp/cash/redwood/Modifier$Companion;
+	public abstract fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
+}
+
+public final class app/cash/redwood/Modifier$Companion : app/cash/redwood/Modifier {
+	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class app/cash/redwood/Modifier$Element : app/cash/redwood/Modifier {
+	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface annotation class app/cash/redwood/RedwoodCodegenApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class app/cash/redwood/ui/Cancellable {
+	public abstract fun cancel ()V
+}
+
+public final class app/cash/redwood/ui/Density {
+	public static final field Companion Lapp/cash/redwood/ui/Density$Companion;
+	public static final synthetic fun box-impl (D)Lapp/cash/redwood/ui/Density;
+	public static fun constructor-impl (D)D
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (DLjava/lang/Object;)Z
+	public static final fun equals-impl0 (DD)Z
+	public final fun getRawDensity ()D
+	public fun hashCode ()I
+	public static fun hashCode-impl (D)I
+	public static final fun toDp-Ht7-4L4 (DD)D
+	public static final fun toDp-Ht7-4L4 (DF)D
+	public static final fun toDp-Ht7-4L4 (DI)D
+	public static final fun toPx-mnpKzHI (DD)D
+	public static final fun toPxInt-mnpKzHI (DD)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (D)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()D
+}
+
+public final class app/cash/redwood/ui/Density$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Density$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-wj95dkU (Lkotlinx/serialization/encoding/Decoder;)D
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize--vrfCzw (Lkotlinx/serialization/encoding/Encoder;D)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Density$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/DensityKt {
+	public static final fun Density (Landroid/content/res/Resources;)D
+}
+
+public final class app/cash/redwood/ui/Dp {
+	public static final field Companion Lapp/cash/redwood/ui/Dp$Companion;
+	public static final synthetic fun box-impl (D)Lapp/cash/redwood/ui/Dp;
+	public static fun constructor-impl (D)D
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (DLjava/lang/Object;)Z
+	public static final fun equals-impl0 (DD)Z
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public static fun hashCode-impl (D)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (D)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()D
+}
+
+public final class app/cash/redwood/ui/Dp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Dp$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-Ht7-4L4 (Lkotlinx/serialization/encoding/Decoder;)D
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-slHoOYc (Lkotlinx/serialization/encoding/Encoder;D)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Dp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/DpKt {
+	public static final fun fromPlatformDp (Lapp/cash/redwood/ui/Dp$Companion;D)D
+	public static final fun getDp (D)D
+	public static final fun getDp (F)D
+	public static final fun getDp (I)D
+	public static final fun toPlatformDp-mnpKzHI (D)D
+}
+
+public final class app/cash/redwood/ui/Margin {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/ui/Margin$Companion;
+	public synthetic fun <init> (DDDDILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (DDDDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom-hdgK9uQ ()D
+	public final fun getEnd-hdgK9uQ ()D
+	public final fun getStart-hdgK9uQ ()D
+	public final fun getTop-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/ui/Margin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Margin$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/ui/Margin;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/ui/Margin;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Margin$Companion {
+	public final fun getZero ()Lapp/cash/redwood/ui/Margin;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/MarginKt {
+	public static final fun Margin-mH_gOfM (DD)Lapp/cash/redwood/ui/Margin;
+	public static synthetic fun Margin-mH_gOfM$default (DDILjava/lang/Object;)Lapp/cash/redwood/ui/Margin;
+	public static final fun Margin-mnpKzHI (D)Lapp/cash/redwood/ui/Margin;
+	public static synthetic fun Margin-mnpKzHI$default (DILjava/lang/Object;)Lapp/cash/redwood/ui/Margin;
+}
+
+public abstract class app/cash/redwood/ui/OnBackPressedCallback {
+	public static final field $stable I
+	public fun <init> (Z)V
+	public final fun getEnabledChangedCallback ()Lkotlin/jvm/functions/Function0;
+	public abstract fun handleOnBackPressed ()V
+	public final fun isEnabled ()Z
+	public final fun setEnabled (Z)V
+	public final fun setEnabledChangedCallback (Lkotlin/jvm/functions/Function0;)V
+}
+
+public abstract interface class app/cash/redwood/ui/OnBackPressedDispatcher {
+	public static final field Companion Lapp/cash/redwood/ui/OnBackPressedDispatcher$Companion;
+	public abstract fun addCallback (Lapp/cash/redwood/ui/OnBackPressedCallback;)Lapp/cash/redwood/ui/Cancellable;
+}
+
+public final class app/cash/redwood/ui/OnBackPressedDispatcher$Companion {
+}
+
+public final class app/cash/redwood/ui/Size {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/ui/Size$Companion;
+	public synthetic fun <init> (DDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight-hdgK9uQ ()D
+	public final fun getWidth-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/ui/Size$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Size$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/ui/Size;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/ui/Size;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Size$Companion {
+	public final fun getZero ()Lapp/cash/redwood/ui/Size;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/UiConfiguration {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/ui/UiConfiguration$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLapp/cash/redwood/ui/Margin;Lapp/cash/redwood/ui/Size;D)V
+	public synthetic fun <init> (ZLapp/cash/redwood/ui/Margin;Lapp/cash/redwood/ui/Size;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDarkMode ()Z
+	public final fun getDensity ()D
+	public final fun getSafeAreaInsets ()Lapp/cash/redwood/ui/Margin;
+	public final fun getViewportSize ()Lapp/cash/redwood/ui/Size;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/ui/UiConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/UiConfiguration$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/ui/UiConfiguration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/ui/UiConfiguration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/UiConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/redwood-runtime/api/jvm/redwood-runtime.api
+++ b/redwood-runtime/api/jvm/redwood-runtime.api
@@ -1,0 +1,216 @@
+public abstract interface annotation class app/cash/redwood/LayoutScopeMarker : java/lang/annotation/Annotation {
+}
+
+public abstract interface class app/cash/redwood/Modifier {
+	public static final field Companion Lapp/cash/redwood/Modifier$Companion;
+	public abstract fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
+}
+
+public final class app/cash/redwood/Modifier$Companion : app/cash/redwood/Modifier {
+	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class app/cash/redwood/Modifier$Element : app/cash/redwood/Modifier {
+	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface annotation class app/cash/redwood/RedwoodCodegenApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class app/cash/redwood/ui/Cancellable {
+	public abstract fun cancel ()V
+}
+
+public final class app/cash/redwood/ui/Density {
+	public static final field Companion Lapp/cash/redwood/ui/Density$Companion;
+	public static final synthetic fun box-impl (D)Lapp/cash/redwood/ui/Density;
+	public static fun constructor-impl (D)D
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (DLjava/lang/Object;)Z
+	public static final fun equals-impl0 (DD)Z
+	public final fun getRawDensity ()D
+	public fun hashCode ()I
+	public static fun hashCode-impl (D)I
+	public static final fun toDp-Ht7-4L4 (DD)D
+	public static final fun toDp-Ht7-4L4 (DF)D
+	public static final fun toDp-Ht7-4L4 (DI)D
+	public static final fun toPx-mnpKzHI (DD)D
+	public static final fun toPxInt-mnpKzHI (DD)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (D)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()D
+}
+
+public final class app/cash/redwood/ui/Density$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Density$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-wj95dkU (Lkotlinx/serialization/encoding/Decoder;)D
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize--vrfCzw (Lkotlinx/serialization/encoding/Encoder;D)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Density$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Dp {
+	public static final field Companion Lapp/cash/redwood/ui/Dp$Companion;
+	public static final synthetic fun box-impl (D)Lapp/cash/redwood/ui/Dp;
+	public static fun constructor-impl (D)D
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (DLjava/lang/Object;)Z
+	public static final fun equals-impl0 (DD)Z
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public static fun hashCode-impl (D)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (D)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()D
+}
+
+public final class app/cash/redwood/ui/Dp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Dp$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-Ht7-4L4 (Lkotlinx/serialization/encoding/Decoder;)D
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-slHoOYc (Lkotlinx/serialization/encoding/Encoder;D)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Dp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/DpKt {
+	public static final fun fromPlatformDp (Lapp/cash/redwood/ui/Dp$Companion;D)D
+	public static final fun getDp (D)D
+	public static final fun getDp (F)D
+	public static final fun getDp (I)D
+	public static final fun toPlatformDp-mnpKzHI (D)D
+}
+
+public final class app/cash/redwood/ui/Margin {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/ui/Margin$Companion;
+	public synthetic fun <init> (DDDDILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (DDDDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom-hdgK9uQ ()D
+	public final fun getEnd-hdgK9uQ ()D
+	public final fun getStart-hdgK9uQ ()D
+	public final fun getTop-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/ui/Margin$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Margin$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/ui/Margin;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/ui/Margin;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Margin$Companion {
+	public final fun getZero ()Lapp/cash/redwood/ui/Margin;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/MarginKt {
+	public static final fun Margin-mH_gOfM (DD)Lapp/cash/redwood/ui/Margin;
+	public static synthetic fun Margin-mH_gOfM$default (DDILjava/lang/Object;)Lapp/cash/redwood/ui/Margin;
+	public static final fun Margin-mnpKzHI (D)Lapp/cash/redwood/ui/Margin;
+	public static synthetic fun Margin-mnpKzHI$default (DILjava/lang/Object;)Lapp/cash/redwood/ui/Margin;
+}
+
+public abstract class app/cash/redwood/ui/OnBackPressedCallback {
+	public static final field $stable I
+	public fun <init> (Z)V
+	public final fun getEnabledChangedCallback ()Lkotlin/jvm/functions/Function0;
+	public abstract fun handleOnBackPressed ()V
+	public final fun isEnabled ()Z
+	public final fun setEnabled (Z)V
+	public final fun setEnabledChangedCallback (Lkotlin/jvm/functions/Function0;)V
+}
+
+public abstract interface class app/cash/redwood/ui/OnBackPressedDispatcher {
+	public static final field Companion Lapp/cash/redwood/ui/OnBackPressedDispatcher$Companion;
+	public abstract fun addCallback (Lapp/cash/redwood/ui/OnBackPressedCallback;)Lapp/cash/redwood/ui/Cancellable;
+}
+
+public final class app/cash/redwood/ui/OnBackPressedDispatcher$Companion {
+}
+
+public final class app/cash/redwood/ui/Size {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/ui/Size$Companion;
+	public synthetic fun <init> (DDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight-hdgK9uQ ()D
+	public final fun getWidth-hdgK9uQ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/ui/Size$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/Size$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/ui/Size;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/ui/Size;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/Size$Companion {
+	public final fun getZero ()Lapp/cash/redwood/ui/Size;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/UiConfiguration {
+	public static final field $stable I
+	public static final field Companion Lapp/cash/redwood/ui/UiConfiguration$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLapp/cash/redwood/ui/Margin;Lapp/cash/redwood/ui/Size;D)V
+	public synthetic fun <init> (ZLapp/cash/redwood/ui/Margin;Lapp/cash/redwood/ui/Size;DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDarkMode ()Z
+	public final fun getDensity ()D
+	public final fun getSafeAreaInsets ()Lapp/cash/redwood/ui/Margin;
+	public final fun getViewportSize ()Lapp/cash/redwood/ui/Size;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/ui/UiConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/ui/UiConfiguration$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/ui/UiConfiguration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/ui/UiConfiguration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/ui/UiConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/redwood-schema/api/redwood-schema.api
+++ b/redwood-schema/api/redwood-schema.api
@@ -1,0 +1,35 @@
+public abstract interface annotation class app/cash/redwood/schema/Children : java/lang/annotation/Annotation {
+	public abstract fun tag ()I
+}
+
+public abstract interface annotation class app/cash/redwood/schema/Default : java/lang/annotation/Annotation {
+	public abstract fun expression ()Ljava/lang/String;
+}
+
+public abstract interface annotation class app/cash/redwood/schema/Modifier : java/lang/annotation/Annotation {
+	public abstract fun scopes ()[Ljava/lang/Class;
+	public abstract fun tag ()I
+}
+
+public abstract interface annotation class app/cash/redwood/schema/Property : java/lang/annotation/Annotation {
+	public abstract fun tag ()I
+}
+
+public abstract interface annotation class app/cash/redwood/schema/Schema : java/lang/annotation/Annotation {
+	public abstract fun dependencies ()[Lapp/cash/redwood/schema/Schema$Dependency;
+	public abstract fun members ()[Ljava/lang/Class;
+	public abstract fun reservedModifiers ()[I
+	public abstract fun reservedWidgets ()[I
+}
+
+public abstract interface annotation class app/cash/redwood/schema/Schema$Dependency : java/lang/annotation/Annotation {
+	public abstract fun schema ()Ljava/lang/Class;
+	public abstract fun tag ()I
+}
+
+public abstract interface annotation class app/cash/redwood/schema/Widget : java/lang/annotation/Annotation {
+	public abstract fun reservedChildren ()[I
+	public abstract fun reservedProperties ()[I
+	public abstract fun tag ()I
+}
+

--- a/redwood-testing/api/android/redwood-testing.api
+++ b/redwood-testing/api/android/redwood-testing.api
@@ -1,0 +1,39 @@
+public final class app/cash/redwood/testing/NoOpOnBackPressedDispatcher : app/cash/redwood/ui/OnBackPressedDispatcher {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/testing/NoOpOnBackPressedDispatcher;
+	public fun addCallback (Lapp/cash/redwood/ui/OnBackPressedCallback;)Lapp/cash/redwood/ui/Cancellable;
+}
+
+public abstract interface class app/cash/redwood/testing/TestRedwoodComposition : app/cash/redwood/compose/RedwoodComposition {
+	public abstract fun awaitSnapshot-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitSnapshot-VtjQ1oo$default (Lapp/cash/redwood/testing/TestRedwoodComposition;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getUiConfigurations ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	public abstract fun saveState ()Lapp/cash/redwood/testing/TestSavedState;
+}
+
+public final class app/cash/redwood/testing/TestRedwoodCompositionKt {
+	public static final fun TestRedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/WidgetSystem;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/testing/TestRedwoodComposition;
+	public static synthetic fun TestRedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/WidgetSystem;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/testing/TestRedwoodComposition;
+}
+
+public abstract class app/cash/redwood/testing/TestSavedState {
+	public static final field $stable I
+}
+
+public final class app/cash/redwood/testing/ToChangeListKt {
+	public static final fun toChangeList (Lapp/cash/redwood/testing/WidgetValue;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;)Ljava/util/List;
+	public static final fun toChangeList (Ljava/util/List;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;)Ljava/util/List;
+	public static synthetic fun toChangeList$default (Lapp/cash/redwood/testing/WidgetValue;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun toChangeList$default (Ljava/util/List;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public abstract interface class app/cash/redwood/testing/WidgetValue {
+	public fun getChildrenLists ()Ljava/util/List;
+	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
+	public abstract fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+
+public final class app/cash/redwood/testing/WidgetValueKt {
+	public static final fun flatten (Ljava/util/List;)Lkotlin/sequences/Sequence;
+}
+

--- a/redwood-testing/api/jvm/redwood-testing.api
+++ b/redwood-testing/api/jvm/redwood-testing.api
@@ -1,0 +1,39 @@
+public final class app/cash/redwood/testing/NoOpOnBackPressedDispatcher : app/cash/redwood/ui/OnBackPressedDispatcher {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/cash/redwood/testing/NoOpOnBackPressedDispatcher;
+	public fun addCallback (Lapp/cash/redwood/ui/OnBackPressedCallback;)Lapp/cash/redwood/ui/Cancellable;
+}
+
+public abstract interface class app/cash/redwood/testing/TestRedwoodComposition : app/cash/redwood/compose/RedwoodComposition {
+	public abstract fun awaitSnapshot-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitSnapshot-VtjQ1oo$default (Lapp/cash/redwood/testing/TestRedwoodComposition;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getUiConfigurations ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	public abstract fun saveState ()Lapp/cash/redwood/testing/TestSavedState;
+}
+
+public final class app/cash/redwood/testing/TestRedwoodCompositionKt {
+	public static final fun TestRedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/WidgetSystem;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/testing/TestRedwoodComposition;
+	public static synthetic fun TestRedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/WidgetSystem;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lapp/cash/redwood/testing/TestSavedState;Lapp/cash/redwood/ui/UiConfiguration;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/testing/TestRedwoodComposition;
+}
+
+public abstract class app/cash/redwood/testing/TestSavedState {
+	public static final field $stable I
+}
+
+public final class app/cash/redwood/testing/ToChangeListKt {
+	public static final fun toChangeList (Lapp/cash/redwood/testing/WidgetValue;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;)Ljava/util/List;
+	public static final fun toChangeList (Ljava/util/List;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;)Ljava/util/List;
+	public static synthetic fun toChangeList$default (Lapp/cash/redwood/testing/WidgetValue;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun toChangeList$default (Ljava/util/List;Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public abstract interface class app/cash/redwood/testing/WidgetValue {
+	public fun getChildrenLists ()Ljava/util/List;
+	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
+	public abstract fun toWidget (Lapp/cash/redwood/widget/WidgetSystem;)Lapp/cash/redwood/widget/Widget;
+}
+
+public final class app/cash/redwood/testing/WidgetValueKt {
+	public static final fun flatten (Ljava/util/List;)Lkotlin/sequences/Sequence;
+}
+

--- a/redwood-tooling-codegen/api/redwood-tooling-codegen.api
+++ b/redwood-tooling-codegen/api/redwood-tooling-codegen.api
@@ -1,0 +1,30 @@
+public final class app/cash/redwood/tooling/codegen/CodegenKt {
+	public static final fun generate (Lapp/cash/redwood/tooling/schema/SchemaSet;Lapp/cash/redwood/tooling/codegen/CodegenType;Ljava/nio/file/Path;)V
+}
+
+public final class app/cash/redwood/tooling/codegen/CodegenType : java/lang/Enum {
+	public static final field Compose Lapp/cash/redwood/tooling/codegen/CodegenType;
+	public static final field Modifiers Lapp/cash/redwood/tooling/codegen/CodegenType;
+	public static final field Testing Lapp/cash/redwood/tooling/codegen/CodegenType;
+	public static final field Widget Lapp/cash/redwood/tooling/codegen/CodegenType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/cash/redwood/tooling/codegen/CodegenType;
+	public static fun values ()[Lapp/cash/redwood/tooling/codegen/CodegenType;
+}
+
+public final class app/cash/redwood/tooling/codegen/Main {
+	public static final fun main ([Ljava/lang/String;)V
+}
+
+public final class app/cash/redwood/tooling/codegen/ProtocolCodegenKt {
+	public static final fun generate (Lapp/cash/redwood/tooling/schema/ProtocolSchemaSet;Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;Ljava/nio/file/Path;)V
+}
+
+public final class app/cash/redwood/tooling/codegen/ProtocolCodegenType : java/lang/Enum {
+	public static final field Compose Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
+	public static final field Widget Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
+	public static fun values ()[Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
+}
+

--- a/redwood-tooling-lint/api/redwood-tooling-lint.api
+++ b/redwood-tooling-lint/api/redwood-tooling-lint.api
@@ -1,0 +1,11 @@
+public final class app/cash/redwood/tooling/lint/ApiMerger {
+	public fun <init> ()V
+	public final fun add (Ljava/lang/String;)Lapp/cash/redwood/tooling/lint/ApiMerger;
+	public final fun merge ()Ljava/lang/String;
+	public final synthetic fun plusAssign (Ljava/lang/String;)V
+}
+
+public final class app/cash/redwood/tooling/lint/Main {
+	public static final fun main ([Ljava/lang/String;)V
+}
+

--- a/redwood-tooling-schema/api/redwood-tooling-schema.api
+++ b/redwood-tooling-schema/api/redwood-tooling-schema.api
@@ -1,0 +1,181 @@
+public abstract interface class app/cash/redwood/tooling/schema/Deprecation {
+	public abstract fun getLevel ()Lapp/cash/redwood/tooling/schema/Deprecation$Level;
+	public abstract fun getMessage ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/tooling/schema/Deprecation$Level : java/lang/Enum {
+	public static final field ERROR Lapp/cash/redwood/tooling/schema/Deprecation$Level;
+	public static final field WARNING Lapp/cash/redwood/tooling/schema/Deprecation$Level;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/cash/redwood/tooling/schema/Deprecation$Level;
+	public static fun values ()[Lapp/cash/redwood/tooling/schema/Deprecation$Level;
+}
+
+public final class app/cash/redwood/tooling/schema/EmbeddedSchema {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lapp/cash/redwood/tooling/schema/EmbeddedSchema;
+	public static synthetic fun copy$default (Lapp/cash/redwood/tooling/schema/EmbeddedSchema;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/redwood/tooling/schema/EmbeddedSchema;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJson ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/tooling/schema/FqType {
+	public static final field Companion Lapp/cash/redwood/tooling/schema/FqType$Companion;
+	public fun <init> (Ljava/util/List;Lapp/cash/redwood/tooling/schema/FqType$Variance;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/util/List;Lapp/cash/redwood/tooling/schema/FqType$Variance;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lapp/cash/redwood/tooling/schema/FqType$Variance;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/util/List;Lapp/cash/redwood/tooling/schema/FqType$Variance;Ljava/util/List;Z)Lapp/cash/redwood/tooling/schema/FqType;
+	public static synthetic fun copy$default (Lapp/cash/redwood/tooling/schema/FqType;Ljava/util/List;Lapp/cash/redwood/tooling/schema/FqType$Variance;Ljava/util/List;ZILjava/lang/Object;)Lapp/cash/redwood/tooling/schema/FqType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNames ()Ljava/util/List;
+	public final fun getNullable ()Z
+	public final fun getParameterTypes ()Ljava/util/List;
+	public final fun getVariance ()Lapp/cash/redwood/tooling/schema/FqType$Variance;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/tooling/schema/FqType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/tooling/schema/FqType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/tooling/schema/FqType;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/tooling/schema/FqType;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/tooling/schema/FqType$Companion {
+	public final fun bestGuess (Ljava/lang/String;)Lapp/cash/redwood/tooling/schema/FqType;
+	public final fun getStar ()Lapp/cash/redwood/tooling/schema/FqType;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/tooling/schema/FqType$Variance : java/lang/Enum {
+	public static final field In Lapp/cash/redwood/tooling/schema/FqType$Variance;
+	public static final field Invariant Lapp/cash/redwood/tooling/schema/FqType$Variance;
+	public static final field Out Lapp/cash/redwood/tooling/schema/FqType$Variance;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/cash/redwood/tooling/schema/FqType$Variance;
+	public static fun values ()[Lapp/cash/redwood/tooling/schema/FqType$Variance;
+}
+
+public final class app/cash/redwood/tooling/schema/Main {
+	public static final fun main ([Ljava/lang/String;)V
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Modifier {
+	public abstract fun getDeprecation ()Lapp/cash/redwood/tooling/schema/Deprecation;
+	public abstract fun getDocumentation ()Ljava/lang/String;
+	public abstract fun getProperties ()Ljava/util/List;
+	public abstract fun getScopes ()Ljava/util/List;
+	public abstract fun getType ()Lapp/cash/redwood/tooling/schema/FqType;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Modifier$Property {
+	public abstract fun getDefaultExpression ()Ljava/lang/String;
+	public abstract fun getDeprecation ()Lapp/cash/redwood/tooling/schema/Deprecation;
+	public abstract fun getDocumentation ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getType ()Lapp/cash/redwood/tooling/schema/FqType;
+	public abstract fun isSerializable ()Z
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolModifier : app/cash/redwood/tooling/schema/Modifier {
+	public abstract fun getTag ()I
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolSchema : app/cash/redwood/tooling/schema/Schema {
+	public fun getDependencies ()Ljava/util/List;
+	public abstract fun getModifiers ()Ljava/util/List;
+	public abstract fun getTaggedDependencies ()Ljava/util/Map;
+	public abstract fun getWidgets ()Ljava/util/List;
+	public abstract fun toEmbeddedSchema ()Lapp/cash/redwood/tooling/schema/EmbeddedSchema;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolSchemaSet : app/cash/redwood/tooling/schema/SchemaSet {
+	public static final field Companion Lapp/cash/redwood/tooling/schema/ProtocolSchemaSet$Companion;
+	public fun getAll ()Ljava/util/List;
+	public abstract fun getDependencies ()Ljava/util/Map;
+	public abstract fun getSchema ()Lapp/cash/redwood/tooling/schema/ProtocolSchema;
+}
+
+public final class app/cash/redwood/tooling/schema/ProtocolSchemaSet$Companion {
+	public final fun load (Lapp/cash/redwood/tooling/schema/FqType;Ljava/lang/ClassLoader;)Lapp/cash/redwood/tooling/schema/ProtocolSchemaSet;
+	public final fun parse (Lkotlin/reflect/KClass;)Lapp/cash/redwood/tooling/schema/ProtocolSchemaSet;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolWidget : app/cash/redwood/tooling/schema/Widget {
+	public abstract fun getTag ()I
+	public abstract fun getTraits ()Ljava/util/List;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolWidget$ProtocolChildren : app/cash/redwood/tooling/schema/ProtocolWidget$ProtocolTrait, app/cash/redwood/tooling/schema/Widget$Children {
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolWidget$ProtocolEvent : app/cash/redwood/tooling/schema/ProtocolWidget$ProtocolTrait, app/cash/redwood/tooling/schema/Widget$Event {
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolWidget$ProtocolProperty : app/cash/redwood/tooling/schema/ProtocolWidget$ProtocolTrait, app/cash/redwood/tooling/schema/Widget$Property {
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/ProtocolWidget$ProtocolTrait : app/cash/redwood/tooling/schema/Widget$Trait {
+	public abstract fun getTag ()I
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Schema {
+	public abstract fun getDependencies ()Ljava/util/List;
+	public abstract fun getDocumentation ()Ljava/lang/String;
+	public abstract fun getModifiers ()Ljava/util/List;
+	public abstract fun getScopes ()Ljava/util/List;
+	public abstract fun getType ()Lapp/cash/redwood/tooling/schema/FqType;
+	public abstract fun getWidgets ()Ljava/util/List;
+}
+
+public final class app/cash/redwood/tooling/schema/SchemaParserFirKt {
+	public static final fun parseProtocolSchema (Ljava/util/Collection;Ljava/util/Collection;Lapp/cash/redwood/tooling/schema/FqType;)Lapp/cash/redwood/tooling/schema/ProtocolSchemaSet;
+	public static final fun parseSchema (Ljava/util/Collection;Ljava/util/Collection;Lapp/cash/redwood/tooling/schema/FqType;)Lapp/cash/redwood/tooling/schema/SchemaSet;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/SchemaSet {
+	public fun getAll ()Ljava/util/List;
+	public abstract fun getDependencies ()Ljava/util/Map;
+	public abstract fun getSchema ()Lapp/cash/redwood/tooling/schema/Schema;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Widget {
+	public abstract fun getDeprecation ()Lapp/cash/redwood/tooling/schema/Deprecation;
+	public abstract fun getDocumentation ()Ljava/lang/String;
+	public abstract fun getTraits ()Ljava/util/List;
+	public abstract fun getType ()Lapp/cash/redwood/tooling/schema/FqType;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Widget$Children : app/cash/redwood/tooling/schema/Widget$Trait {
+	public abstract fun getScope ()Lapp/cash/redwood/tooling/schema/FqType;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Widget$Event : app/cash/redwood/tooling/schema/Widget$Trait {
+	public abstract fun getParameterTypes ()Ljava/util/List;
+	public abstract fun isNullable ()Z
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Widget$Property : app/cash/redwood/tooling/schema/Widget$Trait {
+	public abstract fun getType ()Lapp/cash/redwood/tooling/schema/FqType;
+}
+
+public abstract interface class app/cash/redwood/tooling/schema/Widget$Trait {
+	public abstract fun getDefaultExpression ()Ljava/lang/String;
+	public abstract fun getDeprecation ()Lapp/cash/redwood/tooling/schema/Deprecation;
+	public abstract fun getDocumentation ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+}
+

--- a/redwood-treehouse-guest-compose/api/redwood-treehouse-guest-compose.api
+++ b/redwood-treehouse-guest-compose/api/redwood-treehouse-guest-compose.api
@@ -1,0 +1,9 @@
+public final class app/cash/redwood/treehouse/CompositionKt {
+	public static final fun bind (Lapp/cash/redwood/compose/RedwoodComposition;Lapp/cash/redwood/treehouse/TreehouseUi;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseUi {
+	public abstract fun Show (Landroidx/compose/runtime/Composer;I)V
+	public fun close ()V
+}
+

--- a/redwood-treehouse-guest/api/android/redwood-treehouse-guest.api
+++ b/redwood-treehouse-guest/api/android/redwood-treehouse-guest.api
@@ -1,0 +1,12 @@
+public final class app/cash/redwood/treehouse/StandardAppLifecycle : app/cash/redwood/treehouse/AppLifecycle {
+	public synthetic fun <init> (Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun getFrameClock ()Landroidx/compose/runtime/MonotonicFrameClock;
+	public fun sendFrame (J)V
+	public fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
+}
+
+public final class app/cash/redwood/treehouse/TreehouseComposeKt {
+	public static final fun asZiplineTreehouseUi (Lapp/cash/redwood/treehouse/TreehouseUi;Lapp/cash/redwood/treehouse/StandardAppLifecycle;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;
+}
+

--- a/redwood-treehouse-guest/api/jvm/redwood-treehouse-guest.api
+++ b/redwood-treehouse-guest/api/jvm/redwood-treehouse-guest.api
@@ -1,0 +1,12 @@
+public final class app/cash/redwood/treehouse/StandardAppLifecycle : app/cash/redwood/treehouse/AppLifecycle {
+	public synthetic fun <init> (Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun getFrameClock ()Landroidx/compose/runtime/MonotonicFrameClock;
+	public fun sendFrame (J)V
+	public fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
+}
+
+public final class app/cash/redwood/treehouse/TreehouseComposeKt {
+	public static final fun asZiplineTreehouseUi (Lapp/cash/redwood/treehouse/TreehouseUi;Lapp/cash/redwood/treehouse/StandardAppLifecycle;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;
+}
+

--- a/redwood-treehouse-host-composeui/api/android/redwood-treehouse-host-composeui.api
+++ b/redwood-treehouse-host-composeui/api/android/redwood-treehouse-host-composeui.api
@@ -1,0 +1,4 @@
+public final class app/cash/redwood/treehouse/composeui/TreehouseContentKt {
+	public static final fun TreehouseContent (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView$WidgetSystem;Lapp/cash/redwood/treehouse/TreehouseContentSource;Landroidx/compose/ui/Modifier;Lapp/cash/redwood/treehouse/CodeListener;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/redwood-treehouse-host-composeui/api/jvm/redwood-treehouse-host-composeui.api
+++ b/redwood-treehouse-host-composeui/api/jvm/redwood-treehouse-host-composeui.api
@@ -1,0 +1,4 @@
+public final class app/cash/redwood/treehouse/composeui/TreehouseContentKt {
+	public static final fun TreehouseContent (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView$WidgetSystem;Lapp/cash/redwood/treehouse/TreehouseContentSource;Landroidx/compose/ui/Modifier;Lapp/cash/redwood/treehouse/CodeListener;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/redwood-treehouse-host/api/android/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/android/redwood-treehouse-host.api
@@ -1,0 +1,161 @@
+public final class app/cash/redwood/treehouse/ChangeListRenderer {
+	public fun <init> (Lkotlinx/serialization/json/Json;)V
+	public final fun render-rqC_l18 (Lapp/cash/redwood/treehouse/TreehouseView;Ljava/util/List;)V
+}
+
+public class app/cash/redwood/treehouse/CodeListener {
+	public fun <init> ()V
+	public fun onCodeLoaded (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView;Z)V
+	public fun onInitialCodeLoading (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView;)V
+	public fun onUncaughtException (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView;Ljava/lang/Throwable;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/Content {
+	public abstract fun awaitContent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Lapp/cash/redwood/treehouse/TreehouseView;)V
+	public abstract fun preload (Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lkotlinx/coroutines/flow/StateFlow;)V
+	public abstract fun unbind ()V
+}
+
+public final class app/cash/redwood/treehouse/ContentBindingKt {
+	public static final fun bindWhenReady (Lapp/cash/redwood/treehouse/Content;Lapp/cash/redwood/treehouse/TreehouseView;)Ljava/io/Closeable;
+	public static final fun bindWhenReady (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/TreehouseView;Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/CodeListener;)Ljava/io/Closeable;
+	public static synthetic fun bindWhenReady$default (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/TreehouseView;Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/CodeListener;ILjava/lang/Object;)Ljava/io/Closeable;
+}
+
+public class app/cash/redwood/treehouse/EventListener {
+	public static final field Companion Lapp/cash/redwood/treehouse/EventListener$Companion;
+	public fun <init> ()V
+	public fun bindService (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;)V
+	public fun callEnd (Lapp/cash/zipline/Call;Lapp/cash/zipline/CallResult;Ljava/lang/Object;)V
+	public fun callStart (Lapp/cash/zipline/Call;)Ljava/lang/Object;
+	public fun codeLoadFailed (Ljava/lang/Exception;Ljava/lang/Object;)V
+	public fun codeLoadSkipped (Ljava/lang/Object;)V
+	public fun codeLoadSkippedNotFresh (Ljava/lang/Object;)V
+	public fun codeLoadStart ()Ljava/lang/Object;
+	public fun codeLoadSuccess (Lapp/cash/zipline/ZiplineManifest;Lapp/cash/zipline/Zipline;Ljava/lang/Object;)V
+	public fun codeUnloaded ()V
+	public fun downloadFailed (Ljava/lang/String;Ljava/lang/Exception;Ljava/lang/Object;)V
+	public fun downloadStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun downloadSuccess (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun initializerEnd (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun initializerStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun mainFunctionEnd (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun mainFunctionStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun manifestParseFailed (Ljava/lang/Exception;)V
+	public fun manifestReady (Lapp/cash/zipline/ZiplineManifest;)V
+	public fun manifestVerified (Lapp/cash/zipline/ZiplineManifest;Ljava/lang/String;)V
+	public fun moduleLoadEnd (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun moduleLoadStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun serviceLeaked (Ljava/lang/String;)V
+	public fun takeService (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;)V
+	public fun uncaughtException (Ljava/lang/Throwable;)V
+	public fun unknownChildren-iETOA3M (II)V
+	public fun unknownEvent-_LM6m-c (II)V
+	public fun unknownEventNode-1ccMwuE (II)V
+	public fun unknownModifier-nx0wl1g (I)V
+	public fun unknownProperty-LKUuuww (II)V
+	public fun unknownWidget-WCEpcRY (I)V
+	public fun ziplineCreated (Lapp/cash/zipline/Zipline;)V
+}
+
+public final class app/cash/redwood/treehouse/EventListener$Companion {
+	public final fun getNONE ()Lapp/cash/redwood/treehouse/EventListener$Factory;
+}
+
+public abstract interface class app/cash/redwood/treehouse/EventListener$Factory {
+	public abstract fun create (Lapp/cash/redwood/treehouse/TreehouseApp;Ljava/lang/String;)Lapp/cash/redwood/treehouse/EventListener;
+}
+
+public final class app/cash/redwood/treehouse/MemoryStateStore : app/cash/redwood/treehouse/StateStore {
+	public fun <init> ()V
+	public fun get (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun put (Ljava/lang/String;Lapp/cash/redwood/treehouse/StateSnapshot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class app/cash/redwood/treehouse/StateStore {
+	public abstract fun get (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun put (Ljava/lang/String;Lapp/cash/redwood/treehouse/StateSnapshot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class app/cash/redwood/treehouse/TreehouseApp {
+	public synthetic fun <init> (Lapp/cash/redwood/treehouse/TreehouseApp$Factory;Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun createContent (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;)Lapp/cash/redwood/treehouse/Content;
+	public static synthetic fun createContent$default (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/Content;
+	public final fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
+	public final fun getSpec ()Lapp/cash/redwood/treehouse/TreehouseApp$Spec;
+	public final fun getZipline ()Lapp/cash/zipline/Zipline;
+	public final fun restart ()V
+	public final fun start ()V
+	public final fun stop ()V
+}
+
+public final class app/cash/redwood/treehouse/TreehouseApp$Factory : java/io/Closeable {
+	public fun close ()V
+	public final fun create (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;)Lapp/cash/redwood/treehouse/TreehouseApp;
+	public static synthetic fun create$default (Lapp/cash/redwood/treehouse/TreehouseApp$Factory;Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/TreehouseApp;
+	public final fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
+}
+
+public abstract class app/cash/redwood/treehouse/TreehouseApp$Spec {
+	public fun <init> ()V
+	public abstract fun bindServices (Lapp/cash/zipline/Zipline;)V
+	public abstract fun create (Lapp/cash/zipline/Zipline;)Lapp/cash/redwood/treehouse/AppService;
+	public fun getFreshnessChecker ()Lapp/cash/zipline/loader/FreshnessChecker;
+	public fun getLoadCodeFromNetworkOnly ()Z
+	public abstract fun getManifestUrl ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getName ()Ljava/lang/String;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class app/cash/redwood/treehouse/TreehouseAppFactoryAndroidKt {
+	public static final fun TreehouseAppFactory (Landroid/content/Context;Lokhttp3/OkHttpClient;Lapp/cash/zipline/loader/ManifestVerifier;Lokio/Path;Lokio/FileSystem;Ljava/lang/String;JILapp/cash/redwood/treehouse/StateStore;)Lapp/cash/redwood/treehouse/TreehouseApp$Factory;
+	public static synthetic fun TreehouseAppFactory$default (Landroid/content/Context;Lokhttp3/OkHttpClient;Lapp/cash/zipline/loader/ManifestVerifier;Lokio/Path;Lokio/FileSystem;Ljava/lang/String;JILapp/cash/redwood/treehouse/StateStore;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/TreehouseApp$Factory;
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseContentSource {
+	public abstract fun get (Lapp/cash/redwood/treehouse/AppService;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseDispatchers {
+	public abstract fun checkUi ()V
+	public abstract fun checkZipline ()V
+	public abstract fun close ()V
+	public abstract fun getUi ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public abstract fun getZipline ()Lkotlinx/coroutines/CoroutineDispatcher;
+}
+
+public final class app/cash/redwood/treehouse/TreehouseLayout : app/cash/redwood/widget/RedwoodLayout, app/cash/redwood/treehouse/TreehouseView {
+	public fun <init> (Landroid/content/Context;Lapp/cash/redwood/treehouse/TreehouseView$WidgetSystem;Landroidx/activity/OnBackPressedDispatcher;)V
+	public synthetic fun generateDefaultLayoutParams ()Landroid/view/ViewGroup$LayoutParams;
+	public fun getReadyForContent ()Z
+	public fun getReadyForContentChangeListener ()Lapp/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener;
+	public fun getSaveCallback ()Lapp/cash/redwood/treehouse/TreehouseView$SaveCallback;
+	public fun getStateSnapshotId-kwWZ-Q0 ()Ljava/lang/String;
+	public fun getWidgetSystem ()Lapp/cash/redwood/treehouse/TreehouseView$WidgetSystem;
+	public fun setReadyForContentChangeListener (Lapp/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener;)V
+	public fun setSaveCallback (Lapp/cash/redwood/treehouse/TreehouseView$SaveCallback;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView : app/cash/redwood/widget/RedwoodView {
+	public abstract fun getReadyForContent ()Z
+	public abstract fun getReadyForContentChangeListener ()Lapp/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener;
+	public abstract fun getSaveCallback ()Lapp/cash/redwood/treehouse/TreehouseView$SaveCallback;
+	public abstract fun getStateSnapshotId-kwWZ-Q0 ()Ljava/lang/String;
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/treehouse/TreehouseView$WidgetSystem;
+	public abstract fun setReadyForContentChangeListener (Lapp/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener;)V
+	public abstract fun setSaveCallback (Lapp/cash/redwood/treehouse/TreehouseView$SaveCallback;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener {
+	public abstract fun onReadyForContentChanged (Lapp/cash/redwood/treehouse/TreehouseView;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView$SaveCallback {
+	public abstract fun performSave (Ljava/lang/String;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView$WidgetSystem {
+	public abstract fun widgetFactory (Lkotlinx/serialization/json/Json;Lapp/cash/redwood/protocol/widget/ProtocolMismatchHandler;)Lapp/cash/redwood/protocol/widget/ProtocolFactory;
+}
+

--- a/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
@@ -1,0 +1,144 @@
+public final class app/cash/redwood/treehouse/ChangeListRenderer {
+	public fun <init> (Lkotlinx/serialization/json/Json;)V
+	public final fun render-rqC_l18 (Lapp/cash/redwood/treehouse/TreehouseView;Ljava/util/List;)V
+}
+
+public class app/cash/redwood/treehouse/CodeListener {
+	public fun <init> ()V
+	public fun onCodeLoaded (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView;Z)V
+	public fun onInitialCodeLoading (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView;)V
+	public fun onUncaughtException (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseView;Ljava/lang/Throwable;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/Content {
+	public abstract fun awaitContent (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bind (Lapp/cash/redwood/treehouse/TreehouseView;)V
+	public abstract fun preload (Lapp/cash/redwood/ui/OnBackPressedDispatcher;Lkotlinx/coroutines/flow/StateFlow;)V
+	public abstract fun unbind ()V
+}
+
+public final class app/cash/redwood/treehouse/ContentBindingKt {
+	public static final fun bindWhenReady (Lapp/cash/redwood/treehouse/Content;Lapp/cash/redwood/treehouse/TreehouseView;)Ljava/io/Closeable;
+	public static final fun bindWhenReady (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/TreehouseView;Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/CodeListener;)Ljava/io/Closeable;
+	public static synthetic fun bindWhenReady$default (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/TreehouseView;Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/CodeListener;ILjava/lang/Object;)Ljava/io/Closeable;
+}
+
+public class app/cash/redwood/treehouse/EventListener {
+	public static final field Companion Lapp/cash/redwood/treehouse/EventListener$Companion;
+	public fun <init> ()V
+	public fun bindService (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;)V
+	public fun callEnd (Lapp/cash/zipline/Call;Lapp/cash/zipline/CallResult;Ljava/lang/Object;)V
+	public fun callStart (Lapp/cash/zipline/Call;)Ljava/lang/Object;
+	public fun codeLoadFailed (Ljava/lang/Exception;Ljava/lang/Object;)V
+	public fun codeLoadSkipped (Ljava/lang/Object;)V
+	public fun codeLoadSkippedNotFresh (Ljava/lang/Object;)V
+	public fun codeLoadStart ()Ljava/lang/Object;
+	public fun codeLoadSuccess (Lapp/cash/zipline/ZiplineManifest;Lapp/cash/zipline/Zipline;Ljava/lang/Object;)V
+	public fun codeUnloaded ()V
+	public fun downloadFailed (Ljava/lang/String;Ljava/lang/Exception;Ljava/lang/Object;)V
+	public fun downloadStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun downloadSuccess (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun initializerEnd (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun initializerStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun mainFunctionEnd (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun mainFunctionStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun manifestParseFailed (Ljava/lang/Exception;)V
+	public fun manifestReady (Lapp/cash/zipline/ZiplineManifest;)V
+	public fun manifestVerified (Lapp/cash/zipline/ZiplineManifest;Ljava/lang/String;)V
+	public fun moduleLoadEnd (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun moduleLoadStart (Ljava/lang/String;)Ljava/lang/Object;
+	public fun serviceLeaked (Ljava/lang/String;)V
+	public fun takeService (Ljava/lang/String;Lapp/cash/zipline/ZiplineService;)V
+	public fun uncaughtException (Ljava/lang/Throwable;)V
+	public fun unknownChildren-iETOA3M (II)V
+	public fun unknownEvent-_LM6m-c (II)V
+	public fun unknownEventNode-1ccMwuE (II)V
+	public fun unknownModifier-nx0wl1g (I)V
+	public fun unknownProperty-LKUuuww (II)V
+	public fun unknownWidget-WCEpcRY (I)V
+	public fun ziplineCreated (Lapp/cash/zipline/Zipline;)V
+}
+
+public final class app/cash/redwood/treehouse/EventListener$Companion {
+	public final fun getNONE ()Lapp/cash/redwood/treehouse/EventListener$Factory;
+}
+
+public abstract interface class app/cash/redwood/treehouse/EventListener$Factory {
+	public abstract fun create (Lapp/cash/redwood/treehouse/TreehouseApp;Ljava/lang/String;)Lapp/cash/redwood/treehouse/EventListener;
+}
+
+public final class app/cash/redwood/treehouse/MemoryStateStore : app/cash/redwood/treehouse/StateStore {
+	public fun <init> ()V
+	public fun get (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun put (Ljava/lang/String;Lapp/cash/redwood/treehouse/StateSnapshot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class app/cash/redwood/treehouse/StateStore {
+	public abstract fun get (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun put (Ljava/lang/String;Lapp/cash/redwood/treehouse/StateSnapshot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class app/cash/redwood/treehouse/TreehouseApp {
+	public synthetic fun <init> (Lapp/cash/redwood/treehouse/TreehouseApp$Factory;Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun createContent (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;)Lapp/cash/redwood/treehouse/Content;
+	public static synthetic fun createContent$default (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/Content;
+	public final fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
+	public final fun getSpec ()Lapp/cash/redwood/treehouse/TreehouseApp$Spec;
+	public final fun getZipline ()Lapp/cash/zipline/Zipline;
+	public final fun restart ()V
+	public final fun start ()V
+	public final fun stop ()V
+}
+
+public final class app/cash/redwood/treehouse/TreehouseApp$Factory : java/io/Closeable {
+	public fun close ()V
+	public final fun create (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;)Lapp/cash/redwood/treehouse/TreehouseApp;
+	public static synthetic fun create$default (Lapp/cash/redwood/treehouse/TreehouseApp$Factory;Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/TreehouseApp;
+	public final fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
+}
+
+public abstract class app/cash/redwood/treehouse/TreehouseApp$Spec {
+	public fun <init> ()V
+	public abstract fun bindServices (Lapp/cash/zipline/Zipline;)V
+	public abstract fun create (Lapp/cash/zipline/Zipline;)Lapp/cash/redwood/treehouse/AppService;
+	public fun getFreshnessChecker ()Lapp/cash/zipline/loader/FreshnessChecker;
+	public fun getLoadCodeFromNetworkOnly ()Z
+	public abstract fun getManifestUrl ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getName ()Ljava/lang/String;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseContentSource {
+	public abstract fun get (Lapp/cash/redwood/treehouse/AppService;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseDispatchers {
+	public abstract fun checkUi ()V
+	public abstract fun checkZipline ()V
+	public abstract fun close ()V
+	public abstract fun getUi ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public abstract fun getZipline ()Lkotlinx/coroutines/CoroutineDispatcher;
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView : app/cash/redwood/widget/RedwoodView {
+	public abstract fun getReadyForContent ()Z
+	public abstract fun getReadyForContentChangeListener ()Lapp/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener;
+	public abstract fun getSaveCallback ()Lapp/cash/redwood/treehouse/TreehouseView$SaveCallback;
+	public abstract fun getStateSnapshotId-kwWZ-Q0 ()Ljava/lang/String;
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/treehouse/TreehouseView$WidgetSystem;
+	public abstract fun setReadyForContentChangeListener (Lapp/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener;)V
+	public abstract fun setSaveCallback (Lapp/cash/redwood/treehouse/TreehouseView$SaveCallback;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView$ReadyForContentChangeListener {
+	public abstract fun onReadyForContentChanged (Lapp/cash/redwood/treehouse/TreehouseView;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView$SaveCallback {
+	public abstract fun performSave (Ljava/lang/String;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/TreehouseView$WidgetSystem {
+	public abstract fun widgetFactory (Lkotlinx/serialization/json/Json;Lapp/cash/redwood/protocol/widget/ProtocolMismatchHandler;)Lapp/cash/redwood/protocol/widget/ProtocolFactory;
+}
+

--- a/redwood-treehouse/api/android/redwood-treehouse.api
+++ b/redwood-treehouse/api/android/redwood-treehouse.api
@@ -1,0 +1,261 @@
+public abstract interface class app/cash/redwood/treehouse/AppLifecycle : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/AppLifecycle$Companion;
+	public abstract fun sendFrame (J)V
+	public abstract fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Companion {
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/AppLifecycle;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/AppLifecycle;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/AppLifecycle$Host : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/AppLifecycle$Host$Companion;
+	public abstract fun handleUncaughtException (Ljava/lang/Throwable;)V
+	public abstract fun onUnknownEvent-_LM6m-c (II)V
+	public abstract fun onUnknownEventNode-1ccMwuE (II)V
+	public abstract fun requestFrame ()V
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Host$Companion {
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Host$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/AppLifecycle$Host;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Host$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/AppService : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/AppService$Companion;
+	public abstract fun getAppLifecycle ()Lapp/cash/redwood/treehouse/AppLifecycle;
+}
+
+public final class app/cash/redwood/treehouse/AppService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/AppService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/AppService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/AppService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/AppService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/CancellableService : app/cash/redwood/ui/Cancellable, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/CancellableService$Companion;
+}
+
+public final class app/cash/redwood/treehouse/CancellableService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/CancellableService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/CancellableService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/CancellableService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/CancellableService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/ChangesSinkService : app/cash/redwood/protocol/ChangesSink, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/ChangesSinkService$Companion;
+}
+
+public final class app/cash/redwood/treehouse/ChangesSinkService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/ChangesSinkService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/ChangesSinkService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/ChangesSinkService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/ChangesSinkService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/OnBackPressedCallbackService : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/OnBackPressedCallbackService$Companion;
+	public abstract fun handleOnBackPressed ()V
+	public abstract fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedCallbackService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedCallbackService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedCallbackService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/OnBackPressedDispatcherService : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService$Companion;
+	public abstract fun addCallback (Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;)Lapp/cash/redwood/treehouse/CancellableService;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedDispatcherService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedDispatcherService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedDispatcherService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;)V
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot {
+	public static final field Companion Lapp/cash/redwood/treehouse/StateSnapshot$Companion;
+	public fun <init> (Ljava/util/Map;)V
+	public final fun getContent ()Ljava/util/Map;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/treehouse/StateSnapshot$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/treehouse/StateSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/treehouse/StateSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Id {
+	public static final field Companion Lapp/cash/redwood/treehouse/StateSnapshot$Id$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lapp/cash/redwood/treehouse/StateSnapshot$Id;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Id$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/treehouse/StateSnapshot$Id$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-CVq4lK4 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-x1_DTDE (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Id$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshotKt {
+	public static final fun getSaveableStateSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public abstract interface class app/cash/redwood/treehouse/ZiplineTreehouseUi : app/cash/redwood/protocol/EventSink, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Companion;
+	public fun snapshotState ()Lapp/cash/redwood/treehouse/StateSnapshot;
+	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
+	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
+	public abstract fun start (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;)V
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Companion {
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host : app/cash/redwood/treehouse/ChangesSinkService, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host$Companion;
+	public abstract fun addOnBackPressedCallback (Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;)Lapp/cash/redwood/treehouse/CancellableService;
+	public abstract fun getStateSnapshot ()Lapp/cash/redwood/treehouse/StateSnapshot;
+	public abstract fun getUiConfigurations ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host$Companion {
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;)V
+}
+

--- a/redwood-treehouse/api/jvm/redwood-treehouse.api
+++ b/redwood-treehouse/api/jvm/redwood-treehouse.api
@@ -1,0 +1,261 @@
+public abstract interface class app/cash/redwood/treehouse/AppLifecycle : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/AppLifecycle$Companion;
+	public abstract fun sendFrame (J)V
+	public abstract fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Companion {
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/AppLifecycle;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/AppLifecycle;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/AppLifecycle$Host : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/AppLifecycle$Host$Companion;
+	public abstract fun handleUncaughtException (Ljava/lang/Throwable;)V
+	public abstract fun onUnknownEvent-_LM6m-c (II)V
+	public abstract fun onUnknownEventNode-1ccMwuE (II)V
+	public abstract fun requestFrame ()V
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Host$Companion {
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Host$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/AppLifecycle$Host;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/AppLifecycle$Host$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/AppService : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/AppService$Companion;
+	public abstract fun getAppLifecycle ()Lapp/cash/redwood/treehouse/AppLifecycle;
+}
+
+public final class app/cash/redwood/treehouse/AppService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/AppService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/AppService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/AppService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/AppService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/CancellableService : app/cash/redwood/ui/Cancellable, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/CancellableService$Companion;
+}
+
+public final class app/cash/redwood/treehouse/CancellableService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/CancellableService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/CancellableService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/CancellableService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/CancellableService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/ChangesSinkService : app/cash/redwood/protocol/ChangesSink, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/ChangesSinkService$Companion;
+}
+
+public final class app/cash/redwood/treehouse/ChangesSinkService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/ChangesSinkService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/ChangesSinkService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/ChangesSinkService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/ChangesSinkService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/OnBackPressedCallbackService : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/OnBackPressedCallbackService$Companion;
+	public abstract fun handleOnBackPressed ()V
+	public abstract fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedCallbackService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedCallbackService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedCallbackService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/OnBackPressedDispatcherService : app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService$Companion;
+	public abstract fun addCallback (Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;)Lapp/cash/redwood/treehouse/CancellableService;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedDispatcherService$Companion {
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedDispatcherService$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/OnBackPressedDispatcherService$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;)V
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot {
+	public static final field Companion Lapp/cash/redwood/treehouse/StateSnapshot$Companion;
+	public fun <init> (Ljava/util/Map;)V
+	public final fun getContent ()Ljava/util/Map;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/treehouse/StateSnapshot$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lapp/cash/redwood/treehouse/StateSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lapp/cash/redwood/treehouse/StateSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Id {
+	public static final field Companion Lapp/cash/redwood/treehouse/StateSnapshot$Id$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lapp/cash/redwood/treehouse/StateSnapshot$Id;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Id$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lapp/cash/redwood/treehouse/StateSnapshot$Id$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize-CVq4lK4 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize-x1_DTDE (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshot$Id$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class app/cash/redwood/treehouse/StateSnapshotKt {
+	public static final fun getSaveableStateSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public abstract interface class app/cash/redwood/treehouse/ZiplineTreehouseUi : app/cash/redwood/protocol/EventSink, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Companion;
+	public fun snapshotState ()Lapp/cash/redwood/treehouse/StateSnapshot;
+	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
+	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
+	public abstract fun start (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;)V
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Companion {
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi;)V
+}
+
+public abstract interface class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host : app/cash/redwood/treehouse/ChangesSinkService, app/cash/zipline/ZiplineService {
+	public static final field Companion Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host$Companion;
+	public abstract fun addOnBackPressedCallback (Lapp/cash/redwood/treehouse/OnBackPressedCallbackService;)Lapp/cash/redwood/treehouse/CancellableService;
+	public abstract fun getStateSnapshot ()Lapp/cash/redwood/treehouse/StateSnapshot;
+	public abstract fun getUiConfigurations ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host$Companion {
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host$Companion$Adapter : app/cash/zipline/internal/bridge/ZiplineServiceAdapter, kotlinx/serialization/KSerializer {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun getSerialName ()Ljava/lang/String;
+	public final fun getSerializers ()Ljava/util/List;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;
+	public synthetic fun outboundService (Lapp/cash/zipline/internal/bridge/OutboundCallHandler;)Lapp/cash/zipline/ZiplineService;
+	public fun ziplineFunctions (Lkotlinx/serialization/modules/SerializersModule;)Ljava/util/List;
+}
+
+public final class app/cash/redwood/treehouse/ZiplineTreehouseUi$Host$DefaultImpls {
+	public static fun close (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;)V
+}
+

--- a/redwood-widget-compose/api/redwood-widget-compose.api
+++ b/redwood-widget-compose/api/redwood-widget-compose.api
@@ -1,0 +1,13 @@
+public final class app/cash/redwood/widget/compose/ComposeWidgetChildren : app/cash/redwood/widget/Widget$Children {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun Render (Landroidx/compose/runtime/Composer;I)V
+	public final fun getWidgets ()Ljava/util/List;
+	public fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public fun move (III)V
+	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public fun remove (II)V
+}
+

--- a/redwood-widget-testing/api/android/redwood-widget-testing.api
+++ b/redwood-widget-testing/api/android/redwood-widget-testing.api
@@ -1,0 +1,23 @@
+public abstract class app/cash/redwood/widget/testing/AbstractWidgetChildrenTest {
+	public fun <init> ()V
+	public final fun childrenInstanceDoesNotChange ()V
+	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun insertAppend ()V
+	public final fun insertPrepend ()V
+	public final fun insertRandom ()V
+	public final fun moveMultipleBackward ()V
+	public final fun moveMultipleForward ()V
+	public final fun moveSingleBackward ()V
+	public final fun moveSingleComposeApplierDocumentation ()V
+	public final fun moveSingleForward ()V
+	public final fun moveZero ()V
+	public abstract fun names ()Ljava/util/List;
+	public final fun removeMultipleEnd ()V
+	public final fun removeMultipleStart ()V
+	public final fun removeSingleEnd ()V
+	public final fun removeSingleStart ()V
+	public final fun removeZero ()V
+	public final fun replace ()V
+	public abstract fun widget (Ljava/lang/String;)Ljava/lang/Object;
+}
+

--- a/redwood-widget-testing/api/jvm/redwood-widget-testing.api
+++ b/redwood-widget-testing/api/jvm/redwood-widget-testing.api
@@ -1,0 +1,23 @@
+public abstract class app/cash/redwood/widget/testing/AbstractWidgetChildrenTest {
+	public fun <init> ()V
+	public final fun childrenInstanceDoesNotChange ()V
+	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun insertAppend ()V
+	public final fun insertPrepend ()V
+	public final fun insertRandom ()V
+	public final fun moveMultipleBackward ()V
+	public final fun moveMultipleForward ()V
+	public final fun moveSingleBackward ()V
+	public final fun moveSingleComposeApplierDocumentation ()V
+	public final fun moveSingleForward ()V
+	public final fun moveZero ()V
+	public abstract fun names ()Ljava/util/List;
+	public final fun removeMultipleEnd ()V
+	public final fun removeMultipleStart ()V
+	public final fun removeSingleEnd ()V
+	public final fun removeSingleStart ()V
+	public final fun removeZero ()V
+	public final fun replace ()V
+	public abstract fun widget (Ljava/lang/String;)Ljava/lang/Object;
+}
+

--- a/redwood-widget/api/android/redwood-widget.api
+++ b/redwood-widget/api/android/redwood-widget.api
@@ -1,0 +1,103 @@
+public abstract interface class app/cash/redwood/widget/ChangeListener {
+	public abstract fun onEndChanges ()V
+}
+
+public final class app/cash/redwood/widget/MutableListChildren : app/cash/redwood/widget/Widget$Children, java/util/List, kotlin/jvm/internal/markers/KMutableList {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (ILapp/cash/redwood/widget/Widget;)V
+	public synthetic fun add (ILjava/lang/Object;)V
+	public fun add (Lapp/cash/redwood/widget/Widget;)Z
+	public synthetic fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Lapp/cash/redwood/widget/Widget;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun get (I)Lapp/cash/redwood/widget/Widget;
+	public synthetic fun get (I)Ljava/lang/Object;
+	public fun getSize ()I
+	public fun indexOf (Lapp/cash/redwood/widget/Widget;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Lapp/cash/redwood/widget/Widget;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public fun move (III)V
+	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public final fun remove (I)Lapp/cash/redwood/widget/Widget;
+	public synthetic fun remove (I)Ljava/lang/Object;
+	public fun remove (II)V
+	public fun remove (Lapp/cash/redwood/widget/Widget;)Z
+	public final fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun removeAt (I)Lapp/cash/redwood/widget/Widget;
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILapp/cash/redwood/widget/Widget;)Lapp/cash/redwood/widget/Widget;
+	public synthetic fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+}
+
+public class app/cash/redwood/widget/RedwoodLayout : android/widget/FrameLayout, app/cash/redwood/widget/RedwoodView {
+	public fun <init> (Landroid/content/Context;Landroidx/activity/OnBackPressedDispatcher;)V
+	public fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public fun getOnBackPressedDispatcher ()Lapp/cash/redwood/ui/OnBackPressedDispatcher;
+	public fun getSavedStateRegistry ()Lapp/cash/redwood/widget/SavedStateRegistry;
+	public fun getUiConfiguration ()Lkotlinx/coroutines/flow/StateFlow;
+	protected fun onConfigurationChanged (Landroid/content/res/Configuration;)V
+	protected fun onLayout (ZIIII)V
+	public fun reset ()V
+}
+
+public abstract interface class app/cash/redwood/widget/RedwoodView {
+	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun getOnBackPressedDispatcher ()Lapp/cash/redwood/ui/OnBackPressedDispatcher;
+	public abstract fun getSavedStateRegistry ()Lapp/cash/redwood/widget/SavedStateRegistry;
+	public abstract fun getUiConfiguration ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun reset ()V
+}
+
+public abstract interface class app/cash/redwood/widget/SavedStateRegistry {
+	public abstract fun canBeSaved (Ljava/lang/Object;)Z
+	public abstract fun consumeRestoredState ()Ljava/util/Map;
+	public abstract fun registerSavedStateProvider (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun unregisterSavedStateProvider ()V
+}
+
+public final class app/cash/redwood/widget/ViewGroupChildren : app/cash/redwood/widget/Widget$Children {
+	public fun <init> (Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getWidgets ()Ljava/util/List;
+	public fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public fun move (III)V
+	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public fun remove (II)V
+}
+
+public abstract interface class app/cash/redwood/widget/Widget {
+	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
+	public abstract fun getValue ()Ljava/lang/Object;
+	public abstract fun setModifier (Lapp/cash/redwood/Modifier;)V
+}
+
+public abstract interface class app/cash/redwood/widget/Widget$Children {
+	public abstract fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public abstract fun move (III)V
+	public abstract fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public abstract fun remove (II)V
+}
+
+public abstract interface class app/cash/redwood/widget/WidgetFactoryOwner {
+}
+
+public abstract interface class app/cash/redwood/widget/WidgetSystem {
+}
+

--- a/redwood-widget/api/jvm/redwood-widget.api
+++ b/redwood-widget/api/jvm/redwood-widget.api
@@ -1,0 +1,82 @@
+public abstract interface class app/cash/redwood/widget/ChangeListener {
+	public abstract fun onEndChanges ()V
+}
+
+public final class app/cash/redwood/widget/MutableListChildren : app/cash/redwood/widget/Widget$Children, java/util/List, kotlin/jvm/internal/markers/KMutableList {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (ILapp/cash/redwood/widget/Widget;)V
+	public synthetic fun add (ILjava/lang/Object;)V
+	public fun add (Lapp/cash/redwood/widget/Widget;)Z
+	public synthetic fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Lapp/cash/redwood/widget/Widget;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun get (I)Lapp/cash/redwood/widget/Widget;
+	public synthetic fun get (I)Ljava/lang/Object;
+	public fun getSize ()I
+	public fun indexOf (Lapp/cash/redwood/widget/Widget;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Lapp/cash/redwood/widget/Widget;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public fun move (III)V
+	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public final fun remove (I)Lapp/cash/redwood/widget/Widget;
+	public synthetic fun remove (I)Ljava/lang/Object;
+	public fun remove (II)V
+	public fun remove (Lapp/cash/redwood/widget/Widget;)Z
+	public final fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun removeAt (I)Lapp/cash/redwood/widget/Widget;
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILapp/cash/redwood/widget/Widget;)Lapp/cash/redwood/widget/Widget;
+	public synthetic fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+}
+
+public abstract interface class app/cash/redwood/widget/RedwoodView {
+	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public abstract fun getOnBackPressedDispatcher ()Lapp/cash/redwood/ui/OnBackPressedDispatcher;
+	public abstract fun getSavedStateRegistry ()Lapp/cash/redwood/widget/SavedStateRegistry;
+	public abstract fun getUiConfiguration ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun reset ()V
+}
+
+public abstract interface class app/cash/redwood/widget/SavedStateRegistry {
+	public abstract fun canBeSaved (Ljava/lang/Object;)Z
+	public abstract fun consumeRestoredState ()Ljava/util/Map;
+	public abstract fun registerSavedStateProvider (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun unregisterSavedStateProvider ()V
+}
+
+public abstract interface class app/cash/redwood/widget/Widget {
+	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
+	public abstract fun getValue ()Ljava/lang/Object;
+	public abstract fun setModifier (Lapp/cash/redwood/Modifier;)V
+}
+
+public abstract interface class app/cash/redwood/widget/Widget$Children {
+	public abstract fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public abstract fun move (III)V
+	public abstract fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public abstract fun remove (II)V
+}
+
+public abstract interface class app/cash/redwood/widget/WidgetFactoryOwner {
+}
+
+public abstract interface class app/cash/redwood/widget/WidgetSystem {
+}
+

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/enums.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/enums.kt
@@ -28,6 +28,7 @@ public value class Direction private constructor(private val ordinal: Int) {
     else -> throw AssertionError()
   }
 
+  @RedwoodYogaApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val Inherit: Direction = Direction(0)
     public val LTR: Direction = Direction(1)
@@ -51,6 +52,7 @@ public value class FlexDirection private constructor(private val ordinal: Int) {
     else -> throw AssertionError()
   }
 
+  @RedwoodYogaApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val Row: FlexDirection = FlexDirection(0)
     public val RowReverse: FlexDirection = FlexDirection(1)
@@ -90,6 +92,7 @@ public value class JustifyContent private constructor(private val ordinal: Int) 
     else -> throw AssertionError()
   }
 
+  @RedwoodYogaApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val FlexStart: JustifyContent = JustifyContent(0)
     public val FlexEnd: JustifyContent = JustifyContent(1)
@@ -116,6 +119,7 @@ public value class AlignItems private constructor(private val ordinal: Int) {
     else -> throw AssertionError()
   }
 
+  @RedwoodYogaApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val FlexStart: AlignItems = AlignItems(0)
     public val FlexEnd: AlignItems = AlignItems(1)
@@ -146,6 +150,7 @@ public value class AlignSelf private constructor(private val ordinal: Int) {
     else -> throw AssertionError()
   }
 
+  @RedwoodYogaApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val FlexStart: AlignSelf = AlignSelf(0)
     public val FlexEnd: AlignSelf = AlignSelf(1)

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/measure.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/measure.kt
@@ -35,6 +35,7 @@ public fun interface MeasureCallback {
   public val width: Float,
   public val height: Float,
 ) {
+  @RedwoodYogaApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public const val UNDEFINED: Float = Yoga.YGUndefined
   }
@@ -51,6 +52,7 @@ public value class MeasureMode private constructor(private val ordinal: Int) {
     else -> throw AssertionError()
   }
 
+  @RedwoodYogaApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val Undefined: MeasureMode = MeasureMode(0)
     public val Exactly: MeasureMode = MeasureMode(1)


### PR DESCRIPTION
There's no compatibility validation done here (despite the plugin's name), merely dumping the API based on JVM bytecode. This will help identify breaking changes and new APIs that need called out in the change log.

Part of #1044

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
