### PR TITLE
Zipline 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Fixed:
 - Work around a problem with our memory-leak fix where our old LazyList code would crash when its placeholders were unexpectedly removed.
 - Avoid calling into the internal Zipline instance from the UI thread on startup. This would manifest as weird native crashes due to multiple threads mutating shared memory.
 
+Upgraded:
+- Zipline 1.9.0.
+
 
 ## [0.10.0] - 2024-04-05
 [0.10.0]: https://github.com/cashapp/redwood/releases/tag/0.10.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-activity = "1.8.2"
 androidx-compose-ui = "1.6.5"
 jbCompose = "1.6.2"
 lint = "31.3.2"
-zipline = "1.8.0"
+zipline = "1.9.0"
 coil = "3.0.0-alpha06"
 okio = "3.9.0"
 


### PR DESCRIPTION
- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
