### PR TITLE
Change widget reuse to use hashes to find a match in the pool

### DIFF
--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/NodeReuse.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/NodeReuse.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.host
+
+import app.cash.redwood.RedwoodCodegenApi
+import app.cash.redwood.protocol.ChildrenTag
+import app.cash.redwood.protocol.host.ProtocolBridge.ReuseNode
+
+/**
+ * Returns true if [a] and [b] have the same shape. The shapes match if:
+ *
+ *  * Both have the same widget tag
+ *  * Both have the same number of children, in each slot
+ *  * The paired up children have the same shape, recursively.
+ *
+ * Note that this condition isn't concerned with properties or modifiers.
+ */
+@OptIn(RedwoodCodegenApi::class)
+internal fun shapesEqual(
+  factory: GeneratedProtocolFactory<*>,
+  a: ReuseNode<*>,
+  b: ProtocolNode<*>,
+): Boolean {
+  if (!a.eligibleForReuse) return false // This node is ineligible.
+  if (a.widgetTag == UnknownWidgetTag) return false // No 'Create' for this.
+  if (b.widgetTag != a.widgetTag) return false // Widget types don't match.
+
+  return factory.widgetChildren(a.widgetTag).all { childrenTag ->
+    childrenEqual(
+      factory = factory,
+      aChildren = a.children,
+      bChildren = b.children(childrenTag)?.nodes ?: listOf(),
+      childrenTag = childrenTag,
+    )
+  }
+}
+
+/**
+ * Note that [aChildren] contains all children with all tags, and [bChildren] only contains the
+ * children with [childrenTag].
+ */
+@OptIn(RedwoodCodegenApi::class)
+private fun childrenEqual(
+  factory: GeneratedProtocolFactory<*>,
+  aChildren: List<ReuseNode<*>>,
+  bChildren: List<ProtocolNode<*>>,
+  childrenTag: ChildrenTag,
+): Boolean {
+  var aChildCount = 0
+
+  for (a in aChildren) {
+    if (a.childrenTag != childrenTag) continue // From a different slot.
+    if (a.indexInParent != aChildCount) return false // Out of order child?
+    if (aChildCount >= bChildren.size) return false // b has fewer children.
+    val b = bChildren[aChildCount++]
+    if (!shapesEqual(factory, a, b)) return false // Subtree mismatch.
+  }
+
+  if (aChildCount != bChildren.size) return false // b has more children.
+  return true
+}
+
+/** Returns a hash of this node, or 0L if this node isn't eligible for reuse. */
+@OptIn(RedwoodCodegenApi::class)
+internal fun shapeHash(
+  factory: GeneratedProtocolFactory<*>,
+  node: ReuseNode<*>,
+): Long {
+  if (!node.eligibleForReuse) return 0L // This node is ineligible.
+  if (node.widgetTag == UnknownWidgetTag) return 0L // No 'Create' for this.
+
+  var result = node.widgetTag.value.toLong()
+  for (childrenTag in factory.widgetChildren(node.widgetTag)) {
+    result = (result * 37L) + childrenTag.value
+    var childCount = 0
+    for (child in node.children) {
+      if (child.childrenTag != childrenTag) continue
+      if (child.indexInParent != childCount) return 0L // Out of order child?
+      childCount++
+      result = (result * 41L) + shapeHash(factory, child)
+    }
+  }
+
+  return result
+}
+
+/** Returns the same hash as [shapeHash], but on an already-built [ProtocolNode]. */
+@OptIn(RedwoodCodegenApi::class)
+internal fun shapeHash(
+  factory: GeneratedProtocolFactory<*>,
+  node: ProtocolNode<*>,
+): Long {
+  var result = node.widgetTag.value.toLong()
+  for (childrenTag in factory.widgetChildren(node.widgetTag)) {
+    result = (result * 37L) + childrenTag.value
+    val children = node.children(childrenTag) ?: continue
+    for (child in children.nodes) {
+      result = (result * 41L) + shapeHash(factory, child)
+    }
+  }
+
+  return result
+}

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
@@ -42,6 +42,9 @@ public abstract class ProtocolNode<W : Any> {
   internal var widgetTag: WidgetTag = UnknownWidgetTag
   internal var reuse = false
 
+  /** Assigned when the node is added to the pool. */
+  internal var shapeHash = 0L
+
   public abstract fun apply(change: PropertyChange, eventSink: EventSink)
 
   public fun updateModifier(modifier: Modifier) {

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewRecyclingTester.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewRecyclingTester.kt
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress(
-  "CANNOT_OVERRIDE_INVISIBLE_MEMBER",
-  "INVISIBLE_MEMBER",
-  "INVISIBLE_REFERENCE",
-)
-
 package app.cash.redwood.testing
 
 import androidx.compose.runtime.Composable
@@ -26,21 +20,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.cash.redwood.RedwoodCodegenApi
-import app.cash.redwood.layout.testing.MutableBox
-import app.cash.redwood.layout.testing.MutableColumn
 import app.cash.redwood.layout.testing.RedwoodLayoutTestingWidgetFactory
 import app.cash.redwood.lazylayout.testing.RedwoodLazyLayoutTestingWidgetFactory
 import app.cash.redwood.protocol.host.ProtocolBridge
 import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
 import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import com.example.redwood.testing.protocol.guest.TestSchemaProtocolBridge
 import com.example.redwood.testing.protocol.host.TestSchemaProtocolFactory
-import com.example.redwood.testing.testing.MutableButton
-import com.example.redwood.testing.testing.MutableSplit
-import com.example.redwood.testing.testing.MutableText
 import com.example.redwood.testing.testing.TestSchemaTestingWidgetFactory
 import com.example.redwood.testing.widget.TestSchemaTester
 import com.example.redwood.testing.widget.TestSchemaWidgetSystem
@@ -135,7 +125,8 @@ suspend fun assertReuse(
 
     // Confirm the widgets are all the same.
     if (assertFullSubtreesEqual) {
-      assertThat(step3WidgetsFlattened).isEqualTo(step1WidgetsFlattened)
+      assertThat(step3WidgetsFlattened)
+        .containsExactlyInAnyOrder(*step1WidgetsFlattened.toTypedArray())
     }
     assertThat(widgets.single().value).isEqualTo(step3Value)
     step1Widgets to step3Widgets
@@ -188,17 +179,18 @@ private fun List<Widget<WidgetValue>>.flatten(): Sequence<Widget<WidgetValue>> {
   }
 }
 
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // To test implementation details!
 private suspend fun SequenceScope<Widget<WidgetValue>>.flattenRecursive(
   widget: Widget<WidgetValue>,
 ) {
   yield(widget)
 
   val childrenLists = when (widget) {
-    is MutableBox -> listOf(widget.children)
-    is MutableButton -> listOf()
-    is MutableColumn -> listOf(widget.children)
-    is MutableSplit -> listOf(widget.left, widget.right)
-    is MutableText -> listOf()
+    is app.cash.redwood.layout.testing.MutableBox -> listOf(widget.children)
+    is app.cash.redwood.layout.testing.MutableColumn -> listOf(widget.children)
+    is com.example.redwood.testing.testing.MutableButton -> listOf()
+    is com.example.redwood.testing.testing.MutableSplit -> listOf(widget.left, widget.right)
+    is com.example.redwood.testing.testing.MutableText -> listOf()
     else -> error("unexpected widget: $widget")
   }
 


### PR DESCRIPTION
The previous strategy assumed all nodes were symmetric.
