### PR TITLE
Remove `upToDate` hack

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -130,9 +130,6 @@ class RedwoodBuildPlugin : Plugin<Project> {
         }
         it.exceptionFormat = FULL
       }
-      // Force tests to always run to avoid caching issues.
-      // TODO Delete this! Anything not working is bad/missing task inputs or a bug.
-      task.outputs.upToDateWhen { false }
     }
   }
 


### PR DESCRIPTION
I don't recall what it was specifically for, and it's a terrible idea. Probably for the Gradle plugin's tests. I guess we'll find out...

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
