### PR TITLE
Expose tracked widgets on children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New:
 - Compose UI implementation for `Box`.
 - Layout modifier support for HTML DOM layouts.
 - Unscoped modifiers provide a global hook for side-effecting behavior on native views. For example, create a background color modifier which changes the platform-native UI node through a factory function.
+- `Widget.Children` interface now exposes `widgets: List<Widget<W>>` property. Most subtypes were already exposing this individually.
 
 Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ListeningTestRow.kt
@@ -31,6 +31,8 @@ class ListeningTestRow : TestRow<WidgetValue>, ChangeListener {
   }
 
   override val children = object : Widget.Children<WidgetValue> {
+    override val widgets: List<Widget<WidgetValue>> get() = emptyList()
+
     override fun insert(index: Int, widget: Widget<WidgetValue>) {
       changes += "children insert"
     }

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
@@ -25,18 +25,19 @@ internal class ProtocolWidgetChildren(
   private val tag: ChildrenTag,
   private val state: ProtocolState,
 ) : Widget.Children<Unit> {
-  private val ids = mutableListOf<Id>()
+  private val _widgets = mutableListOf<ProtocolWidget>()
+  override val widgets: List<Widget<Unit>> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<Unit>) {
     widget as ProtocolWidget
-    ids.add(index, widget.id)
+    _widgets.add(index, widget)
     state.addWidget(widget)
     state.append(ChildrenChange.Add(id, tag, widget.id, index))
   }
 
   override fun remove(index: Int, count: Int) {
-    val removingIds = ids.subList(index, index + count)
-    val removedIds = removingIds.toList()
+    val removingIds = _widgets.subList(index, index + count)
+    val removedIds = removingIds.map(ProtocolWidget::id)
     removingIds.clear()
 
     for (removedId in removedIds) {
@@ -47,7 +48,7 @@ internal class ProtocolWidgetChildren(
   }
 
   override fun move(fromIndex: Int, toIndex: Int, count: Int) {
-    ids.move(fromIndex, toIndex, count)
+    _widgets.move(fromIndex, toIndex, count)
     state.append(ChildrenChange.Move(id, tag, fromIndex, toIndex, count))
   }
 

--- a/redwood-widget-compose/api/redwood-widget-compose.api
+++ b/redwood-widget-compose/api/redwood-widget-compose.api
@@ -4,7 +4,7 @@ public final class app/cash/redwood/widget/compose/ComposeWidgetChildren : app/c
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun Render (Landroidx/compose/runtime/Composer;I)V
-	public final fun getWidgets ()Ljava/util/List;
+	public fun getWidgets ()Ljava/util/List;
 	public fun insert (ILapp/cash/redwood/widget/Widget;)V
 	public fun move (III)V
 	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V

--- a/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
+++ b/redwood-widget-compose/src/commonMain/kotlin/app/cash/redwood/widget/compose/ComposeWidgetChildren.kt
@@ -29,7 +29,7 @@ public class ComposeWidgetChildren @JvmOverloads constructor(
   private var modifierTick by mutableStateOf(0)
 
   private val _widgets = mutableStateListOf<Widget<@Composable () -> Unit>>()
-  public val widgets: List<Widget<@Composable () -> Unit>> get() = _widgets
+  override val widgets: List<Widget<@Composable () -> Unit>> get() = _widgets
 
   @Composable
   public fun Render() {

--- a/redwood-widget/api/android/redwood-widget.api
+++ b/redwood-widget/api/android/redwood-widget.api
@@ -19,6 +19,7 @@ public final class app/cash/redwood/widget/MutableListChildren : app/cash/redwoo
 	public fun get (I)Lapp/cash/redwood/widget/Widget;
 	public synthetic fun get (I)Ljava/lang/Object;
 	public fun getSize ()I
+	public fun getWidgets ()Ljava/util/List;
 	public fun indexOf (Lapp/cash/redwood/widget/Widget;)I
 	public final fun indexOf (Ljava/lang/Object;)I
 	public fun insert (ILapp/cash/redwood/widget/Widget;)V
@@ -75,7 +76,7 @@ public abstract interface class app/cash/redwood/widget/SavedStateRegistry {
 public final class app/cash/redwood/widget/ViewGroupChildren : app/cash/redwood/widget/Widget$Children {
 	public fun <init> (Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getWidgets ()Ljava/util/List;
+	public fun getWidgets ()Ljava/util/List;
 	public fun insert (ILapp/cash/redwood/widget/Widget;)V
 	public fun move (III)V
 	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
@@ -89,6 +90,7 @@ public abstract interface class app/cash/redwood/widget/Widget {
 }
 
 public abstract interface class app/cash/redwood/widget/Widget$Children {
+	public abstract fun getWidgets ()Ljava/util/List;
 	public abstract fun insert (ILapp/cash/redwood/widget/Widget;)V
 	public abstract fun move (III)V
 	public abstract fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V

--- a/redwood-widget/api/jvm/redwood-widget.api
+++ b/redwood-widget/api/jvm/redwood-widget.api
@@ -19,6 +19,7 @@ public final class app/cash/redwood/widget/MutableListChildren : app/cash/redwoo
 	public fun get (I)Lapp/cash/redwood/widget/Widget;
 	public synthetic fun get (I)Ljava/lang/Object;
 	public fun getSize ()I
+	public fun getWidgets ()Ljava/util/List;
 	public fun indexOf (Lapp/cash/redwood/widget/Widget;)I
 	public final fun indexOf (Ljava/lang/Object;)I
 	public fun insert (ILapp/cash/redwood/widget/Widget;)V
@@ -68,6 +69,7 @@ public abstract interface class app/cash/redwood/widget/Widget {
 }
 
 public abstract interface class app/cash/redwood/widget/Widget$Children {
+	public abstract fun getWidgets ()Ljava/util/List;
 	public abstract fun insert (ILapp/cash/redwood/widget/Widget;)V
 	public abstract fun move (III)V
 	public abstract fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V

--- a/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
+++ b/redwood-widget/src/androidMain/kotlin/app/cash/redwood/widget/ViewGroupChildren.kt
@@ -28,7 +28,7 @@ public class ViewGroupChildren(
   },
 ) : Widget.Children<View> {
   private val _widgets = ArrayList<Widget<View>>()
-  public val widgets: List<Widget<View>> get() = _widgets
+  override val widgets: List<Widget<View>> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<View>) {
     _widgets.add(index, widget)

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/MutableListChildren.kt
@@ -27,6 +27,8 @@ public class MutableListChildren<W : Any>(
   private val container: MutableList<Widget<W>> = mutableListOf(),
   private val modifierUpdated: () -> Unit = {},
 ) : Widget.Children<W>, MutableList<Widget<W>> by container {
+  override val widgets: MutableList<Widget<W>> get() = container
+
   override fun insert(index: Int, widget: Widget<W>) {
     container.add(index, widget)
   }

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -45,6 +45,12 @@ public interface Widget<W : Any> {
    * list. No additional validation needs to be performed (for example, checking index bounds).
    */
   public interface Children<W : Any> {
+    /**
+     * A view of current child widgets.
+     * This list will change its contents as the mutator functions below are invoked.
+     */
+    public val widgets: List<Widget<W>>
+
     /** Insert child [widget] at [index]. */
     public fun insert(index: Int, widget: Widget<W>)
 

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/UIViewChildren.kt
@@ -33,7 +33,7 @@ public class UIViewChildren(
   },
 ) : Widget.Children<UIView> {
   private val _widgets = ArrayList<Widget<UIView>>()
-  public val widgets: List<Widget<UIView>> get() = _widgets
+  override val widgets: List<Widget<UIView>> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<UIView>) {
     _widgets.add(index, widget)

--- a/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
+++ b/redwood-widget/src/jsMain/kotlin/app/cash/redwood/widget/HTMLElementChildren.kt
@@ -22,7 +22,7 @@ public class HTMLElementChildren(
   private val container: HTMLElement,
 ) : Widget.Children<HTMLElement> {
   private val _widgets = ArrayList<Widget<HTMLElement>>()
-  public val widgets: List<Widget<HTMLElement>> get() = _widgets
+  override val widgets: List<Widget<HTMLElement>> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<HTMLElement>) {
     _widgets.add(index, widget)


### PR DESCRIPTION
In practice, every non-specialized subtype was already maintaining this list. This will be needed for subtree traversal at the protocol layer in a future change.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
