### PR TITLE
Be more defensive accepting potentially-recycled views

### DIFF
--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -282,6 +282,9 @@ internal open class ViewLazyList private constructor(
 
         val view = value?.value
         if (view != null) {
+          require(view.parent == null) {
+            "Received $view with unexpected parent ${view.parent}; modifier=${content?.modifier}"
+          }
           view.layoutParams = createLayoutParams()
           container.addView(view)
         }

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeUpdateProcessor.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.lazylayout.widget
 
+import app.cash.redwood.Modifier
 import app.cash.redwood.widget.Widget
 
 /**
@@ -110,6 +111,18 @@ class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCe
   }
 
   override fun setContent(view: StringCell, content: Widget<String>?) {
+    content as StringWidget?
+
+    // It is an error for `content` to already have a parent cell.
+    val previous = view.content as StringWidget?
+    require(content?.parentCell == null)
+    if (previous != null) {
+      previous.parentCell = null
+    }
+    if (content != null) {
+      content.parentCell = view
+    }
+
     view.version++
     view.content = content
   }
@@ -169,5 +182,12 @@ class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCe
   ) {
     var version = 0
     var content: Widget<String>? = null
+  }
+
+  class StringWidget(
+    override var value: String,
+  ) : Widget<String> {
+    internal var parentCell: StringCell? = null
+    override var modifier: Modifier = Modifier
   }
 }

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
@@ -15,8 +15,7 @@
  */
 package app.cash.redwood.lazylayout.widget
 
-import app.cash.redwood.Modifier
-import app.cash.redwood.widget.Widget
+import app.cash.redwood.lazylayout.widget.FakeUpdateProcessor.StringWidget
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
@@ -527,11 +526,5 @@ class LazyListUpdateProcessorTest {
     processor.onEndChanges()
 
     assertThat(processor.toString()).isEqualTo("[8...] Iv2 Jv2 Kv2")
-  }
-
-  class StringWidget(
-    override var value: String,
-  ) : Widget<String> {
-    override var modifier: Modifier = Modifier
   }
 }


### PR DESCRIPTION
We've seen a couple crashes because the newly-added views' parent views are non-null.
