### PR TITLE
When performing a programmatic scroll-to-top in UIViewLazyList, alert the LazyListScrollProcessor so that it can update its viewport early

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -76,6 +76,7 @@ internal open class UIViewLazyList() : LazyList<UIView>, ChangeListener {
       // assume that it's a programmatic scroll-to-top call.
       if (contentOffset.useContents { y } == 0.0 && this.contentOffset.useContents { y } != 0.0) {
         isDoingProgrammaticScroll = true
+        scrollProcessor.onScrollToTop()
       }
       super.setContentOffset(contentOffset, animated)
     }
@@ -197,10 +198,6 @@ internal open class UIViewLazyList() : LazyList<UIView>, ChangeListener {
       }
 
       override fun scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {
-        isDoingProgrammaticScroll = false
-      }
-
-      override fun scrollViewDidScrollToTop(scrollView: UIScrollView) {
         isDoingProgrammaticScroll = false
       }
     }

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -16,6 +16,7 @@ public abstract class app/cash/redwood/lazylayout/widget/LazyListScrollProcessor
 	public fun <init> ()V
 	public abstract fun contentSize ()I
 	public final fun onEndChanges ()V
+	public final fun onScrollToTop ()V
 	public final fun onUserScroll (II)V
 	public final fun onViewportChanged (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun programmaticScroll (IZ)V

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -38,6 +38,7 @@ abstract class app.cash.redwood.lazylayout.widget/LazyListScrollProcessor { // a
     abstract fun programmaticScroll(kotlin/Int, kotlin/Boolean) // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.programmaticScroll|programmaticScroll(kotlin.Int;kotlin.Boolean){}[0]
     constructor <init>() // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.<init>|<init>(){}[0]
     final fun onEndChanges() // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.onEndChanges|onEndChanges(){}[0]
+    final fun onScrollToTop() // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.onScrollToTop|onScrollToTop(){}[0]
     final fun onUserScroll(kotlin/Int, kotlin/Int) // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.onUserScroll|onUserScroll(kotlin.Int;kotlin.Int){}[0]
     final fun onViewportChanged(kotlin/Function2<kotlin/Int, kotlin/Int, kotlin/Unit>) // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.onViewportChanged|onViewportChanged(kotlin.Function2<kotlin.Int,kotlin.Int,kotlin.Unit>){}[0]
     final fun scrollItemIndex(app.cash.redwood.lazylayout.api/ScrollItemIndex) // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.scrollItemIndex|scrollItemIndex(app.cash.redwood.lazylayout.api.ScrollItemIndex){}[0]

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessor.kt
@@ -65,6 +65,18 @@ public abstract class LazyListScrollProcessor {
     onViewportChanged?.invoke(firstIndex, lastIndex)
   }
 
+  /**
+   * Reacts to a scroll-to-top being initiated.
+   */
+  public fun onScrollToTop() {
+    if (this.mostRecentFirstIndex == 0) return // Already at the top.
+    if (this.mostRecentLastIndex == -1) return // Never scrolled. Ignore.
+
+    // This assumes that (mostRecentLastIndex - mostRecentFirstIndex + 1) rows
+    // will be visible after the scroll-to-top completes.
+    onUserScroll(0, mostRecentLastIndex - mostRecentFirstIndex)
+  }
+
   /** Returns the number of items we're scrolling over. */
   public abstract fun contentSize(): Int
 

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessorTest.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListScrollProcessorTest.kt
@@ -102,4 +102,17 @@ class LazyListScrollProcessorTest {
     processor.onUserScroll(6, 15)
     assertThat(processor.takeEvents()).containsExactly("userScroll(6, 15)")
   }
+
+  @Test
+  fun onScrollToTop() {
+    processor.size = 30
+
+    // Do a user scroll.
+    processor.onUserScroll(5, 14)
+    assertThat(processor.takeEvents()).containsExactly("userScroll(5, 14)")
+
+    // Alert the processor that a scroll-to-top is happening.
+    processor.onScrollToTop()
+    assertThat(processor.takeEvents()).containsExactly("userScroll(0, 9)")
+  }
 }


### PR DESCRIPTION
Follow-up to PR #1944
