### PR TITLE
Make `ProtocolState` a `RedwoodCodegenApi`

### DIFF
--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
@@ -15,12 +15,14 @@
  */
 package app.cash.redwood.protocol.guest
 
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.widget.Widget
 
 /** @suppress For generated code use only. */
+@RedwoodCodegenApi
 public class ProtocolState {
   private var nextValue = Id.Root.value + 1
   private val widgets = PlatformMap<Int, ProtocolWidget>()

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
@@ -15,11 +15,13 @@
  */
 package app.cash.redwood.protocol.guest
 
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenChange
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.widget.Widget
 
+@OptIn(RedwoodCodegenApi::class)
 internal class ProtocolWidgetChildren(
   private val id: Id,
   private val tag: ChildrenTag,

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolGuestGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolGuestGeneration.kt
@@ -92,6 +92,7 @@ internal fun generateProtocolBridge(
     .addType(
       TypeSpec.classBuilder(type)
         .addSuperinterface(ProtocolGuest.ProtocolBridge)
+        .optIn(Redwood.RedwoodCodegenApi)
         .primaryConstructor(
           FunSpec.constructorBuilder()
             .addModifiers(PRIVATE)
@@ -204,6 +205,7 @@ internal fun generateProtocolWidgetFactory(
       TypeSpec.classBuilder(type)
         .addModifiers(INTERNAL)
         .addSuperinterface(schema.getWidgetFactoryType().parameterizedBy(protocolViewType))
+        .addAnnotation(Redwood.RedwoodCodegenApi)
         .primaryConstructor(
           FunSpec.constructorBuilder()
             .addParameter("state", ProtocolGuest.ProtocolState)
@@ -313,6 +315,7 @@ internal fun generateProtocolWidget(
         .addModifiers(INTERNAL)
         .addSuperinterface(ProtocolGuest.ProtocolWidget)
         .addSuperinterface(widgetName.parameterizedBy(protocolViewType))
+        .addAnnotation(Redwood.RedwoodCodegenApi)
         .primaryConstructor(
           FunSpec.constructorBuilder()
             .addParameter("state", ProtocolGuest.ProtocolState)


### PR DESCRIPTION
Not sure how we missed it first time around...

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
