### PR TITLE
Add support for unscoped modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 New:
 - Compose UI implementation for `Box`.
 - Layout modifier support for HTML DOM layouts.
+- Unscoped modifiers provide a global hook for side-effecting behavior on native views. For example, create a background color modifier which changes the platform-native UI node through a factory function.
 
 Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).

--- a/build-support/src/main/resources/app/cash/redwood/buildsupport/flexboxHelpers.kt
+++ b/build-support/src/main/resources/app/cash/redwood/buildsupport/flexboxHelpers.kt
@@ -86,7 +86,7 @@ internal fun CrossAxisAlignment.toAlignSelf() = when (this) {
 }
 
 internal fun Node.applyModifier(parentModifier: Modifier, density: Density) {
-  parentModifier.forEach { childModifier ->
+  parentModifier.forEachScoped { childModifier ->
     when (childModifier) {
       is GrowModifier -> {
         flexGrow = childModifier.value.toFloat()

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
@@ -151,6 +151,11 @@ public class WidgetNode<out W : Widget<V>, V : Any>(
   public companion object {
     public val SetModifiers: WidgetNode<Widget<Any>, Any>.(Modifier) -> Unit = {
       recordChanged()
+
+      it.forEachUnscoped { element ->
+        applier.widgetSystem.apply(widget.value, element)
+      }
+
       widget.modifier = it
       container?.onModifierUpdated(index, widget)
     }

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningButton.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningButton.kt
@@ -19,6 +19,7 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.testing.WidgetValue
 import app.cash.redwood.widget.ChangeListener
 import com.example.redwood.testing.widget.Button
+import com.example.redwood.testing.widget.ButtonValue
 
 class ListeningButton : Button<WidgetValue>, ChangeListener {
   private val changes = ArrayList<String>()
@@ -46,5 +47,5 @@ class ListeningButton : Button<WidgetValue>, ChangeListener {
       changes += "modifier $value"
     }
 
-  override val value get() = throw AssertionError()
+  override val value get() = ButtonValue(text = "", onClick = {})
 }

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.testing.WidgetValue
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.Widget
 import com.example.redwood.testing.widget.TestRow
+import com.example.redwood.testing.widget.TestRowValue
 
 class ListeningTestRow : TestRow<WidgetValue>, ChangeListener {
   private val changes = ArrayList<String>()
@@ -55,5 +56,5 @@ class ListeningTestRow : TestRow<WidgetValue>, ChangeListener {
       changes += "modifier $value"
     }
 
-  override val value: WidgetValue get() = throw AssertionError()
+  override val value: WidgetValue get() = TestRowValue()
 }

--- a/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiBox.kt
+++ b/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiBox.kt
@@ -85,7 +85,7 @@ internal class ComposeUiBox(
     var matchParentWidth = matchParentWidth
     var matchParentHeight = matchParentHeight
 
-    forEach { childModifier ->
+    forEachScoped { childModifier ->
       when (childModifier) {
         is HorizontalAlignment -> {
           matchParentWidth = childModifier.alignment == CrossAxisAlignment.Stretch

--- a/redwood-layout-dom/src/commonMain/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
+++ b/redwood-layout-dom/src/commonMain/kotlin/app/cash/redwood/layout/dom/HTMLElementRedwoodLayoutWidgetFactory.kt
@@ -156,7 +156,7 @@ private class HTMLFlexElementChildren(
       }
     }
 
-    modifier.forEach { element ->
+    modifier.forEachScoped { element ->
       when (element) {
         is MarginModifier -> {
           value.style.apply {

--- a/redwood-layout-modifiers/api/redwood-layout-modifiers.api
+++ b/redwood-layout-modifiers/api/redwood-layout-modifiers.api
@@ -1,37 +1,37 @@
-public abstract interface class app/cash/redwood/layout/modifier/Flex : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/Flex : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getValue ()D
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/Grow : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/Grow : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getValue ()D
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/Height : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/Height : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getHeight-hdgK9uQ ()D
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/HorizontalAlignment : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/HorizontalAlignment : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getAlignment-eoX4IBc ()I
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/Margin : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/Margin : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getMargin ()Lapp/cash/redwood/ui/Margin;
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/Shrink : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/Shrink : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getValue ()D
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/Size : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/Size : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getHeight-hdgK9uQ ()D
 	public abstract fun getWidth-hdgK9uQ ()D
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/VerticalAlignment : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/VerticalAlignment : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getAlignment-eoX4IBc ()I
 }
 
-public abstract interface class app/cash/redwood/layout/modifier/Width : app/cash/redwood/Modifier$Element {
+public abstract interface class app/cash/redwood/layout/modifier/Width : app/cash/redwood/Modifier$ScopedElement {
 	public abstract fun getWidth-hdgK9uQ ()D
 }
 

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -115,7 +115,7 @@ internal class UIViewBox : Box<UIView> {
         var requestedWidth: CGFloat = Double.MIN_VALUE
         var requestedHeight: CGFloat = Double.MIN_VALUE
 
-        widget.modifier.forEach { childModifier ->
+        widget.modifier.forEachScoped { childModifier ->
           when (childModifier) {
             is HorizontalAlignment -> {
               itemHorizontalAlignment = childModifier.alignment
@@ -193,7 +193,7 @@ internal class UIViewBox : Box<UIView> {
 
       // Get the largest sizes based on explicit widget modifiers.
       children.widgets.forEach { widget ->
-        widget.modifier.forEach { childModifier ->
+        widget.modifier.forEachScoped { childModifier ->
           when (childModifier) {
             is Width -> with(Density.Default) {
               maxRequestedWidth = maxOf(maxRequestedWidth, childModifier.width.toPx())

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewBox.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewBox.kt
@@ -141,7 +141,7 @@ internal class ViewBox(
     var requestedWidth = Int.MIN_VALUE
     var requestedHeight = Int.MIN_VALUE
 
-    modifier.forEach { childModifier ->
+    modifier.forEachScoped { childModifier ->
       // Check for modifier overrides in the children, otherwise default to the Box's alignment
       // values.
       when (childModifier) {

--- a/redwood-layout-widget/api/redwood-layout-widget.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.api
@@ -34,11 +34,17 @@ public abstract interface class app/cash/redwood/layout/widget/RedwoodLayoutWidg
 }
 
 public abstract interface class app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner : app/cash/redwood/widget/WidgetFactoryOwner {
+	public static final field Companion Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner$Companion;
 	public abstract fun getRedwoodLayout ()Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;
+}
+
+public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner$Companion {
+	public final fun apply (Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 }
 
 public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
 	public fun <init> (Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;)V
+	public fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 	public fun getRedwoodLayout ()Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;
 }
 

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -51,11 +51,17 @@ public abstract interface class app/cash/redwood/lazylayout/widget/RedwoodLazyLa
 }
 
 public abstract interface class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner : app/cash/redwood/widget/WidgetFactoryOwner {
+	public static final field Companion Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner$Companion;
 	public abstract fun getRedwoodLazyLayout ()Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;
+}
+
+public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner$Companion {
+	public final fun apply (Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 }
 
 public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSystem : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
 	public fun <init> (Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;)V
+	public fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 	public fun getRedwoodLazyLayout ()Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;
 }
 

--- a/redwood-protocol-guest/api/android/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/android/redwood-protocol-guest.api
@@ -39,7 +39,7 @@ public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget :
 	public abstract fun getId-0HhLjSo ()I
 	public abstract fun getTag-BlhN7y0 ()I
 	public synthetic fun getValue ()Ljava/lang/Object;
-	public fun getValue ()Ljava/lang/Void;
+	public fun getValue ()Lkotlin/Unit;
 	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
 }
 

--- a/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
@@ -39,7 +39,7 @@ public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget :
 	public abstract fun getId-0HhLjSo ()I
 	public abstract fun getTag-BlhN7y0 ()I
 	public synthetic fun getValue ()Ljava/lang/Object;
-	public fun getValue ()Ljava/lang/Void;
+	public fun getValue ()Lkotlin/Unit;
 	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
 }
 

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolBridge.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolBridge.kt
@@ -34,14 +34,14 @@ public interface ProtocolBridge : EventSink {
    * The root of the widget tree onto which [widgetSystem]-produced widgets can be added. Changes to
    * this instance are recorded as changes to [Id.Root] and [ChildrenTag.Root].
    */
-  public val root: Widget.Children<Nothing>
+  public val root: Widget.Children<Unit>
 
   /**
    * The provider of factories of widgets which record property changes and whose children changes
    * are also recorded. You **must** attach returned widgets to [root] or the children of a widget
    * in the tree beneath [root] in order for it to be tracked.
    */
-  public val widgetSystem: WidgetSystem<Nothing>
+  public val widgetSystem: WidgetSystem<Unit>
 
   /**
    * Returns any changes to [root] or [widgetSystem]-produced widgets since the last time this

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
@@ -64,7 +64,7 @@ public class ProtocolState {
 
   public fun getWidget(id: Id): ProtocolWidget? = widgets[id.value]
 
-  public fun widgetChildren(id: Id, tag: ChildrenTag): Widget.Children<Nothing> {
+  public fun widgetChildren(id: Id, tag: ChildrenTag): Widget.Children<Unit> {
     return ProtocolWidgetChildren(id, tag, this)
   }
 }

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
@@ -26,12 +26,11 @@ import app.cash.redwood.widget.Widget
  *
  * @suppress For generated code use only.
  */
-public interface ProtocolWidget : Widget<Nothing> {
+public interface ProtocolWidget : Widget<Unit> {
   public val id: Id
   public val tag: WidgetTag
 
-  override val value: Nothing
-    get() = throw AssertionError()
+  override val value: Unit get() = Unit
 
   public fun sendEvent(event: Event)
 }

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
@@ -24,10 +24,10 @@ internal class ProtocolWidgetChildren(
   private val id: Id,
   private val tag: ChildrenTag,
   private val state: ProtocolState,
-) : Widget.Children<Nothing> {
+) : Widget.Children<Unit> {
   private val ids = mutableListOf<Id>()
 
-  override fun insert(index: Int, widget: Widget<Nothing>) {
+  override fun insert(index: Int, widget: Widget<Unit>) {
     widget as ProtocolWidget
     ids.add(index, widget.id)
     state.addWidget(widget)
@@ -51,6 +51,6 @@ internal class ProtocolWidgetChildren(
     state.append(ChildrenChange.Move(id, tag, fromIndex, toIndex, count))
   }
 
-  override fun onModifierUpdated(index: Int, widget: Widget<Nothing>) {
+  override fun onModifierUpdated(index: Int, widget: Widget<Unit>) {
   }
 }

--- a/redwood-protocol-host/api/android/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/android/redwood-protocol-host.api
@@ -14,6 +14,7 @@ public final class app/cash/redwood/protocol/widget/ProtocolChildren {
 }
 
 public abstract interface class app/cash/redwood/protocol/widget/ProtocolFactory {
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
 }
 
 public abstract interface class app/cash/redwood/protocol/widget/ProtocolMismatchHandler {

--- a/redwood-protocol-host/api/jvm/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/jvm/redwood-protocol-host.api
@@ -14,6 +14,7 @@ public final class app/cash/redwood/protocol/widget/ProtocolChildren {
 }
 
 public abstract interface class app/cash/redwood/protocol/widget/ProtocolFactory {
+	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
 }
 
 public abstract interface class app/cash/redwood/protocol/widget/ProtocolMismatchHandler {

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolBridge.kt
@@ -96,10 +96,16 @@ public class ProtocolBridge<W : Any>(
         }
 
         is ModifierChange -> {
-          val modifier = change.elements.fold<_, Modifier>(Modifier) { modifier, element ->
-            modifier.then(factory.createModifier(element))
-          }
           val node = node(id)
+          val value = node.widget.value
+
+          val modifier = change.elements.fold<_, Modifier>(Modifier) { outer, element ->
+            val inner = factory.createModifier(element)
+            if (inner is Modifier.UnscopedElement) {
+              factory.widgetSystem.apply(value, inner)
+            }
+            outer.then(inner)
+          }
           node.updateModifier(modifier)
 
           val widget = node.widget

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolFactory.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/widget/ProtocolFactory.kt
@@ -19,6 +19,7 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ModifierElement
 import app.cash.redwood.protocol.WidgetTag
+import app.cash.redwood.widget.WidgetSystem
 import kotlin.native.ObjCName
 
 /**
@@ -27,7 +28,9 @@ import kotlin.native.ObjCName
  * @see ProtocolBridge
  */
 @ObjCName("ProtocolFactory", exact = true)
-public interface ProtocolFactory<W : Any>
+public interface ProtocolFactory<W : Any> {
+  public val widgetSystem: WidgetSystem<W>
+}
 
 /**
  * [ProtocolFactory] but containing codegen APIs.

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyExampleSchemaWidgetFactory.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.Modifier
+import com.example.redwood.testing.modifier.BackgroundColor
 import com.example.redwood.testing.widget.Button
 import com.example.redwood.testing.widget.Button2
 import com.example.redwood.testing.widget.Rectangle
@@ -25,18 +26,20 @@ import com.example.redwood.testing.widget.TestSchemaWidgetFactory
 import com.example.redwood.testing.widget.Text
 import com.example.redwood.testing.widget.TextInput
 
-open class EmptyTestSchemaWidgetFactory : TestSchemaWidgetFactory<Nothing> {
-  override fun TestRow(): TestRow<Nothing> = TODO()
-  override fun ScopedTestRow(): ScopedTestRow<Nothing> = TODO()
-  override fun Text(): Text<Nothing> = TODO()
-  override fun Button() = object : Button<Nothing> {
-    override val value get() = TODO()
+open class EmptyTestSchemaWidgetFactory : TestSchemaWidgetFactory<Unit> {
+  override fun TestRow(): TestRow<Unit> = TODO()
+  override fun ScopedTestRow(): ScopedTestRow<Unit> = TODO()
+  override fun Text(): Text<Unit> = TODO()
+  override fun Button() = object : Button<Unit> {
+    override val value get() = Unit
     override var modifier: Modifier = Modifier
 
     override fun text(text: String?) = TODO()
     override fun onClick(onClick: (() -> Unit)?) = TODO()
   }
-  override fun Button2(): Button2<Nothing> = TODO()
-  override fun TextInput(): TextInput<Nothing> = TODO()
-  override fun Rectangle(): Rectangle<Nothing> = TODO()
+  override fun Button2(): Button2<Unit> = TODO()
+  override fun TextInput(): TextInput<Unit> = TODO()
+  override fun Rectangle(): Rectangle<Unit> = TODO()
+  override fun BackgroundColor(value: Unit, modifier: BackgroundColor) {
+  }
 }

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyRedwoodLayoutWidgetFactory.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyRedwoodLayoutWidgetFactory.kt
@@ -17,7 +17,7 @@ package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.layout.widget.RedwoodLayoutWidgetFactory
 
-class EmptyRedwoodLayoutWidgetFactory : RedwoodLayoutWidgetFactory<Nothing> {
+class EmptyRedwoodLayoutWidgetFactory : RedwoodLayoutWidgetFactory<Unit> {
   override fun Box() = TODO()
   override fun Column() = TODO()
   override fun Row() = TODO()

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyRedwoodLazyLayoutWidgetFactory.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/EmptyRedwoodLazyLayoutWidgetFactory.kt
@@ -17,7 +17,7 @@ package app.cash.redwood.protocol.widget
 
 import app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory
 
-class EmptyRedwoodLazyLayoutWidgetFactory : RedwoodLazyLayoutWidgetFactory<Nothing> {
+class EmptyRedwoodLazyLayoutWidgetFactory : RedwoodLazyLayoutWidgetFactory<Unit> {
   override fun LazyList() = TODO()
   override fun RefreshableLazyList() = TODO()
 }

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolFactoryTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/widget/ProtocolFactoryTest.kt
@@ -327,8 +327,8 @@ class ProtocolFactoryTest {
       .isEqualTo(Event(Id(1), EventTag(4), listOf(JsonPrimitive("PT10S"))))
   }
 
-  class RecordingTextInput : TextInput<Nothing> {
-    override val value get() = TODO()
+  class RecordingTextInput : TextInput<Unit> {
+    override val value get() = Unit
     override var modifier: Modifier = Modifier
 
     var text: String? = null

--- a/redwood-runtime/api/android/redwood-runtime.api
+++ b/redwood-runtime/api/android/redwood-runtime.api
@@ -4,17 +4,31 @@ public abstract interface annotation class app/cash/redwood/LayoutScopeMarker : 
 public abstract interface class app/cash/redwood/Modifier {
 	public static final field Companion Lapp/cash/redwood/Modifier$Companion;
 	public abstract fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
 	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
 }
 
 public final class app/cash/redwood/Modifier$Companion : app/cash/redwood/Modifier {
 	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
 	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class app/cash/redwood/Modifier$Element : app/cash/redwood/Modifier {
 	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class app/cash/redwood/Modifier$ScopedElement : app/cash/redwood/Modifier$Element {
+	public fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class app/cash/redwood/Modifier$UnscopedElement : app/cash/redwood/Modifier$Element {
+	public fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface annotation class app/cash/redwood/RedwoodCodegenApi : java/lang/annotation/Annotation {

--- a/redwood-runtime/api/jvm/redwood-runtime.api
+++ b/redwood-runtime/api/jvm/redwood-runtime.api
@@ -4,17 +4,31 @@ public abstract interface annotation class app/cash/redwood/LayoutScopeMarker : 
 public abstract interface class app/cash/redwood/Modifier {
 	public static final field Companion Lapp/cash/redwood/Modifier$Companion;
 	public abstract fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
 	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
 }
 
 public final class app/cash/redwood/Modifier$Companion : app/cash/redwood/Modifier {
 	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
 	public fun then (Lapp/cash/redwood/Modifier;)Lapp/cash/redwood/Modifier;
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class app/cash/redwood/Modifier$Element : app/cash/redwood/Modifier {
 	public fun forEach (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class app/cash/redwood/Modifier$ScopedElement : app/cash/redwood/Modifier$Element {
+	public fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class app/cash/redwood/Modifier$UnscopedElement : app/cash/redwood/Modifier$Element {
+	public fun forEachScoped (Lkotlin/jvm/functions/Function1;)V
+	public fun forEachUnscoped (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface annotation class app/cash/redwood/RedwoodCodegenApi : java/lang/annotation/Annotation {

--- a/redwood-runtime/src/commonTest/kotlin/app/cash/redwood/ui/ModifierTest.kt
+++ b/redwood-runtime/src/commonTest/kotlin/app/cash/redwood/ui/ModifierTest.kt
@@ -109,6 +109,6 @@ class ModifierTest {
   }
 }
 
-private class NamedModifier(private val name: String) : Modifier.Element {
+private class NamedModifier(private val name: String) : Modifier.ScopedElement {
   override fun toString() = name
 }

--- a/redwood-schema/src/main/kotlin/app/cash/redwood/schema/annotations.kt
+++ b/redwood-schema/src/main/kotlin/app/cash/redwood/schema/annotations.kt
@@ -200,9 +200,19 @@ public annotation class Children(
 public annotation class Default(val expression: String)
 
 /**
- * Annotates a data class which represents a layout modifier for a [Widget]. Each layout modifier
- * in a [Schema] must have a unique [tag] among all [Modifier] annotations in the [Schema].
- * Additionally, each layout modifier can be associated with one or more scopes.
+ * Annotates a data class which represents a modifier for a [Widget].
+ *
+ * Each modifier in a [Schema] must have a unique [tag] among all [Modifier] annotations in the
+ * [Schema].
+ *
+ * ```
+ * @Modifier(1)
+ * data class BackgroundColor(
+ *   val value: Color,
+ * )
+ * ```
+ *
+ * To create a modifier that applies a specific parent widget, supply one or more scope types.
  *
  * ```
  * @Modifier(1, RowScope::class)
@@ -210,6 +220,24 @@ public annotation class Default(val expression: String)
  *   val value: VerticalAlignment,
  * )
  * ```
+ *
+ * When defining the [Widget], use the same scope type as a receiver on [Children] property.
+ *
+ * ```
+ * @Widget(1)
+ * data class Row(
+ *   @Children(1) val children: RowScope.() -> Unit,
+ * )
+ * ```
+ *
+ * When a modifier is applied to a widget it will be processed in one of two ways:
+ * 1. If scoped, the parent widget which provides the scope will query the value. For example,
+ *    each implementation of a `Row` will handle `HorizontalAlignment` set on its children.
+ * 2. If unscoped, the widget factory interface will expose callback functions that are invoked
+ *    when a value is used. For example, a `BackgroundColor(value: V, modifier: BackgroundColor)`
+ *    function will be generated on the widget factory for each implementation to provide. The
+ *    implementation should be idempotent, as it will be invoked each time a new modifier chain is
+ *    set, even if the specific unscoped modifier has not changed.
  */
 @Retention(RUNTIME)
 @Target(CLASS)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/codegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/codegen.kt
@@ -41,8 +41,9 @@ internal fun SchemaSet.generateFileSpecs(type: CodegenType): List<FileSpec> {
     when (type) {
       Compose -> {
         generateModifierImpls(schema)?.let { add(it) }
+        generateUnscopedModifiers(schema)?.let { add(it) }
         for (scope in schema.scopes) {
-          add(generateScope(schema, scope))
+          add(generateModifierScope(schema, scope))
         }
         for (widget in schema.widgets) {
           add(generateComposable(schema, widget))

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -39,7 +39,7 @@ import com.squareup.kotlinpoet.joinToCode
 /*
 @ObjCName("ExampleProtocolFactory", exact = true)
 public class ExampleProtocolFactory<W : Any>(
-  private val widgetSystem: ExampleWidgetSystem<W>,
+  override val widgetSystem: ExampleWidgetSystem<W>,
   private val json: Json = Json.Default,
   private val mismatchHandler: ProtocolMismatchHandler = ProtocolMismatchHandler.Throwing,
 ) : GeneratedProtocolFactory<W> {
@@ -101,7 +101,7 @@ internal fun generateProtocolFactory(
             .build(),
         )
         .addProperty(
-          PropertySpec.builder("widgetSystem", widgetSystem, PRIVATE)
+          PropertySpec.builder("widgetSystem", widgetSystem, OVERRIDE)
             .initializer("widgetSystem")
             .build(),
         )

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -59,6 +59,8 @@ internal val Event.lambdaType: TypeName
     returnType = UNIT,
   ).copy(nullable = isNullable)
 
+internal val Schema.unscopedModifiers get() = modifiers.filter { it.scopes.isEmpty() }
+
 internal fun Schema.composePackage(host: Schema? = null): String {
   return if (host == null) {
     val packageName = type.names[0]

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -139,7 +139,16 @@ internal fun generateMutableWidgetFactory(schema: Schema): FileSpec {
               FunSpec.builder(widget.type.flatName)
                 .addModifiers(OVERRIDE)
                 .returns(schema.widgetType(widget).parameterizedBy(RedwoodTesting.WidgetValue))
-                .addCode("return %T()", schema.mutableWidgetType(widget))
+                .addStatement("return %T()", schema.mutableWidgetType(widget))
+                .build(),
+            )
+          }
+          for (modifier in schema.unscopedModifiers) {
+            addFunction(
+              FunSpec.builder(modifier.type.flatName)
+                .addModifiers(OVERRIDE)
+                .addParameter("value", RedwoodTesting.WidgetValue)
+                .addParameter("modifier", schema.modifierType(modifier))
                 .build(),
             )
           }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -61,6 +61,8 @@ internal object WidgetProtocol {
 internal object Redwood {
   val Modifier = ClassName("app.cash.redwood", "Modifier")
   val ModifierElement = Modifier.nestedClass("Element")
+  val ModifierScopedElement = Modifier.nestedClass("ScopedElement")
+  val ModifierUnscopedElement = Modifier.nestedClass("UnscopedElement")
   val LayoutScopeMarker = ClassName("app.cash.redwood", "LayoutScopeMarker")
   val RedwoodCodegenApi = ClassName("app.cash.redwood", "RedwoodCodegenApi")
   val OnBackPressedDispatcher = ClassName("app.cash.redwood.ui", "OnBackPressedDispatcher")

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ComposeGenerationTest.kt
@@ -57,7 +57,7 @@ class ComposeGenerationTest {
   @Test fun `scope is annotated with layout scope marker`() {
     val schema = ProtocolSchemaSet.parse(ScopedAndUnscopedSchema::class).schema
 
-    val fileSpec = generateScope(schema, FqType(listOf("example", "RowScope")))
+    val fileSpec = generateModifierScope(schema, FqType(listOf("example", "RowScope")))
     assertThat(fileSpec.toString()).contains(
       """
       |@LayoutScopeMarker

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ModifierGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ModifierGenerationTest.kt
@@ -74,7 +74,7 @@ class ModifierGenerationTest {
 
     val modifier = schema.modifiers.single { it.type.names.last() == "ScopedModifier" }
     val scope = modifier.scopes.single { it.names.last() == "ModifierScope" }
-    val scopeSpec = generateScope(schema, scope)
+    val scopeSpec = generateModifierScope(schema, scope)
     assertThat(scopeSpec.toString()).contains(
       """
       |  @Stable

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
@@ -441,9 +441,6 @@ private fun parseModifier(
   require(tag in 1 until MAX_MEMBER_TAG) {
     "@Modifier $memberFqType tag must be in range [1, $MAX_MEMBER_TAG): $tag"
   }
-  require(annotation.scopes.isNotEmpty()) {
-    "@Modifier $memberFqType must have at least one scope."
-  }
 
   val properties = if (memberType.objectInstance != null) {
     emptyList()

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -1009,25 +1009,6 @@ class SchemaParserTest(
   }
 
   @Schema(
-    members = [
-      UnscopedModifier::class,
-    ],
-  )
-  interface UnscopedModifierSchema
-
-  @Modifier(1)
-  object UnscopedModifier
-
-  @Test fun `layout modifier must have at least one scope`() {
-    assertFailure { parser.parse(UnscopedModifierSchema::class) }
-      .isInstanceOf<IllegalArgumentException>()
-      .hasMessage(
-        "@Modifier app.cash.redwood.tooling.schema.SchemaParserTest.UnscopedModifier " +
-          "must have at least one scope.",
-      )
-  }
-
-  @Schema(
     [
       SerializationModifier::class,
     ],

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
@@ -21,9 +21,11 @@ import app.cash.redwood.protocol.ModifierElement
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.protocol.widget.GeneratedProtocolFactory
 import app.cash.redwood.protocol.widget.ProtocolNode
+import app.cash.redwood.widget.WidgetSystem
 
 @OptIn(RedwoodCodegenApi::class)
 internal class FakeProtocolNodeFactory : GeneratedProtocolFactory<FakeWidget> {
+  override val widgetSystem: WidgetSystem<FakeWidget> = FakeWidgetSystem()
   override fun createNode(tag: WidgetTag): ProtocolNode<FakeWidget> = FakeProtocolNode()
   override fun createModifier(element: ModifierElement): Modifier = Modifier
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseView.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseView.kt
@@ -27,7 +27,7 @@ internal class FakeTreehouseView(
   override val onBackPressedDispatcher: FakeOnBackPressedDispatcher,
   override val uiConfiguration: StateFlow<UiConfiguration> = MutableStateFlow(UiConfiguration()),
 ) : TreehouseView<FakeWidget> {
-  override val widgetSystem = FakeWidgetSystem()
+  override val widgetSystem = FakeTreehouseWidgetSystem()
 
   override var readyForContentChangeListener: ReadyForContentChangeListener<FakeWidget>? = null
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseWidgetSystem.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseWidgetSystem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Square, Inc.
+ * Copyright (C) 2023 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 package app.cash.redwood.treehouse
 
-import app.cash.redwood.Modifier.UnscopedElement
-import app.cash.redwood.widget.WidgetSystem
+import app.cash.redwood.protocol.widget.ProtocolMismatchHandler
+import kotlinx.serialization.json.Json
 
-class FakeWidgetSystem : WidgetSystem<FakeWidget> {
-  override fun apply(value: FakeWidget, element: UnscopedElement) {
-  }
+internal class FakeTreehouseWidgetSystem : TreehouseView.WidgetSystem<FakeWidget> {
+  override fun widgetFactory(
+    json: Json,
+    protocolMismatchHandler: ProtocolMismatchHandler,
+  ) = FakeProtocolNodeFactory()
 }

--- a/redwood-widget/api/android/redwood-widget.api
+++ b/redwood-widget/api/android/redwood-widget.api
@@ -99,5 +99,6 @@ public abstract interface class app/cash/redwood/widget/WidgetFactoryOwner {
 }
 
 public abstract interface class app/cash/redwood/widget/WidgetSystem {
+	public abstract fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 }
 

--- a/redwood-widget/api/jvm/redwood-widget.api
+++ b/redwood-widget/api/jvm/redwood-widget.api
@@ -78,5 +78,6 @@ public abstract interface class app/cash/redwood/widget/WidgetFactoryOwner {
 }
 
 public abstract interface class app/cash/redwood/widget/WidgetSystem {
+	public abstract fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 }
 

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/WidgetSystem.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/WidgetSystem.kt
@@ -15,8 +15,16 @@
  */
 package app.cash.redwood.widget
 
+import app.cash.redwood.Modifier
+
 /**
- * Marker interface for types whose properties expose factories for a schema and all its
+ * Interface for types whose properties expose factories for a schema and all its
  * transitive dependencies.
  */
-public interface WidgetSystem<W : Any>
+public interface WidgetSystem<W : Any> {
+  /**
+   * Find the appropriate schema factory and function to handle [element]
+   * and apply it to [value].
+   */
+  public fun apply(value: W, element: Modifier.UnscopedElement)
+}

--- a/test-app/android-views/src/main/kotlin/com/example/redwood/testing/android/views/AndroidTestSchemaWidgetFactory.kt
+++ b/test-app/android-views/src/main/kotlin/com/example/redwood/testing/android/views/AndroidTestSchemaWidgetFactory.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.view.View
 import android.widget.Button as ButtonWidget
 import android.widget.TextView
+import com.example.redwood.testing.modifier.BackgroundColor
 import com.example.redwood.testing.widget.Button
 import com.example.redwood.testing.widget.Rectangle
 import com.example.redwood.testing.widget.TestSchemaWidgetFactory
@@ -34,4 +35,7 @@ class AndroidTestSchemaWidgetFactory(
   override fun Button2() = TODO()
   override fun TextInput() = TODO()
   override fun Rectangle(): Rectangle<View> = ViewRectangle(context)
+  override fun BackgroundColor(value: View, modifier: BackgroundColor) {
+    value.setBackgroundColor(modifier.color)
+  }
 }

--- a/test-app/browser/src/commonMain/kotlin/com/example/redwood/testing/browser/widgetFactory.kt
+++ b/test-app/browser/src/commonMain/kotlin/com/example/redwood/testing/browser/widgetFactory.kt
@@ -15,6 +15,7 @@
  */
 package com.example.redwood.testing.browser
 
+import com.example.redwood.testing.modifier.BackgroundColor
 import com.example.redwood.testing.widget.Button
 import com.example.redwood.testing.widget.TestSchemaWidgetFactory
 import com.example.redwood.testing.widget.Text
@@ -45,4 +46,9 @@ class HtmlWidgetFactory(
   override fun ScopedTestRow() = throw UnsupportedOperationException()
 
   override fun TestRow() = throw UnsupportedOperationException()
+
+  @OptIn(ExperimentalStdlibApi::class)
+  override fun BackgroundColor(value: HTMLElement, modifier: BackgroundColor) {
+    value.style.backgroundColor = "#" + modifier.color.toHexString()
+  }
 }

--- a/test-app/ios-uikit/TestApp/IosTestSchemaWidgetFactory.swift
+++ b/test-app/ios-uikit/TestApp/IosTestSchemaWidgetFactory.swift
@@ -47,4 +47,19 @@ class IosTestSchemaWidgetFactory: TestSchemaWidgetFactory {
     func TestRow() -> TestRow {
         fatalError()
     }
+
+    func BackgroundColor(value: Any, modifier: BackgroundColor) {
+        (value as! UIView).backgroundColor = UIColor(argb: UInt(modifier.color))
+    }
+}
+
+extension UIColor {
+    convenience init(argb: UInt) {
+        let alpha = CGFloat((argb >> 24) & 0xFF) / 255.0
+        let red = CGFloat((argb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((argb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(argb & 0xFF) / 255.0
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
 }

--- a/test-app/ios-uikit/TestApp/RectangleBinding.swift
+++ b/test-app/ios-uikit/TestApp/RectangleBinding.swift
@@ -36,14 +36,3 @@ class RectangleBinding: Rectangle {
         root.layer.cornerRadius = CGFloat(cornerRadius)
     }
 }
-
-private extension UIColor {
-    convenience init(argb: UInt) {
-        let alpha = CGFloat((argb >> 24) & 0xFF) / 255.0
-        let red = CGFloat((argb >> 16) & 0xFF) / 255.0
-        let green = CGFloat((argb >> 8) & 0xFF) / 255.0
-        let blue = CGFloat(argb & 0xFF) / 255.0
-
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
-    }
-}

--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/TestApp.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/TestApp.kt
@@ -36,6 +36,7 @@ private val screens = buildMap<String, @Composable TestContext.() -> Unit> {
   put("Repo Search") { RepoSearch(httpClient) }
   put("UI Configuration") { UiConfigurationValues() }
   put("Box Sandbox") { BoxSandbox() }
+  put("Unscoped Modifiers") { UnscopedModifiers() }
 }
 
 @Stable

--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/UnscopedModifiers.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testing/presenter/UnscopedModifiers.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.redwood.testing.presenter
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
+import app.cash.redwood.Modifier
+import app.cash.redwood.layout.api.Constraint.Companion.Fill
+import app.cash.redwood.layout.api.CrossAxisAlignment.Companion.Stretch
+import app.cash.redwood.layout.compose.Column
+import app.cash.redwood.layout.compose.Row
+import com.example.redwood.testing.compose.Button
+import com.example.redwood.testing.compose.backgroundColor
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+
+private const val ROWS = 5
+private const val COLS = 3
+
+@Composable
+@OptIn(ExperimentalStdlibApi::class)
+fun UnscopedModifiers(modifier: Modifier = Modifier) {
+  val colors = remember {
+    // https://issuetracker.google.com/issues/330350695
+    List(ROWS * COLS) { Random.nextInt() }.toMutableStateList()
+  }
+  LaunchedEffect(Unit) {
+    while (true) {
+      delay(1.seconds)
+
+      val randomIndex = Random.nextInt(colors.size)
+      colors[randomIndex] = Random.nextInt()
+    }
+  }
+
+  Column(width = Fill, horizontalAlignment = Stretch, modifier = modifier) {
+    for (row in 0 until ROWS) {
+      Row {
+        for (col in 0 until COLS) {
+          val value = colors[row * COLS + col]
+          Button(
+            text = "#" + value.toHexString(),
+            modifier = Modifier
+              .backgroundColor(value)
+              .flex(1.0),
+            onClick = { colors.fill(value) },
+          )
+        }
+      }
+    }
+  }
+}

--- a/test-app/schema/src/main/kotlin/com/example/redwood/testing/schema.kt
+++ b/test-app/schema/src/main/kotlin/com/example/redwood/testing/schema.kt
@@ -42,6 +42,7 @@ import kotlin.time.Duration
     Button2::class,
     TextInput::class,
     Rectangle::class,
+    BackgroundColor::class,
   ],
   dependencies = [
     Dependency(1, RedwoodLayout::class),
@@ -140,3 +141,8 @@ public object CustomTypeWithMultipleScopes
 
 @Modifier(7, TestScope::class)
 public data object CustomTypeDataObject
+
+@Modifier(8)
+public data class BackgroundColor(
+  val color: Int,
+)

--- a/test-app/schema/widget/build.gradle
+++ b/test-app/schema/widget/build.gradle
@@ -11,6 +11,7 @@ kotlin {
       dependencies {
         api projects.redwoodLayoutWidget
         api projects.redwoodLazylayoutWidget
+        api projects.testApp.schema.modifiers
       }
     }
   }


### PR DESCRIPTION
Unlike scoped modifiers, which are expected to be interpreted by the parent (and provider of the scope), unscoped modifiers are processed globally by the factory. These can be used for side-effecting operations, such as setting an accessibility description or universally supporting setting a background color.

I'm going to say this closes #1541 because it enables that to exist, but I don't think we want to provide it. A comprehensive background modifier probably wants things like corner radius support and maybe more options.

Refs #1084.

Things coming later:
- Tests (I want to change the test codegen first)
- Returning a new native UI node (Diff already too big, plus this isn't not urgently needed)
- #1583

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
