### PR TITLE
In UIViewLazyList, don't remove subviews from hierarchy during prepareForReuse call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Fixed:
 - In `UIViewLazyList`, adding `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows`, and wrapping changes in `UIView.performWithoutAnimation` blocks.
 - Fix memory leak in 'protocol-guest' and 'protocol-host' where child nodes beneath a removed node were incorrectly retained in an internal map indefinitely.
 - Ensure that Zipline services are not closed prematurely when disposing a Treehouse UI.
+- In `UIViewLazyList`, don't remove subviews from hierarchy during `prepareForReuse` call
 
 
 ## [0.9.0] - 2024-02-28

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -296,7 +296,6 @@ internal class LazyListContainerCell(
 
   override fun prepareForReuse() {
     super.prepareForReuse()
-    removeAllSubviews()
     binding?.unbind()
     binding = null
   }


### PR DESCRIPTION
Now that view recycling is supported, we should not be pre-emptively blowing away widget views

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
