### PR TITLE
Expose guest Redwood version to host

### DIFF
--- a/redwood-treehouse-guest/api/android/redwood-treehouse-guest.api
+++ b/redwood-treehouse-guest/api/android/redwood-treehouse-guest.api
@@ -2,6 +2,7 @@ public final class app/cash/redwood/treehouse/StandardAppLifecycle : app/cash/re
 	public synthetic fun <init> (Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public final fun getFrameClock ()Landroidx/compose/runtime/MonotonicFrameClock;
+	public fun getGuestProtocolVersion-7jYel6c ()Ljava/lang/String;
 	public fun sendFrame (J)V
 	public fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
 }

--- a/redwood-treehouse-guest/api/jvm/redwood-treehouse-guest.api
+++ b/redwood-treehouse-guest/api/jvm/redwood-treehouse-guest.api
@@ -2,6 +2,7 @@ public final class app/cash/redwood/treehouse/StandardAppLifecycle : app/cash/re
 	public synthetic fun <init> (Lapp/cash/redwood/protocol/guest/ProtocolBridge$Factory;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public final fun getFrameClock ()Landroidx/compose/runtime/MonotonicFrameClock;
+	public fun getGuestProtocolVersion-7jYel6c ()Ljava/lang/String;
 	public fun sendFrame (J)V
 	public fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
 }

--- a/redwood-treehouse-guest/api/redwood-treehouse-guest.klib.api
+++ b/redwood-treehouse-guest/api/redwood-treehouse-guest.klib.api
@@ -12,5 +12,7 @@ final class app.cash.redwood.treehouse/StandardAppLifecycle : app.cash.redwood.t
     final fun start(app.cash.redwood.treehouse/AppLifecycle.Host) // app.cash.redwood.treehouse/StandardAppLifecycle.start|start(app.cash.redwood.treehouse.AppLifecycle.Host){}[0]
     final val frameClock // app.cash.redwood.treehouse/StandardAppLifecycle.frameClock|{}frameClock[0]
         final fun <get-frameClock>(): androidx.compose.runtime/MonotonicFrameClock // app.cash.redwood.treehouse/StandardAppLifecycle.frameClock.<get-frameClock>|<get-frameClock>(){}[0]
+    final val guestProtocolVersion // app.cash.redwood.treehouse/StandardAppLifecycle.guestProtocolVersion|{}guestProtocolVersion[0]
+        final fun <get-guestProtocolVersion>(): app.cash.redwood.protocol/RedwoodVersion // app.cash.redwood.treehouse/StandardAppLifecycle.guestProtocolVersion.<get-guestProtocolVersion>|<get-guestProtocolVersion>(){}[0]
 }
 final fun (app.cash.redwood.treehouse/TreehouseUi).app.cash.redwood.treehouse/asZiplineTreehouseUi(app.cash.redwood.treehouse/StandardAppLifecycle): app.cash.redwood.treehouse/ZiplineTreehouseUi // app.cash.redwood.treehouse/asZiplineTreehouseUi|asZiplineTreehouseUi@app.cash.redwood.treehouse.TreehouseUi(app.cash.redwood.treehouse.StandardAppLifecycle){}[0]

--- a/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/StandardAppLifecycle.kt
+++ b/redwood-treehouse-guest/src/commonMain/kotlin/app/cash/redwood/treehouse/StandardAppLifecycle.kt
@@ -23,6 +23,7 @@ import app.cash.redwood.protocol.RedwoodVersion
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.protocol.guest.ProtocolBridge
 import app.cash.redwood.protocol.guest.ProtocolMismatchHandler
+import app.cash.redwood.protocol.guest.guestRedwoodVersion
 import app.cash.redwood.treehouse.AppLifecycle.Host
 import app.cash.zipline.ZiplineApiMismatchException
 import kotlin.coroutines.CoroutineContext
@@ -37,6 +38,9 @@ public class StandardAppLifecycle(
 ) : AppLifecycle {
   private var started = false
   private lateinit var host: Host
+
+  override val guestProtocolVersion: RedwoodVersion
+    get() = guestRedwoodVersion
 
   internal val hostProtocolVersion: RedwoodVersion get() {
     return try {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.RedwoodVersion
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -54,6 +55,8 @@ internal abstract class CodeSession<A : AppService>(
   }
 
   abstract val json: Json
+
+  abstract val guestProtocolVersion: RedwoodVersion
 
   fun start() {
     dispatchers.checkUi()

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
@@ -15,7 +15,9 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.RedwoodVersion
 import app.cash.zipline.Zipline
+import app.cash.zipline.ZiplineApiMismatchException
 import app.cash.zipline.ZiplineScope
 import app.cash.zipline.withScope
 import kotlinx.coroutines.CoroutineScope
@@ -35,12 +37,22 @@ internal class ZiplineCodeSession<A : AppService>(
   appService = appService,
 ) {
   private val ziplineScope = ZiplineScope()
+  private lateinit var appLifecycle: AppLifecycle
 
   override val json: Json
     get() = zipline.json
 
+  override val guestProtocolVersion: RedwoodVersion
+    get() {
+      return try {
+        appLifecycle.guestProtocolVersion
+      } catch (_: ZiplineApiMismatchException) {
+        RedwoodVersion.Unknown
+      }
+    }
+
   override fun ziplineStart() {
-    val appLifecycle = appService.withScope(ziplineScope).appLifecycle
+    appLifecycle = appService.withScope(ziplineScope).appLifecycle
 
     val host = RealAppLifecycleHost(
       appLifecycle = appLifecycle,

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/AbstractFrameClockTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/AbstractFrameClockTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.RedwoodVersion
 import app.cash.redwood.treehouse.AppLifecycle.Host
 import assertk.all
 import assertk.assertThat
@@ -42,6 +43,7 @@ abstract class AbstractFrameClockTest {
 
     val frameTimes = Channel<Long>(Channel.UNLIMITED)
     val appLifecycle = object : AppLifecycle {
+      override val guestProtocolVersion get() = RedwoodVersion.Unknown
       override fun start(host: Host) {
       }
       override fun sendFrame(timeNanos: Long) {

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeAppService.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeAppService.kt
@@ -15,6 +15,9 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.RedwoodVersion
+import app.cash.redwood.protocol.host.hostRedwoodVersion
+
 internal class FakeAppService private constructor(
   private val name: String,
   private val eventLog: EventLog,
@@ -26,6 +29,10 @@ internal class FakeAppService private constructor(
     get() = mutableUis.toList()
 
   override val appLifecycle = object : AppLifecycle {
+    override val guestProtocolVersion: RedwoodVersion
+      // Use latest host version as the guest version to avoid any compatibility behavior.
+      get() = hostRedwoodVersion
+
     override fun start(host: AppLifecycle.Host) {
       eventLog += "$name.appLifecycle.start()"
     }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
@@ -15,6 +15,8 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.protocol.RedwoodVersion
+import app.cash.redwood.protocol.host.hostRedwoodVersion
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
 
@@ -32,6 +34,10 @@ internal class FakeCodeSession(
 ) {
   override val json: Json
     get() = Json
+
+  override val guestProtocolVersion: RedwoodVersion
+    // Use latest host version as the guest version to avoid any compatibility behavior.
+    get() = hostRedwoodVersion
 
   override fun ziplineStart() {
     eventLog += "$name.start()"

--- a/redwood-treehouse/api/android/redwood-treehouse.api
+++ b/redwood-treehouse/api/android/redwood-treehouse.api
@@ -1,5 +1,6 @@
 public abstract interface class app/cash/redwood/treehouse/AppLifecycle : app/cash/zipline/ZiplineService {
 	public static final field Companion Lapp/cash/redwood/treehouse/AppLifecycle$Companion;
+	public abstract fun getGuestProtocolVersion-7jYel6c ()Ljava/lang/String;
 	public abstract fun sendFrame (J)V
 	public abstract fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
 }

--- a/redwood-treehouse/api/jvm/redwood-treehouse.api
+++ b/redwood-treehouse/api/jvm/redwood-treehouse.api
@@ -1,5 +1,6 @@
 public abstract interface class app/cash/redwood/treehouse/AppLifecycle : app/cash/zipline/ZiplineService {
 	public static final field Companion Lapp/cash/redwood/treehouse/AppLifecycle$Companion;
+	public abstract fun getGuestProtocolVersion-7jYel6c ()Ljava/lang/String;
 	public abstract fun sendFrame (J)V
 	public abstract fun start (Lapp/cash/redwood/treehouse/AppLifecycle$Host;)V
 }

--- a/redwood-treehouse/api/redwood-treehouse.klib.api
+++ b/redwood-treehouse/api/redwood-treehouse.klib.api
@@ -18,6 +18,8 @@ abstract interface app.cash.redwood.treehouse/AppLifecycle : app.cash.zipline/Zi
             abstract fun <get-hostProtocolVersion>(): app.cash.redwood.protocol/RedwoodVersion // app.cash.redwood.treehouse/AppLifecycle.Host.hostProtocolVersion.<get-hostProtocolVersion>|<get-hostProtocolVersion>(){}[0]
         final object Companion // app.cash.redwood.treehouse/AppLifecycle.Host.Companion|null[0]
     }
+    abstract val guestProtocolVersion // app.cash.redwood.treehouse/AppLifecycle.guestProtocolVersion|{}guestProtocolVersion[0]
+        abstract fun <get-guestProtocolVersion>(): app.cash.redwood.protocol/RedwoodVersion // app.cash.redwood.treehouse/AppLifecycle.guestProtocolVersion.<get-guestProtocolVersion>|<get-guestProtocolVersion>(){}[0]
     final object Companion // app.cash.redwood.treehouse/AppLifecycle.Companion|null[0]
 }
 abstract interface app.cash.redwood.treehouse/AppService : app.cash.zipline/ZiplineService { // app.cash.redwood.treehouse/AppService|null[0]

--- a/redwood-treehouse/api/zipline-api.toml
+++ b/redwood-treehouse/api/zipline-api.toml
@@ -9,6 +9,9 @@ functions = [
 
   # fun start(app.cash.redwood.treehouse.AppLifecycle.Host): kotlin.Unit
   "Xd61ecfL",
+
+  # val guestProtocolVersion: app.cash.redwood.protocol.RedwoodVersion
+  "0iFPbldz",
 ]
 
 [app.cash.redwood.treehouse.AppLifecycle.Host]

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/AppLifecycle.kt
@@ -25,6 +25,13 @@ import kotlinx.serialization.Contextual
 
 @ObjCName("AppLifecycle", exact = true)
 public interface AppLifecycle : ZiplineService {
+  /**
+   * The Redwood version of the guest.
+   * This may be used to alter the behavior to work around bugs discovered in the future, and to
+   * ensure the serialized protocol remains compatible with what the guest expects.
+   */
+  public val guestProtocolVersion: RedwoodVersion
+
   public fun start(host: Host)
 
   public fun sendFrame(timeNanos: @Contextual Long)
@@ -34,7 +41,7 @@ public interface AppLifecycle : ZiplineService {
     /**
      * The Redwood version of the host.
      * This may be used to alter the behavior to work around bugs discovered in the future, and to
-     * ensure the serialized protocol is remains compatible with what the host expects.
+     * ensure the serialized protocol remains compatible with what the host expects.
      */
     public val hostProtocolVersion: RedwoodVersion
 


### PR DESCRIPTION
In order to ensure the guest is fully setup such that we can query this, we have to defer creating the host-side bridge until we have received some changes.

Closes #1901

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
