### PR TITLE
Don't crash when loaded rows are removed.

### DIFF
--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -282,6 +282,9 @@ internal open class ViewLazyList private constructor(
 
         val view = value?.value
         if (view != null) {
+          require(view.parent == null) {
+            "Received $view with unexpected parent ${view.parent}; modifier=${content?.modifier}"
+          }
           view.layoutParams = createLayoutParams()
           container.addView(view)
         }

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
@@ -237,7 +237,8 @@ public abstract class LazyListUpdateProcessor<V : Any, W : Any> {
         is Edit.Remove -> {
           for (i in edit.index until edit.index + edit.count) {
             val index = itemsBefore.size + edit.index
-            loadedItems.removeAt(edit.index)
+            val removed = loadedItems.removeAt(edit.index)
+            removed.unbind()
 
             // Publish a structural change.
             deleteRows(index, 1)

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeUpdateProcessor.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.lazylayout.widget
 
+import app.cash.redwood.Modifier
 import app.cash.redwood.widget.Widget
 
 /**
@@ -95,7 +96,8 @@ class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCe
         scrollWindowOffset--
       } else if (index < scrollWindowLimit) {
         // Delete a cell from the scroll window. We'll replenish the window below.
-        scrollWindowCells.removeAt(index - scrollWindowOffset).binding.unbind()
+        val removed = scrollWindowCells.removeAt(index - scrollWindowOffset)
+        require(!removed.binding.isPlaceholder && removed.content == null)
       }
     }
 
@@ -110,6 +112,18 @@ class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCe
   }
 
   override fun setContent(view: StringCell, content: Widget<String>?) {
+    content as StringWidget?
+
+    // It is an error for `content` to already have a parent cell.
+    val previous = view.content as StringWidget?
+    require(content?.parentCell == null)
+    if (previous != null) {
+      previous.parentCell = null
+    }
+    if (content != null) {
+      content.parentCell = view
+    }
+
     view.version++
     view.content = content
   }
@@ -169,5 +183,12 @@ class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCe
   ) {
     var version = 0
     var content: Widget<String>? = null
+  }
+
+  class StringWidget(
+    override var value: String,
+  ) : Widget<String> {
+    internal var parentCell: StringCell? = null
+    override var modifier: Modifier = Modifier
   }
 }

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
@@ -15,8 +15,7 @@
  */
 package app.cash.redwood.lazylayout.widget
 
-import app.cash.redwood.Modifier
-import app.cash.redwood.widget.Widget
+import app.cash.redwood.lazylayout.widget.FakeUpdateProcessor.StringWidget
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
@@ -529,9 +528,39 @@ class LazyListUpdateProcessorTest {
     assertThat(processor.toString()).isEqualTo("[8...] Iv2 Jv2 Kv2")
   }
 
-  class StringWidget(
-    override var value: String,
-  ) : Widget<String> {
-    override var modifier: Modifier = Modifier
+  @Test
+  fun removeMiddleLoadedItemThatIsBound() {
+    processor.itemsBefore(8)
+    processor.itemsAfter(8)
+    processor.items.insert(0, StringWidget("I"))
+    processor.items.insert(1, StringWidget("J"))
+    processor.items.insert(2, StringWidget("K"))
+    processor.items.insert(3, StringWidget("L"))
+    processor.onEndChanges()
+
+    processor.scrollTo(6, 8)
+    assertThat(processor.toString()).isEqualTo("[6...] . . I J K L . . [...6]")
+
+    processor.items.remove(2, 1) // 'K'.
+    processor.onEndChanges()
+    assertThat(processor.toString()).isEqualTo("[6...] . . I J L . . . [...5]")
+  }
+
+  @Test
+  fun removeMiddleLoadedItemThatIsNotBound() {
+    processor.itemsBefore(8)
+    processor.itemsAfter(8)
+    processor.items.insert(0, StringWidget("I"))
+    processor.items.insert(1, StringWidget("J"))
+    processor.items.insert(2, StringWidget("K"))
+    processor.items.insert(3, StringWidget("L"))
+    processor.onEndChanges()
+
+    processor.scrollTo(2, 4)
+    assertThat(processor.toString()).isEqualTo("[2...] . . . . [...14]")
+
+    processor.items.remove(2, 1) // 'K'.
+    processor.onEndChanges()
+    assertThat(processor.toString()).isEqualTo("[2...] . . . . [...13]")
   }
 }


### PR DESCRIPTION
We had a bug where we asynchronously detached a LazyList item from its parent, but synchronously recycled it. We didn't see this occur in practice very much because the bug only triggered when the removed row was in the middle of the loaded range. Rows at the top or bottom of the loaded range were synchronously turned into placeholders when they are removed from the loaded range.

One tough limitation of this approach is the removed items lose their content immediately, which may interfere with delete animations. This isn't an urgent problem for us but it suggests that we should explore an API to put items into the pool asynchronously and not the moment they're logically removed.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
