### PR TITLE
Remove widgets recursively on guest side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Fixed:
 - Fix the backgroundColor for `UIViewLazyList` to be transparent. This matches the behavior of the other `LazyList` platform implementations.
 - Fix `TreehouseUIView` to size itself according to the size of its subview.
 - In `UIViewLazyList`, adding `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows`, and wrapping changes in `UIView.performWithoutAnimation` blocks.
+- Fix memory leak in 'protocol-guest' where child nodes beneath a removed node were incorrectly retained in an internal map indefinitely.
 
 
 ## [0.9.0] - 2024-02-28

--- a/redwood-protocol-guest/api/android/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/android/redwood-protocol-guest.api
@@ -32,7 +32,6 @@ public final class app/cash/redwood/protocol/guest/ProtocolState {
 	public final fun getWidget-ou3jOuA (I)Lapp/cash/redwood/protocol/guest/ProtocolWidget;
 	public final fun nextId-0HhLjSo ()I
 	public final fun removeWidget-ou3jOuA (I)V
-	public final fun widgetChildren-AWfp_YY (II)Lapp/cash/redwood/widget/Widget$Children;
 }
 
 public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget : app/cash/redwood/widget/Widget {
@@ -41,5 +40,17 @@ public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget :
 	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun getValue ()Lkotlin/Unit;
 	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
+	public abstract fun visitIds (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolWidgetChildren : app/cash/redwood/widget/Widget$Children {
+	public static final field $stable I
+	public synthetic fun <init> (IILapp/cash/redwood/protocol/guest/ProtocolState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getWidgets ()Ljava/util/List;
+	public fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public fun move (III)V
+	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public fun remove (II)V
+	public final fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
@@ -32,7 +32,6 @@ public final class app/cash/redwood/protocol/guest/ProtocolState {
 	public final fun getWidget-ou3jOuA (I)Lapp/cash/redwood/protocol/guest/ProtocolWidget;
 	public final fun nextId-0HhLjSo ()I
 	public final fun removeWidget-ou3jOuA (I)V
-	public final fun widgetChildren-AWfp_YY (II)Lapp/cash/redwood/widget/Widget$Children;
 }
 
 public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget : app/cash/redwood/widget/Widget {
@@ -41,5 +40,17 @@ public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget :
 	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun getValue ()Lkotlin/Unit;
 	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
+	public abstract fun visitIds (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class app/cash/redwood/protocol/guest/ProtocolWidgetChildren : app/cash/redwood/widget/Widget$Children {
+	public static final field $stable I
+	public synthetic fun <init> (IILapp/cash/redwood/protocol/guest/ProtocolState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getWidgets ()Ljava/util/List;
+	public fun insert (ILapp/cash/redwood/widget/Widget;)V
+	public fun move (III)V
+	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
+	public fun remove (II)V
+	public final fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
@@ -17,9 +17,7 @@ package app.cash.redwood.protocol.guest
 
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Change
-import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
-import app.cash.redwood.widget.Widget
 
 /** @suppress For generated code use only. */
 @RedwoodCodegenApi
@@ -65,8 +63,4 @@ public class ProtocolState {
   }
 
   public fun getWidget(id: Id): ProtocolWidget? = widgets[id.value]
-
-  public fun widgetChildren(id: Id, tag: ChildrenTag): Widget.Children<Unit> {
-    return ProtocolWidgetChildren(id, tag, this)
-  }
 }

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.protocol.guest
 
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.WidgetTag
@@ -26,6 +27,7 @@ import app.cash.redwood.widget.Widget
  *
  * @suppress For generated code use only.
  */
+@RedwoodCodegenApi
 public interface ProtocolWidget : Widget<Unit> {
   public val id: Id
   public val tag: WidgetTag
@@ -33,4 +35,7 @@ public interface ProtocolWidget : Widget<Unit> {
   override val value: Unit get() = Unit
 
   public fun sendEvent(event: Event)
+
+  /** Recursively visit IDs in this widget's tree, starting with this widget's [id]. */
+  public fun visitIds(block: (Id) -> Unit)
 }

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
@@ -21,14 +21,15 @@ import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.widget.Widget
 
-@OptIn(RedwoodCodegenApi::class)
-internal class ProtocolWidgetChildren(
+/** @suppress For generated code use only. */
+@RedwoodCodegenApi
+public class ProtocolWidgetChildren(
   private val id: Id,
   private val tag: ChildrenTag,
   private val state: ProtocolState,
 ) : Widget.Children<Unit> {
   private val _widgets = mutableListOf<ProtocolWidget>()
-  override val widgets: List<Widget<Unit>> get() = _widgets
+  override val widgets: List<ProtocolWidget> get() = _widgets
 
   override fun insert(index: Int, widget: Widget<Unit>) {
     widget as ProtocolWidget
@@ -38,14 +39,14 @@ internal class ProtocolWidgetChildren(
   }
 
   override fun remove(index: Int, count: Int) {
-    val removingIds = _widgets.subList(index, index + count)
-    val removedIds = removingIds.map(ProtocolWidget::id)
-    removingIds.clear()
-
-    for (removedId in removedIds) {
-      state.removeWidget(removedId)
+    val removedIds = ArrayList<Id>(count)
+    for (i in index until index + count) {
+      val widget = _widgets[i]
+      widget.visitIds(state::removeWidget)
+      removedIds += widget.id
     }
 
+    _widgets.remove(index, count)
     state.append(ChildrenChange.Remove(id, tag, index, count, removedIds))
   }
 
@@ -55,5 +56,11 @@ internal class ProtocolWidgetChildren(
   }
 
   override fun onModifierUpdated(index: Int, widget: Widget<Unit>) {
+  }
+
+  public fun visitIds(block: (Id) -> Unit) {
+    for (i in _widgets.indices) {
+      _widgets[i].visitIds(block)
+    }
   }
 }

--- a/redwood-protocol-guest/src/commonTest/kotlin/app/cash/redwood/protocol/guest/GeneratedProtocolBridgeTest.kt
+++ b/redwood-protocol-guest/src/commonTest/kotlin/app/cash/redwood/protocol/guest/GeneratedProtocolBridgeTest.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.protocol.guest
 
 import app.cash.redwood.Modifier
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Create
 import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.EventTag
@@ -40,6 +41,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.modules.SerializersModule
 
+@OptIn(RedwoodCodegenApi::class)
 class GeneratedProtocolBridgeTest {
   @Test fun propertyUsesSerializersModule() {
     val json = Json {

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -48,6 +48,7 @@ internal object ProtocolGuest {
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.guest", "ProtocolMismatchHandler")
   val ProtocolWidget = ClassName("app.cash.redwood.protocol.guest", "ProtocolWidget")
+  val ProtocolWidgetChildren = ClassName("app.cash.redwood.protocol.guest", "ProtocolWidgetChildren")
 }
 
 internal object WidgetProtocol {


### PR DESCRIPTION
Closes #1899.

~With #1901 we can send the entire subtree in the `removedIds` list to the host to fix #1900 for older hosts.~ We cannot. See #1920 for reason.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
