### PR TITLE
Remove widgets recursively on host side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Fixed:
 - Fix the backgroundColor for `UIViewLazyList` to be transparent. This matches the behavior of the other `LazyList` platform implementations.
 - Fix `TreehouseUIView` to size itself according to the size of its subview.
 - In `UIViewLazyList`, adding `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows`, and wrapping changes in `UIView.performWithoutAnimation` blocks.
-- Fix memory leak in 'protocol-guest' where child nodes beneath a removed node were incorrectly retained in an internal map indefinitely.
+- Fix memory leak in 'protocol-guest' and 'protocol-host' where child nodes beneath a removed node were incorrectly retained in an internal map indefinitely.
 
 
 ## [0.9.0] - 2024-02-28

--- a/redwood-protocol-host/api/android/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/android/redwood-protocol-host.api
@@ -1,6 +1,6 @@
 public abstract interface class app/cash/redwood/protocol/host/GeneratedProtocolFactory : app/cash/redwood/protocol/host/ProtocolFactory {
 	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
-	public abstract fun createNode-WCEpcRY (I)Lapp/cash/redwood/protocol/host/ProtocolNode;
+	public abstract fun createNode-kyz2zXs (II)Lapp/cash/redwood/protocol/host/ProtocolNode;
 	public abstract fun widgetChildren-WCEpcRY (I)Ljava/util/List;
 }
 
@@ -12,6 +12,7 @@ public final class app/cash/redwood/protocol/host/ProtocolBridge : app/cash/redw
 public final class app/cash/redwood/protocol/host/ProtocolChildren {
 	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;)V
 	public final fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class app/cash/redwood/protocol/host/ProtocolFactory {
@@ -31,10 +32,13 @@ public final class app/cash/redwood/protocol/host/ProtocolMismatchHandler$Compan
 }
 
 public abstract class app/cash/redwood/protocol/host/ProtocolNode {
-	public fun <init> ()V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public abstract fun apply (Lapp/cash/redwood/protocol/PropertyChange;Lapp/cash/redwood/protocol/EventSink;)V
 	public abstract fun children-dBpC-2Y (I)Lapp/cash/redwood/protocol/host/ProtocolChildren;
+	public final fun getId-0HhLjSo ()I
 	public abstract fun getWidget ()Lapp/cash/redwood/widget/Widget;
+	public final fun getWidgetTag-BlhN7y0 ()I
 	public final fun updateModifier (Lapp/cash/redwood/Modifier;)V
+	public abstract fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/redwood-protocol-host/api/jvm/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/jvm/redwood-protocol-host.api
@@ -1,6 +1,6 @@
 public abstract interface class app/cash/redwood/protocol/host/GeneratedProtocolFactory : app/cash/redwood/protocol/host/ProtocolFactory {
 	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
-	public abstract fun createNode-WCEpcRY (I)Lapp/cash/redwood/protocol/host/ProtocolNode;
+	public abstract fun createNode-kyz2zXs (II)Lapp/cash/redwood/protocol/host/ProtocolNode;
 	public abstract fun widgetChildren-WCEpcRY (I)Ljava/util/List;
 }
 
@@ -12,6 +12,7 @@ public final class app/cash/redwood/protocol/host/ProtocolBridge : app/cash/redw
 public final class app/cash/redwood/protocol/host/ProtocolChildren {
 	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;)V
 	public final fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
+	public final fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class app/cash/redwood/protocol/host/ProtocolFactory {
@@ -31,10 +32,13 @@ public final class app/cash/redwood/protocol/host/ProtocolMismatchHandler$Compan
 }
 
 public abstract class app/cash/redwood/protocol/host/ProtocolNode {
-	public fun <init> ()V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public abstract fun apply (Lapp/cash/redwood/protocol/PropertyChange;Lapp/cash/redwood/protocol/EventSink;)V
 	public abstract fun children-dBpC-2Y (I)Lapp/cash/redwood/protocol/host/ProtocolChildren;
+	public final fun getId-0HhLjSo ()I
 	public abstract fun getWidget ()Lapp/cash/redwood/widget/Widget;
+	public final fun getWidgetTag-BlhN7y0 ()I
 	public final fun updateModifier (Lapp/cash/redwood/Modifier;)V
+	public abstract fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/redwood-protocol-host/build.gradle
+++ b/redwood-protocol-host/build.gradle
@@ -24,6 +24,7 @@ kotlin {
         implementation libs.kotlin.test
         implementation libs.assertk
         implementation projects.testApp.schema.compose
+        implementation projects.testApp.schema.testing
         implementation projects.testApp.schema.widgetProtocol
       }
     }

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/NodeReuse.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/NodeReuse.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.protocol.host
 
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
+import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.protocol.host.ProtocolBridge.ReuseNode
 
 /**
@@ -114,3 +115,5 @@ internal fun shapeHash(
 
   return result
 }
+
+internal val UnknownWidgetTag: WidgetTag = WidgetTag(-1)

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.protocol.host
 import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
+import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.ModifierElement
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.WidgetSystem
@@ -41,13 +42,13 @@ public interface ProtocolFactory<W : Any> {
 @RedwoodCodegenApi
 public interface GeneratedProtocolFactory<W : Any> : ProtocolFactory<W> {
   /**
-   * Create a new protocol node of the specified [tag].
+   * Create a new protocol node with [id] of the specified [tag].
    *
    * Invalid [tag] values can either produce an exception or result in `null` being returned.
    * If `null` is returned, the caller should make every effort to ignore this node and
    * continue executing.
    */
-  public fun createNode(tag: WidgetTag): ProtocolNode<W>?
+  public fun createNode(id: Id, tag: WidgetTag): ProtocolNode<W>?
 
   /**
    * Create a new modifier from the specified [element].

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ChildrenNodeIndexTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ChildrenNodeIndexTest.kt
@@ -19,7 +19,9 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.EventSink
+import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.PropertyChange
+import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
 import assertk.assertThat
@@ -125,13 +127,16 @@ class ChildrenNodeIndexTest {
 }
 
 @OptIn(RedwoodCodegenApi::class)
-private class WidgetNode(override val widget: StringWidget) : ProtocolNode<String>() {
+private class WidgetNode(override val widget: StringWidget) : ProtocolNode<String>(Id(1), WidgetTag(1)) {
   override fun apply(change: PropertyChange, eventSink: EventSink) {
     throw UnsupportedOperationException()
   }
 
   override fun children(tag: ChildrenTag): ProtocolChildren<String>? {
     throw UnsupportedOperationException()
+  }
+
+  override fun visitIds(block: (Id) -> Unit) {
   }
 }
 

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ProtocolFactoryTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ProtocolFactoryTest.kt
@@ -58,7 +58,7 @@ class ProtocolFactoryTest {
     )
 
     val t = assertFailsWith<IllegalArgumentException> {
-      factory.createNode(WidgetTag(345432))
+      factory.createNode(Id(1), WidgetTag(345432))
     }
     assertThat(t).hasMessage("Unknown widget tag 345432")
   }
@@ -74,7 +74,7 @@ class ProtocolFactoryTest {
       mismatchHandler = handler,
     )
 
-    assertThat(factory.createNode(WidgetTag(345432))).isNull()
+    assertThat(factory.createNode(Id(1), WidgetTag(345432))).isNull()
 
     assertThat(handler.events.single()).isEqualTo("Unknown widget 345432")
   }
@@ -214,7 +214,7 @@ class ProtocolFactoryTest {
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
     )
-    val button = factory.createNode(WidgetTag(4))!!
+    val button = factory.createNode(Id(1), WidgetTag(4))!!
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.children(ChildrenTag(345432))
@@ -233,7 +233,7 @@ class ProtocolFactoryTest {
       mismatchHandler = handler,
     )
 
-    val button = factory.createNode(WidgetTag(4))!!
+    val button = factory.createNode(Id(1), WidgetTag(4))!!
     assertThat(button.children(ChildrenTag(345432))).isNull()
 
     assertThat(handler.events.single()).isEqualTo("Unknown children 345432 for 4")
@@ -256,7 +256,7 @@ class ProtocolFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.createNode(WidgetTag(5))!!
+    val textInput = factory.createNode(Id(1), WidgetTag(5))!!
 
     val throwingEventSink = EventSink { error(it) }
     textInput.apply(PropertyChange(Id(1), PropertyTag(2), JsonPrimitive("PT10S")), throwingEventSink)
@@ -272,7 +272,7 @@ class ProtocolFactoryTest {
         RedwoodLazyLayout = EmptyRedwoodLazyLayoutWidgetFactory(),
       ),
     )
-    val button = factory.createNode(WidgetTag(4))!!
+    val button = factory.createNode(Id(1), WidgetTag(4))!!
 
     val change = PropertyChange(Id(1), PropertyTag(345432))
     val eventSink = EventSink { throw UnsupportedOperationException() }
@@ -292,7 +292,7 @@ class ProtocolFactoryTest {
       ),
       mismatchHandler = handler,
     )
-    val button = factory.createNode(WidgetTag(4))!!
+    val button = factory.createNode(Id(1), WidgetTag(4))!!
 
     button.apply(PropertyChange(Id(1), PropertyTag(345432))) { throw UnsupportedOperationException() }
 
@@ -316,7 +316,7 @@ class ProtocolFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.createNode(WidgetTag(5))!!
+    val textInput = factory.createNode(Id(1), WidgetTag(5))!!
 
     val eventSink = RecordingEventSink()
     textInput.apply(PropertyChange(Id(1), PropertyTag(4), JsonPrimitive(true)), eventSink)

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
@@ -22,6 +22,7 @@ import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.EventTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.PropertyChange
+import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.protocol.host.ProtocolChildren
 import app.cash.redwood.protocol.host.ProtocolNode
 import kotlinx.serialization.json.JsonPrimitive
@@ -30,7 +31,10 @@ import kotlinx.serialization.json.JsonPrimitive
  * This supports [FakeWidget] and its [FakeWidget.label] property.
  */
 @RedwoodCodegenApi
-internal class FakeProtocolNode : ProtocolNode<FakeWidget>() {
+internal class FakeProtocolNode(
+  id: Id,
+  tag: WidgetTag,
+) : ProtocolNode<FakeWidget>(id, tag) {
   override val widget = FakeWidget()
 
   override fun apply(change: PropertyChange, eventSink: EventSink) {
@@ -42,5 +46,9 @@ internal class FakeProtocolNode : ProtocolNode<FakeWidget>() {
 
   override fun children(tag: ChildrenTag): ProtocolChildren<FakeWidget>? {
     error("unexpected call")
+  }
+
+  override fun visitIds(block: (Id) -> Unit) {
+    block(id)
   }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.treehouse
 import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
+import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.ModifierElement
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.protocol.host.GeneratedProtocolFactory
@@ -27,7 +28,7 @@ import app.cash.redwood.widget.WidgetSystem
 @OptIn(RedwoodCodegenApi::class)
 internal class FakeProtocolNodeFactory : GeneratedProtocolFactory<FakeWidget> {
   override val widgetSystem: WidgetSystem<FakeWidget> = FakeWidgetSystem()
-  override fun createNode(tag: WidgetTag): ProtocolNode<FakeWidget> = FakeProtocolNode()
+  override fun createNode(id: Id, tag: WidgetTag): ProtocolNode<FakeWidget> = FakeProtocolNode(id, tag)
   override fun createModifier(element: ModifierElement): Modifier = Modifier
   override fun widgetChildren(tag: WidgetTag): List<ChildrenTag> = emptyList()
 }


### PR DESCRIPTION
Closes #1900. We no longer rely on `removedIds` from the protocol. ~With #1901 we can conditionally use the `removedIds` to send an entire subtree's IDs from the guest-side to fix this bug on the host-side for older hosts. That's why this doesn't _yet_ close the issue.~ We cannot work around this for older hosts. The protocol validates that the `count == removedIds.size` on both sides, so we can't sneak more values in.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
