### PR TITLE
Atomically launch Zipline cleanup coroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changed:
 - The generated "widget factories" type (e.g., `MySchemaWidgetFactories`) is now called a "widget system" (e.g., `MySchemaWidgetSystem`). Sometimes it was also referred to as a "provider" in parameter names. A `@Deprecated typealias` is generated for now, but will be removed in the future.
 
 Fixed:
+- Fix failure to release JS resources when calling `CoroutineScope` is being cancelled
 - JVM targets now correctly link against Java 8 APIs. Previously they produced Java 8 bytecode, but linked against the compile JDK's APIs (21). This allowed linking against newer APIs that might not exist on older runtimes, which is no longer possible. Android targets which also produce Java 8 bytecode were not affected.
 - Fix the `View` implementation of `Box` to wrap its width and height by default. This matches the behavior of the `UIView` implementation and all other layout widgets.
 - Fix the `UIView` implementation of `Box` not updating when some of its parameters are changed.

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -18,6 +18,8 @@ package app.cash.redwood.treehouse
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.job
@@ -63,6 +65,7 @@ internal abstract class CodeSession<A : AppService>(
   /** Invoked on [TreehouseDispatchers.zipline]. */
   protected abstract fun ziplineStart()
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun stop() {
     dispatchers.checkUi()
 
@@ -74,7 +77,7 @@ internal abstract class CodeSession<A : AppService>(
       listener.onStop(this)
     }
 
-    scope.launch(dispatchers.zipline) {
+    scope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
       ziplineStop()
       scope.cancel()
     }


### PR DESCRIPTION
When the calling coroutine scope is being torn down, the coroutine launched to invoke `ziplineStop` will not run. Changed start to ATOMIC to ensure that this cleanup coroutine is run in this situation.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
