### PR TITLE
Do not query guest version from UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 
 Fixed:
 - Work around a problem with our memory-leak fix where our old LazyList code would crash when its placeholders were unexpectedly removed.
+- Avoid calling into the internal Zipline instance from the UI thread on startup. This would manifest as weird native crashes due to multiple threads mutating shared memory.
 
 
 ## [0.10.0] - 2024-04-05


### PR DESCRIPTION
I'm not sure how I ended up committing the previous version as I specifically was making changes specifically to avoid this, but I did. Instead, read the version once on startup when the app lifecycle is first bound and cache its value for later access on the UI thread.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
