### PR TITLE
Optimize detecting whether a reused widget was created

### DIFF
--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolBridge.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolBridge.kt
@@ -176,14 +176,19 @@ public class ProtocolBridge<W : Any>(
 
     // Find nodes that have Modifier.reuse
     val idToNode = mutableMapOf<Id, ReuseNode<W>>()
-    for ((index, change) in changes.withIndex()) {
+    var lastCreatedId = Id.Root
+    for (change in changes) {
+      if (change is Create) {
+        lastCreatedId = change.id
+        continue
+      }
       if (change !is ModifierChange) continue
 
       // Must have a reuse modifier.
       if (change.elements.none { it.tag.value == REUSE_MODIFIER_TAG }) continue
 
       // Must have a Create node that precedes it.
-      if (changes.subList(0, index).none { it is Create && it.id == change.id }) continue
+      if (lastCreatedId != change.id) continue
 
       idToNode[change.id] = ReuseNode(
         widgetId = change.id,


### PR DESCRIPTION
Because the protocol guarantees that create/property/modifier changes are all grouped together in that order, we can simply track the last created widget we saw to determine if the target widget was created in this set of changes.

Closes #1924

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
