### PR TITLE
Reenable the debug build type for libraries.

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -190,12 +190,6 @@ class RedwoodBuildPlugin : Plugin<Project> {
         // Keep native symbols for diagnosing sample application crashes.
         doNotStrip("**/*.so")
       }
-      android.buildTypes.apply {
-        // Libraries don't build debug so fall back to release.
-        getByName("debug") {
-          it.matchingFallbacks += "release"
-        }
-      }
       val androidComponents = extensions.getByType(AndroidComponentsExtension::class.java)
       androidComponents.beforeVariants {
         // Disable the release build type for sample applications because we never need it.

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -184,16 +184,6 @@ class RedwoodBuildPlugin : Plugin<Project> {
       }
     }
 
-    plugins.withId("com.android.library") {
-      val androidComponents = extensions.getByType(AndroidComponentsExtension::class.java)
-      androidComponents.beforeVariants {
-        // Disable the debug build type for libraries because we only publish release.
-        if (it.buildType == "debug") {
-          it.enable = false
-        }
-      }
-    }
-
     plugins.withId("com.android.application") {
       val android = extensions.getByName("android") as BaseExtension
       android.packagingOptions.apply {


### PR DESCRIPTION
Looking for feedback on this. We need the `debug` build type for use with `includeBuild`.

I explored only enabling `debug` if redwood is used as part of `includeBuild` in another repo, but couldn't find an easy way (the projects maintain separate properties maps).