### PR TITLE
Change Gradle plugin IDs to guest/host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changed:
   - Testing code is now under `your.package.testing`.
   - Protocol guest code is now under `your.package.protocol.guest`.
   - Protocol host code is now under `your.package.protocol.host`.
+- The 'app.cash.redwood.generator.compose.protocol' and 'app.cash.redwood.generator.widget.protocol' Gradle plugins are now deprecated and will be removed in the next release. Use 'app.cash.redwood.generator.protocol.guest' and 'app.cash.redwood.generator.protocol.host', respectively.
+- The 'redwood-tooling-codegen' CLI flags for protocol codegen have changed from `--compose-protocol` and `--widget-protocol` to `--protocol-guest` and `--protocol-host`, respectively.
 
 Fixed:
 - Fix failure to release JS resources when calling `CoroutineScope` is being cancelled

--- a/redwood-gradle-plugin/api/redwood-gradle-plugin.api
+++ b/redwood-gradle-plugin/api/redwood-gradle-plugin.api
@@ -25,6 +25,8 @@ public final class app/cash/redwood/gradle/RedwoodComposePlugin : org/jetbrains/
 
 public final class app/cash/redwood/gradle/RedwoodComposeProtocolGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
 	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
 }
 
 public abstract class app/cash/redwood/gradle/RedwoodGeneratorExtension : app/cash/redwood/gradle/RedwoodSchemaExtension {
@@ -40,11 +42,11 @@ public abstract class app/cash/redwood/gradle/RedwoodGeneratorPlugin : org/gradl
 
 public final class app/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy : java/lang/Enum {
 	public static final field Compose Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
-	public static final field ComposeProtocol Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
 	public static final field Modifiers Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static final field ProtocolGuest Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
+	public static final field ProtocolHost Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
 	public static final field Testing Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
 	public static final field Widget Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
-	public static final field WidgetProtocol Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
 	public static fun values ()[Lapp/cash/redwood/gradle/RedwoodGeneratorPlugin$Strategy;
@@ -57,6 +59,14 @@ public final class app/cash/redwood/gradle/RedwoodLintPlugin : org/gradle/api/Pl
 }
 
 public final class app/cash/redwood/gradle/RedwoodModifiersGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+
+public final class app/cash/redwood/gradle/RedwoodProtocolGuestGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
+	public fun <init> ()V
+}
+
+public final class app/cash/redwood/gradle/RedwoodProtocolHostGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
 	public fun <init> ()V
 }
 
@@ -82,5 +92,7 @@ public final class app/cash/redwood/gradle/RedwoodWidgetGeneratorPlugin : app/ca
 
 public final class app/cash/redwood/gradle/RedwoodWidgetProtocolGeneratorPlugin : app/cash/redwood/gradle/RedwoodGeneratorPlugin {
 	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
 }
 

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -80,6 +80,18 @@ gradlePlugin {
       description = "Redwood schema layout modifier code generation Gradle plugin"
       implementationClass = "app.cash.redwood.gradle.RedwoodModifiersGeneratorPlugin"
     }
+    redwoodProtocolGuestGenerator {
+      id = "app.cash.redwood.generator.protocol.guest"
+      displayName = "Redwood generator (guest protocol)"
+      description = "Redwood schema guest protocol code generation Gradle plugin"
+      implementationClass = "app.cash.redwood.gradle.RedwoodProtocolGuestGeneratorPlugin"
+    }
+    redwoodProtocolHostGenerator {
+      id = "app.cash.redwood.generator.protocol.host"
+      displayName = "Redwood generator (host protocol)"
+      description = "Redwood schema host protocol code generation Gradle plugin"
+      implementationClass = "app.cash.redwood.gradle.RedwoodProtocolHostGeneratorPlugin"
+    }
     redwoodTestingGenerator {
       id = "app.cash.redwood.generator.testing"
       displayName = "Redwood generator (testing)"

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
@@ -16,13 +16,14 @@
 package app.cash.redwood.gradle
 
 import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.Compose
-import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.ComposeProtocol
 import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.Modifiers
+import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.ProtocolGuest
+import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.ProtocolHost
 import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.Testing
 import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.Widget
-import app.cash.redwood.gradle.RedwoodGeneratorPlugin.Strategy.WidgetProtocol
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.logging.Logging
 import org.gradle.language.base.plugins.LifecycleBasePlugin.BUILD_GROUP
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.Companion.COMMON_MAIN_SOURCE_SET_NAME
@@ -31,10 +32,22 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.Companion.COMMON_MAIN_
 public class RedwoodComposeGeneratorPlugin : RedwoodGeneratorPlugin(Compose)
 
 @Suppress("unused") // Invoked reflectively by Gradle.
-public class RedwoodComposeProtocolGeneratorPlugin : RedwoodGeneratorPlugin(ComposeProtocol)
+public class RedwoodComposeProtocolGeneratorPlugin : RedwoodGeneratorPlugin(ProtocolGuest) {
+  override fun apply(project: Project) {
+    Logging.getLogger(RedwoodComposeProtocolGeneratorPlugin::class.java)
+      .warn("This plugin is deprecated. Use 'app.cash.redwood.generator.protocol.guest' instead.")
+    super.apply(project)
+  }
+}
 
 @Suppress("unused") // Invoked reflectively by Gradle.
 public class RedwoodModifiersGeneratorPlugin : RedwoodGeneratorPlugin(Modifiers)
+
+@Suppress("unused") // Invoked reflectively by Gradle.
+public class RedwoodProtocolGuestGeneratorPlugin : RedwoodGeneratorPlugin(ProtocolGuest)
+
+@Suppress("unused") // Invoked reflectively by Gradle.
+public class RedwoodProtocolHostGeneratorPlugin : RedwoodGeneratorPlugin(ProtocolHost)
 
 @Suppress("unused") // Invoked reflectively by Gradle.
 public class RedwoodTestingGeneratorPlugin : RedwoodGeneratorPlugin(Testing)
@@ -43,7 +56,13 @@ public class RedwoodTestingGeneratorPlugin : RedwoodGeneratorPlugin(Testing)
 public class RedwoodWidgetGeneratorPlugin : RedwoodGeneratorPlugin(Widget)
 
 @Suppress("unused") // Invoked reflectively by Gradle.
-public class RedwoodWidgetProtocolGeneratorPlugin : RedwoodGeneratorPlugin(WidgetProtocol)
+public class RedwoodWidgetProtocolGeneratorPlugin : RedwoodGeneratorPlugin(ProtocolHost) {
+  override fun apply(project: Project) {
+    Logging.getLogger(RedwoodComposeProtocolGeneratorPlugin::class.java)
+      .warn("This plugin is deprecated. Use 'app.cash.redwood.generator.protocol.host' instead.")
+    super.apply(project)
+  }
+}
 
 public abstract class RedwoodGeneratorPlugin(
   private val strategy: Strategy,
@@ -53,18 +72,18 @@ public abstract class RedwoodGeneratorPlugin(
     internal val dependencyArtifactId: String,
   ) {
     Compose("--compose", "redwood-compose"),
-    ComposeProtocol("--compose-protocol", "redwood-protocol-guest"),
     Modifiers("--modifier", "redwood-runtime"),
+    ProtocolGuest("--protocol-guest", "redwood-protocol-guest"),
+    ProtocolHost("--protocol-host", "redwood-protocol-host"),
     Testing("--testing", "redwood-testing"),
     Widget("--widget", "redwood-widget"),
-    WidgetProtocol("--widget-protocol", "redwood-protocol-host"),
   }
 
   override fun apply(project: Project) {
     if (strategy == Compose) {
       project.plugins.apply(RedwoodComposePlugin::class.java)
     }
-    if (strategy == ComposeProtocol || strategy == WidgetProtocol) {
+    if (strategy == ProtocolGuest || strategy == ProtocolHost) {
       project.plugins.apply("org.jetbrains.kotlin.plugin.serialization")
     }
 

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/compose-protocol/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/compose-protocol/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'app.cash.redwood.generator.compose.protocol'
+apply plugin: 'app.cash.redwood.generator.protocol.guest'
 
 kotlin {
   jvm()

--- a/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/widget-protocol/build.gradle
+++ b/redwood-gradle-plugin/src/test/fixture/protocol-no-modifiers/widget-protocol/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
-apply plugin: 'app.cash.redwood.generator.widget.protocol'
+apply plugin: 'app.cash.redwood.generator.protocol.host'
 
 kotlin {
   jvm()

--- a/redwood-tooling-codegen/api/redwood-tooling-codegen.api
+++ b/redwood-tooling-codegen/api/redwood-tooling-codegen.api
@@ -21,8 +21,8 @@ public final class app/cash/redwood/tooling/codegen/ProtocolCodegenKt {
 }
 
 public final class app/cash/redwood/tooling/codegen/ProtocolCodegenType : java/lang/Enum {
-	public static final field Compose Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
-	public static final field Widget Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
+	public static final field Guest Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
+	public static final field Host Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;
 	public static fun values ()[Lapp/cash/redwood/tooling/codegen/ProtocolCodegenType;

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/GenerateCommand.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/GenerateCommand.kt
@@ -35,11 +35,11 @@ internal class GenerateCommand : CliktCommand(name = "generate") {
   private val type by option()
     .switch(
       "--compose" to CodegenType.Compose,
-      "--compose-protocol" to ProtocolCodegenType.Compose,
       "--modifier" to CodegenType.Modifiers,
+      "--protocol-guest" to ProtocolCodegenType.Guest,
+      "--protocol-host" to ProtocolCodegenType.Host,
       "--testing" to CodegenType.Testing,
       "--widget" to CodegenType.Widget,
-      "--widget-protocol" to ProtocolCodegenType.Widget,
     )
     .help("Type of code to generate")
     .required()

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
@@ -15,15 +15,15 @@
  */
 package app.cash.redwood.tooling.codegen
 
-import app.cash.redwood.tooling.codegen.ProtocolCodegenType.Compose
-import app.cash.redwood.tooling.codegen.ProtocolCodegenType.Widget
+import app.cash.redwood.tooling.codegen.ProtocolCodegenType.Guest
+import app.cash.redwood.tooling.codegen.ProtocolCodegenType.Host
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
 import com.squareup.kotlinpoet.FileSpec
 import java.nio.file.Path
 
 public enum class ProtocolCodegenType {
-  Compose,
-  Widget,
+  Guest,
+  Host,
 }
 
 public fun ProtocolSchemaSet.generate(type: ProtocolCodegenType, destination: Path) {
@@ -35,7 +35,7 @@ public fun ProtocolSchemaSet.generate(type: ProtocolCodegenType, destination: Pa
 internal fun ProtocolSchemaSet.generateFileSpecs(type: ProtocolCodegenType): List<FileSpec> {
   return buildList {
     when (type) {
-      Compose -> {
+      Guest -> {
         add(protocolGuestDeprecations(schema))
         add(generateProtocolBridge(this@generateFileSpecs))
         add(generateComposeProtocolModifierSerialization(this@generateFileSpecs))
@@ -48,7 +48,7 @@ internal fun ProtocolSchemaSet.generateFileSpecs(type: ProtocolCodegenType): Lis
         }
       }
 
-      Widget -> {
+      Host -> {
         add(protocolHostDeprecations(schema))
         add(generateProtocolFactory(this@generateFileSpecs))
         for (dependency in all) {

--- a/samples/emoji-search/schema/compose/protocol/build.gradle
+++ b/samples/emoji-search/schema/compose/protocol/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.generator.compose.protocol'
+apply plugin: 'app.cash.redwood.generator.protocol.guest'
 
 archivesBaseName = 'schema-compose-protocol'
 

--- a/samples/emoji-search/schema/widget/protocol/build.gradle
+++ b/samples/emoji-search/schema/widget/protocol/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.generator.widget.protocol'
+apply plugin: 'app.cash.redwood.generator.protocol.host'
 
 archivesBaseName = 'schema-widget-protocol'
 

--- a/test-app/schema/compose-protocol/build.gradle
+++ b/test-app/schema/compose-protocol/build.gradle
@@ -1,7 +1,7 @@
 import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.generator.compose.protocol'
+apply plugin: 'app.cash.redwood.generator.protocol.guest'
 
 kotlin {
   KmpTargets.addAllTargets(project)

--- a/test-app/schema/widget-protocol/build.gradle
+++ b/test-app/schema/widget-protocol/build.gradle
@@ -1,7 +1,7 @@
 import app.cash.redwood.buildsupport.KmpTargets
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'app.cash.redwood.generator.widget.protocol'
+apply plugin: 'app.cash.redwood.generator.protocol.host'
 
 kotlin {
   KmpTargets.addAllTargets(project)


### PR DESCRIPTION
Keep the old ones around as deprecated for one release.

Closes #1907

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
