### PR TITLE
Synthesize depth-first removes for old hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Fixed:
 - Fix the backgroundColor for `UIViewLazyList` to be transparent. This matches the behavior of the other `LazyList` platform implementations.
 - Fix `TreehouseUIView` to size itself according to the size of its subview.
 - In `UIViewLazyList`, adding `beginUpdates`/`endUpdates` calls to `insertRows`/`deleteRows`, and wrapping changes in `UIView.performWithoutAnimation` blocks.
-- Fix memory leak in 'protocol-guest' and 'protocol-host' where child nodes beneath a removed node were incorrectly retained in an internal map indefinitely.
+- Fix memory leak in 'protocol-guest' and 'protocol-host' where child nodes beneath a removed node were incorrectly retained in an internal map indefinitely. The guest protocol code has been updated to work around this memory leak when deployed to old hosts by sending individual remove operations for each node in the subtree.
 - Ensure that Zipline services are not closed prematurely when disposing a Treehouse UI.
 - In `UIViewLazyList`, don't remove subviews from hierarchy during `prepareForReuse` call
 

--- a/redwood-protocol-guest/api/android/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/android/redwood-protocol-guest.api
@@ -25,7 +25,7 @@ public final class app/cash/redwood/protocol/guest/ProtocolRedwoodCompositionKt 
 
 public final class app/cash/redwood/protocol/guest/ProtocolState {
 	public static final field $stable I
-	public fun <init> ()V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addWidget (Lapp/cash/redwood/protocol/guest/ProtocolWidget;)V
 	public final fun append (Lapp/cash/redwood/protocol/Change;)V
 	public final fun getChangesOrNull ()Ljava/util/List;
@@ -35,23 +35,23 @@ public final class app/cash/redwood/protocol/guest/ProtocolState {
 }
 
 public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget : app/cash/redwood/widget/Widget {
+	public abstract fun depthFirstWalk (Lkotlin/jvm/functions/Function3;)V
 	public abstract fun getId-0HhLjSo ()I
 	public abstract fun getTag-BlhN7y0 ()I
 	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun getValue ()Lkotlin/Unit;
 	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
-	public abstract fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class app/cash/redwood/protocol/guest/ProtocolWidgetChildren : app/cash/redwood/widget/Widget$Children {
 	public static final field $stable I
 	public synthetic fun <init> (IILapp/cash/redwood/protocol/guest/ProtocolState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun depthFirstWalk (Lapp/cash/redwood/protocol/guest/ProtocolWidget;Lkotlin/jvm/functions/Function3;)V
 	public fun getWidgets ()Ljava/util/List;
 	public fun insert (ILapp/cash/redwood/widget/Widget;)V
 	public fun move (III)V
 	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
 	public fun remove (II)V
-	public final fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class app/cash/redwood/protocol/guest/VersionKt {

--- a/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/jvm/redwood-protocol-guest.api
@@ -25,7 +25,7 @@ public final class app/cash/redwood/protocol/guest/ProtocolRedwoodCompositionKt 
 
 public final class app/cash/redwood/protocol/guest/ProtocolState {
 	public static final field $stable I
-	public fun <init> ()V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addWidget (Lapp/cash/redwood/protocol/guest/ProtocolWidget;)V
 	public final fun append (Lapp/cash/redwood/protocol/Change;)V
 	public final fun getChangesOrNull ()Ljava/util/List;
@@ -35,23 +35,23 @@ public final class app/cash/redwood/protocol/guest/ProtocolState {
 }
 
 public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget : app/cash/redwood/widget/Widget {
+	public abstract fun depthFirstWalk (Lkotlin/jvm/functions/Function3;)V
 	public abstract fun getId-0HhLjSo ()I
 	public abstract fun getTag-BlhN7y0 ()I
 	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun getValue ()Lkotlin/Unit;
 	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
-	public abstract fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class app/cash/redwood/protocol/guest/ProtocolWidgetChildren : app/cash/redwood/widget/Widget$Children {
 	public static final field $stable I
 	public synthetic fun <init> (IILapp/cash/redwood/protocol/guest/ProtocolState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun depthFirstWalk (Lapp/cash/redwood/protocol/guest/ProtocolWidget;Lkotlin/jvm/functions/Function3;)V
 	public fun getWidgets ()Ljava/util/List;
 	public fun insert (ILapp/cash/redwood/widget/Widget;)V
 	public fun move (III)V
 	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
 	public fun remove (II)V
-	public final fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class app/cash/redwood/protocol/guest/VersionKt {

--- a/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
@@ -25,8 +25,8 @@ abstract interface app.cash.redwood.protocol.guest/ProtocolMismatchHandler { // 
     }
 }
 abstract interface app.cash.redwood.protocol.guest/ProtocolWidget : app.cash.redwood.widget/Widget<kotlin/Unit> { // app.cash.redwood.protocol.guest/ProtocolWidget|null[0]
+    abstract fun depthFirstWalk(kotlin/Function3<app.cash.redwood.protocol.guest/ProtocolWidget, app.cash.redwood.protocol/ChildrenTag, app.cash.redwood.protocol.guest/ProtocolWidgetChildren, kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidget.depthFirstWalk|depthFirstWalk(kotlin.Function3<app.cash.redwood.protocol.guest.ProtocolWidget,app.cash.redwood.protocol.ChildrenTag,app.cash.redwood.protocol.guest.ProtocolWidgetChildren,kotlin.Unit>){}[0]
     abstract fun sendEvent(app.cash.redwood.protocol/Event) // app.cash.redwood.protocol.guest/ProtocolWidget.sendEvent|sendEvent(app.cash.redwood.protocol.Event){}[0]
-    abstract fun visitIds(kotlin/Function1<app.cash.redwood.protocol/Id, kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidget.visitIds|visitIds(kotlin.Function1<app.cash.redwood.protocol.Id,kotlin.Unit>){}[0]
     abstract val id // app.cash.redwood.protocol.guest/ProtocolWidget.id|{}id[0]
         abstract fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.guest/ProtocolWidget.id.<get-id>|<get-id>(){}[0]
     abstract val tag // app.cash.redwood.protocol.guest/ProtocolWidget.tag|{}tag[0]
@@ -35,7 +35,7 @@ abstract interface app.cash.redwood.protocol.guest/ProtocolWidget : app.cash.red
         open fun <get-value>() // app.cash.redwood.protocol.guest/ProtocolWidget.value.<get-value>|<get-value>(){}[0]
 }
 final class app.cash.redwood.protocol.guest/ProtocolState { // app.cash.redwood.protocol.guest/ProtocolState|null[0]
-    constructor <init>() // app.cash.redwood.protocol.guest/ProtocolState.<init>|<init>(){}[0]
+    constructor <init>(app.cash.redwood.protocol/RedwoodVersion) // app.cash.redwood.protocol.guest/ProtocolState.<init>|<init>(app.cash.redwood.protocol.RedwoodVersion){}[0]
     final fun addWidget(app.cash.redwood.protocol.guest/ProtocolWidget) // app.cash.redwood.protocol.guest/ProtocolState.addWidget|addWidget(app.cash.redwood.protocol.guest.ProtocolWidget){}[0]
     final fun append(app.cash.redwood.protocol/Change) // app.cash.redwood.protocol.guest/ProtocolState.append|append(app.cash.redwood.protocol.Change){}[0]
     final fun getChangesOrNull(): kotlin.collections/List<app.cash.redwood.protocol/Change>? // app.cash.redwood.protocol.guest/ProtocolState.getChangesOrNull|getChangesOrNull(){}[0]
@@ -45,11 +45,11 @@ final class app.cash.redwood.protocol.guest/ProtocolState { // app.cash.redwood.
 }
 final class app.cash.redwood.protocol.guest/ProtocolWidgetChildren : app.cash.redwood.widget/Widget.Children<kotlin/Unit> { // app.cash.redwood.protocol.guest/ProtocolWidgetChildren|null[0]
     constructor <init>(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, app.cash.redwood.protocol.guest/ProtocolState) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.<init>|<init>(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;app.cash.redwood.protocol.guest.ProtocolState){}[0]
+    final fun depthFirstWalk(app.cash.redwood.protocol.guest/ProtocolWidget, kotlin/Function3<app.cash.redwood.protocol.guest/ProtocolWidget, app.cash.redwood.protocol/ChildrenTag, app.cash.redwood.protocol.guest/ProtocolWidgetChildren, kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.depthFirstWalk|depthFirstWalk(app.cash.redwood.protocol.guest.ProtocolWidget;kotlin.Function3<app.cash.redwood.protocol.guest.ProtocolWidget,app.cash.redwood.protocol.ChildrenTag,app.cash.redwood.protocol.guest.ProtocolWidgetChildren,kotlin.Unit>){}[0]
     final fun insert(kotlin/Int, app.cash.redwood.widget/Widget<kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.insert|insert(kotlin.Int;app.cash.redwood.widget.Widget<kotlin.Unit>){}[0]
     final fun move(kotlin/Int, kotlin/Int, kotlin/Int) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.move|move(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
     final fun onModifierUpdated(kotlin/Int, app.cash.redwood.widget/Widget<kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.onModifierUpdated|onModifierUpdated(kotlin.Int;app.cash.redwood.widget.Widget<kotlin.Unit>){}[0]
     final fun remove(kotlin/Int, kotlin/Int) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.remove|remove(kotlin.Int;kotlin.Int){}[0]
-    final fun visitIds(kotlin/Function1<app.cash.redwood.protocol/Id, kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.visitIds|visitIds(kotlin.Function1<app.cash.redwood.protocol.Id,kotlin.Unit>){}[0]
     final val widgets // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.widgets|{}widgets[0]
         final fun <get-widgets>(): kotlin.collections/List<app.cash.redwood.protocol.guest/ProtocolWidget> // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.widgets.<get-widgets>|<get-widgets>(){}[0]
 }

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolState.kt
@@ -18,13 +18,23 @@ package app.cash.redwood.protocol.guest
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.Id
+import app.cash.redwood.protocol.RedwoodVersion
 
 /** @suppress For generated code use only. */
 @RedwoodCodegenApi
-public class ProtocolState {
+public class ProtocolState(
+  hostVersion: RedwoodVersion,
+) {
   private var nextValue = Id.Root.value + 1
   private val widgets = PlatformMap<Int, ProtocolWidget>()
   private var changes = PlatformList<Change>()
+
+  /**
+   * Host versions prior to 0.10.0 contained a bug where they did not recursively remove widgets
+   * from the protocol map which leaked any child views of a removed node. We can work around this
+   * on the guest side by synthesizing removes for every node in the subtree.
+   */
+  internal val synthesizeSubtreeRemoval = hostVersion < RedwoodVersion("0.10.0-SNAPSHOT")
 
   public fun nextId(): Id {
     val value = nextValue

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.protocol.guest
 
 import app.cash.redwood.RedwoodCodegenApi
+import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.WidgetTag
@@ -36,6 +37,37 @@ public interface ProtocolWidget : Widget<Unit> {
 
   public fun sendEvent(event: Event)
 
-  /** Recursively visit IDs in this widget's tree, starting with this widget's [id]. */
-  public fun visitIds(block: (Id) -> Unit)
+  /**
+   * Perform a depth-first walk of this widget's children hierarchy.
+   *
+   * For example, given the hierarchy:
+   * ```kotlin
+   * Split(
+   *   left = {
+   *     Row {
+   *       Text(..)
+   *       Button(..)
+   *     }
+   *   },
+   *   right = {
+   *     Column {
+   *       Button(..)
+   *       Text(..)
+   *     }
+   *   }
+   * }
+   * ```
+   * You will see the following argument values passed to [block] if invoked on the `Split`:
+   * 1. parent: `Row`, childrenTag: 1, children: `[Text+Button]`
+   * 2. parent: `Split`, childrenTag: 1, children: `[Row]`
+   * 3. parent: `Column`, childrenTag: 1, children: `[Button+Text]`
+   * 4. parent: `Split`, childrenTag: 2, children: `[Column]`
+   */
+  public fun depthFirstWalk(
+    block: (
+      parent: ProtocolWidget,
+      childrenTag: ChildrenTag,
+      children: ProtocolWidgetChildren,
+    ) -> Unit,
+  )
 }

--- a/redwood-protocol/api/redwood-protocol.api
+++ b/redwood-protocol/api/redwood-protocol.api
@@ -77,6 +77,7 @@ public final class app/cash/redwood/protocol/ChildrenChange$Move$Companion {
 
 public final class app/cash/redwood/protocol/ChildrenChange$Remove : app/cash/redwood/protocol/ChildrenChange {
 	public static final field Companion Lapp/cash/redwood/protocol/ChildrenChange$Remove$Companion;
+	public synthetic fun <init> (IIIILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (IIIILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCount ()I

--- a/redwood-protocol/api/redwood-protocol.klib.api
+++ b/redwood-protocol/api/redwood-protocol.klib.api
@@ -322,7 +322,7 @@ sealed interface app.cash.redwood.protocol/ChildrenChange : app.cash.redwood.pro
             final fun <get-toIndex>(): kotlin/Int // app.cash.redwood.protocol/ChildrenChange.Move.toIndex.<get-toIndex>|<get-toIndex>(){}[0]
     }
     final class Remove : app.cash.redwood.protocol/ChildrenChange { // app.cash.redwood.protocol/ChildrenChange.Remove|null[0]
-        constructor <init>(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, kotlin/Int, kotlin.collections/List<app.cash.redwood.protocol/Id>) // app.cash.redwood.protocol/ChildrenChange.Remove.<init>|<init>(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;kotlin.Int;kotlin.collections.List<app.cash.redwood.protocol.Id>){}[0]
+        constructor <init>(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, kotlin/Int, kotlin.collections/List<app.cash.redwood.protocol/Id> =...) // app.cash.redwood.protocol/ChildrenChange.Remove.<init>|<init>(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;kotlin.Int;kotlin.collections.List<app.cash.redwood.protocol.Id>){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // app.cash.redwood.protocol/ChildrenChange.Remove.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // app.cash.redwood.protocol/ChildrenChange.Remove.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // app.cash.redwood.protocol/ChildrenChange.Remove.toString|toString(){}[0]

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.protocol
 
 import dev.drewhamilton.poko.Poko
+import kotlin.DeprecationLevel.ERROR
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -151,12 +152,8 @@ public sealed interface ChildrenChange : Change {
     override val tag: ChildrenTag,
     public val index: Int,
     public val count: Int,
-    public val removedIds: List<Id>,
-  ) : ChildrenChange {
-    init {
-      require(count == removedIds.size) {
-        "Count $count != Removed ID list size ${removedIds.size}"
-      }
-    }
-  }
+    // TODO Remove this for Redwood 1.0.0.
+    @Deprecated("Only sent for compatibility with old hosts. Do not consume.", level = ERROR)
+    public val removedIds: List<Id> = emptyList(),
+  ) : ChildrenChange
 }

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
@@ -57,6 +57,8 @@ class ProtocolTest {
       Create(Id(1), WidgetTag(2)),
       ChildrenChange.Add(Id(1), ChildrenTag(2), Id(3), 4),
       ChildrenChange.Move(Id(1), ChildrenTag(2), 3, 4, 5),
+      ChildrenChange.Remove(Id(4), ChildrenTag(3), 2, 1),
+      // We send a list of removed IDs only for old hosts.
       ChildrenChange.Remove(Id(1), ChildrenTag(2), 3, 4, listOf(Id(5), Id(6), Id(7), Id(8))),
       ModifierChange(
         Id(1),
@@ -90,19 +92,13 @@ class ProtocolTest {
       """["create",{"id":1,"tag":2}],""" +
       """["add",{"id":1,"tag":2,"childId":3,"index":4}],""" +
       """["move",{"id":1,"tag":2,"fromIndex":3,"toIndex":4,"count":5}],""" +
+      """["remove",{"id":4,"tag":3,"index":2,"count":1}],""" +
       """["remove",{"id":1,"tag":2,"index":3,"count":4,"removedIds":[5,6,7,8]}],""" +
       """["modifier",{"id":1,"elements":[[1,{}],[2,3],[3,[]],[4],[5]]}],""" +
       """["property",{"id":1,"tag":2,"value":"hello"}],""" +
       """["property",{"id":1,"tag":2}]""" +
       "]"
     assertJsonRoundtrip(ListSerializer(Change.serializer()), changes, json)
-  }
-
-  @Test fun removeCountMustMatchListSize() {
-    val t = assertFailsWith<IllegalArgumentException> {
-      ChildrenChange.Remove(Id(1), ChildrenTag(2), 3, 4, listOf(Id(5), Id(6), Id(7)))
-    }
-    assertThat(t).hasMessage("Count 4 != Removed ID list size 3")
   }
 
   @Test fun modifierElementSerialization() {


### PR DESCRIPTION
This works around a since-fixed memory leak.

Fixing #1900 for old hosts via #1901.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
