### PR TITLE
Remove view from intermediate container after snapshot

### DIFF
--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewBoxTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewBoxTest.kt
@@ -68,5 +68,6 @@ class ViewBoxTest(
     }
     container.addView(value)
     paparazzi.snapshot(container)
+    container.removeView(value)
   }
 }


### PR DESCRIPTION
Otherwise you cannot snapshot twice.

For #1877

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
