### PR TITLE
Fix coroutine scoping of Redwood Treehouse UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Fixed:
 - Fix `TreehouseUIView` to size itself according to the size of its subview.
 - In `UIViewLazyList`, adding `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows`, and wrapping changes in `UIView.performWithoutAnimation` blocks.
 - Fix memory leak in 'protocol-guest' and 'protocol-host' where child nodes beneath a removed node were incorrectly retained in an internal map indefinitely.
+- Ensure that Zipline services are not closed prematurely when disposing a Treehouse UI.
 
 
 ## [0.9.0] - 2024-02-28


### PR DESCRIPTION
Ensure that Zipline resources aren't closed until the UI's coroutine scope job completes.

This prevents a queued-up job from resuming(?) and crashing from a `ZiplineException` instead of gracefully handling a `CancellationException` when trying to collect a `ZiplineService`-backed flow.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
