### PR TITLE
In YogaUIView's layoutNodes method, return early for nested YogaUIViews to prevent redundant frame calculations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Fixed:
 - Avoid calling into the internal Zipline instance from the UI thread on startup. This would manifest as weird native crashes due to multiple threads mutating shared memory.
 - In `UIViewLazyList`, fix `UInt` to `UIColor` conversion math used for  `pullRefreshContentColor`.
 - In `YogaUIView`'s `setScrollEnabled` method, only call `setNeedsLayout` if the `scrollEnabled` value is actually changing.
+- In `YogaUIView`'s `layoutNodes` method, return early for nested `YogaUIView`s to prevent redundant frame calculations.
 
 Upgraded:
 - Zipline 1.9.0.

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -90,6 +90,13 @@ internal class YogaUIView(
     val height = node.height.toDouble()
     node.view.setFrame(CGRectMake(x, y, width, height))
 
+    if (node.view is YogaUIView) {
+      // Optimization: for a YogaUIView nested within another YogaUIView,
+      // there's no need to call layoutNodes for its children here,
+      // as it will happen within its own layoutSubviews() pass.
+      return
+    }
+
     for (childNode in node.children) {
       layoutNodes(childNode)
     }


### PR DESCRIPTION
Follow-up to PR #1996

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
