### PR TITLE
In UIViewLazyList, fix UInt to UIColor conversion math used for pullRefreshContentColor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changed:
 Fixed:
 - Work around a problem with our memory-leak fix where our old LazyList code would crash when its placeholders were unexpectedly removed.
 - Avoid calling into the internal Zipline instance from the UI thread on startup. This would manifest as weird native crashes due to multiple threads mutating shared memory.
+- In `UIViewLazyList`, fix `UInt` to `UIColor` conversion math used for  `pullRefreshContentColor`.
 
 Upgraded:
 - Zipline 1.9.0.

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -375,8 +375,8 @@ internal class UIViewRefreshableLazyList : UIViewLazyList(), RefreshableLazyList
 }
 
 private fun UIColor(color: UInt): UIColor = UIColor(
-  alpha = ((color and 0xFF000000u) shr 24).toDouble(),
-  red = ((color and 0x00FF0000u) shr 16).toDouble(),
-  green = ((color and 0x0000FF00u) shr 8).toDouble(),
-  blue = (color and 0x000000FFu).toDouble(),
+  alpha = ((color and 0xFF000000u) shr 24).toDouble() / 255.0,
+  red = ((color and 0x00FF0000u) shr 16).toDouble() / 255.0,
+  green = ((color and 0x0000FF00u) shr 8).toDouble() / 255.0,
+  blue = (color and 0x000000FFu).toDouble() / 255.0,
 )


### PR DESCRIPTION
Previously, almost all ARGB values would result in a white UIColor, since all RGB values above 1.0 were being interpreted as 1.0.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
