### PR TITLE
Reduce size of widget children map

### DIFF
--- a/redwood-protocol-host/api/android/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/android/redwood-protocol-host.api
@@ -1,7 +1,7 @@
 public abstract interface class app/cash/redwood/protocol/host/GeneratedProtocolFactory : app/cash/redwood/protocol/host/ProtocolFactory {
 	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
 	public abstract fun createNode-WCEpcRY (I)Lapp/cash/redwood/protocol/host/ProtocolNode;
-	public abstract fun getChildrenTags ()Ljava/util/Map;
+	public abstract fun widgetChildren-WCEpcRY (I)Ljava/util/List;
 }
 
 public final class app/cash/redwood/protocol/host/ProtocolBridge : app/cash/redwood/protocol/ChangesSink {

--- a/redwood-protocol-host/api/jvm/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/jvm/redwood-protocol-host.api
@@ -1,7 +1,7 @@
 public abstract interface class app/cash/redwood/protocol/host/GeneratedProtocolFactory : app/cash/redwood/protocol/host/ProtocolFactory {
 	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
 	public abstract fun createNode-WCEpcRY (I)Lapp/cash/redwood/protocol/host/ProtocolNode;
-	public abstract fun getChildrenTags ()Ljava/util/Map;
+	public abstract fun widgetChildren-WCEpcRY (I)Ljava/util/List;
 }
 
 public final class app/cash/redwood/protocol/host/ProtocolBridge : app/cash/redwood/protocol/ChangesSink {

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolBridge.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolBridge.kt
@@ -305,7 +305,7 @@ public class ProtocolBridge<W : Any>(
       if (widgetTag == UnknownWidgetTag) return false // No 'Create' for this.
       if (other.widgetTag != widgetTag) return false // Widget types don't match.
 
-      for (childrenTag in factory.childrenTags[widgetTag]!!) {
+      for (childrenTag in factory.widgetChildren(widgetTag)) {
         if (
           !shapeMatchesChildren(
             factory = factory,

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
@@ -57,11 +57,6 @@ public interface GeneratedProtocolFactory<W : Any> : ProtocolFactory<W> {
    */
   public fun createModifier(element: ModifierElement): Modifier
 
-  /**
-   * A map that reflects the tree structure for this factory.
-   *
-   * This map's keys are all known widget tags. Each entry's values are the known children tags
-   * for that widget tag.
-   */
-  public val childrenTags: Map<WidgetTag, List<ChildrenTag>>
+  /** Look up known children tags for the given widget [tag]. */
+  public fun widgetChildren(tag: WidgetTag): List<ChildrenTag>
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
@@ -27,7 +27,7 @@ import app.cash.redwood.widget.WidgetSystem
 @OptIn(RedwoodCodegenApi::class)
 internal class FakeProtocolNodeFactory : GeneratedProtocolFactory<FakeWidget> {
   override val widgetSystem: WidgetSystem<FakeWidget> = FakeWidgetSystem()
-  override val childrenTags: Map<WidgetTag, List<ChildrenTag>> = mapOf()
   override fun createNode(tag: WidgetTag): ProtocolNode<FakeWidget> = FakeProtocolNode()
   override fun createModifier(element: ModifierElement): Modifier = Modifier
+  override fun widgetChildren(tag: WidgetTag): List<ChildrenTag> = emptyList()
 }


### PR DESCRIPTION
Do not generate entries for widgets which contain no children.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
