### PR TITLE
Hold views instead of widgets in LazyListUpdateProcessor

### DIFF
--- a/redwood-lazylayout-dom/src/commonMain/kotlin/app/cash/redwood/lazylayout/dom/HTMLLazyList.kt
+++ b/redwood-lazylayout-dom/src/commonMain/kotlin/app/cash/redwood/lazylayout/dom/HTMLLazyList.kt
@@ -45,9 +45,9 @@ internal open class HTMLLazyList(document: Document) : LazyList<HTMLElement> {
     override fun deleteRows(index: Int, count: Int) {
     }
 
-    override fun setContent(view: HTMLElement, content: Widget<HTMLElement>?) {
+    override fun setContent(view: HTMLElement, content: HTMLElement?, modifier: Modifier) {
       if (content != null) {
-        view.appendChild(content.value)
+        view.appendChild(content)
       }
     }
   }

--- a/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
+++ b/redwood-lazylayout-view/src/main/kotlin/app/cash/redwood/lazylayout/view/ViewLazyList.kt
@@ -17,6 +17,7 @@
 
 package app.cash.redwood.lazylayout.view
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.Gravity
 import android.view.View
@@ -72,13 +73,11 @@ internal open class ViewLazyList private constructor(
   override val value: View get() = recyclerView
 
   private val processor = object : LazyListUpdateProcessor<ViewHolder, View>() {
-    override fun createPlaceholder(original: View): View {
-      return object : View(value.context) {
-        override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-          setMeasuredDimension(original.width, original.height)
-        }
-      }
-    }
+    override fun createPlaceholder(original: View) =
+      SizeOnlyPlaceholder(original, value.context)
+
+    override fun isSizeOnlyPlaceholder(placeholder: View) =
+      placeholder is SizeOnlyPlaceholder
 
     override fun insertRows(index: Int, count: Int) {
       adapter.notifyItemRangeInserted(index, count)
@@ -88,7 +87,7 @@ internal open class ViewLazyList private constructor(
       adapter.notifyItemRangeRemoved(index, count)
     }
 
-    override fun setContent(view: ViewHolder, content: Widget<View>?) {
+    override fun setContent(view: ViewHolder, content: View?, modifier: Modifier) {
       view.content = content
     }
   }
@@ -182,7 +181,7 @@ internal open class ViewLazyList private constructor(
     // Layout params are invalid when crossAxisAlignment changes.
     for (binding in processor.bindings) {
       val view = binding.view ?: continue
-      view.content?.value?.layoutParams = createLayoutParams()
+      view.content?.layoutParams = createLayoutParams()
     }
   }
 
@@ -275,18 +274,17 @@ internal open class ViewLazyList private constructor(
   ) : RecyclerView.ViewHolder(container) {
     var binding: Binding<ViewHolder, View>? = null
 
-    var content: Widget<View>? = null
+    var content: View? = null
       set(value) {
         field = value
         container.removeAllViews()
 
-        val view = value?.value
-        if (view != null) {
-          require(view.parent == null) {
-            "Received $view with unexpected parent ${view.parent}; modifier=${content?.modifier}"
+        if (value != null) {
+          require(value.parent == null) {
+            "Received $value with unexpected parent ${value.parent}"
           }
-          view.layoutParams = createLayoutParams()
-          container.addView(view)
+          value.layoutParams = createLayoutParams()
+          container.addView(value)
         }
       }
   }
@@ -319,5 +317,15 @@ internal class ViewRefreshableLazyList(
 
   override fun pullRefreshContentColor(@ColorInt pullRefreshContentColor: UInt) {
     swipeRefreshLayout.setColorSchemeColors(pullRefreshContentColor.toInt())
+  }
+}
+
+@SuppressLint("ViewConstructor")
+private class SizeOnlyPlaceholder(
+  private val original: View,
+  context: Context,
+) : View(context) {
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    setMeasuredDimension(original.width, original.height)
   }
 }

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -34,10 +34,11 @@ public abstract class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor
 	public final fun getPlaceholder ()Lapp/cash/redwood/widget/Widget$Children;
 	public final fun getSize ()I
 	protected abstract fun insertRows (II)V
+	protected fun isSizeOnlyPlaceholder (Ljava/lang/Object;)Z
 	public final fun itemsAfter (I)V
 	public final fun itemsBefore (I)V
 	public final fun onEndChanges ()V
-	protected abstract fun setContent (Ljava/lang/Object;Lapp/cash/redwood/widget/Widget;)V
+	protected abstract fun setContent (Ljava/lang/Object;Ljava/lang/Object;Lapp/cash/redwood/Modifier;)V
 }
 
 public final class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Binding {

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -9,7 +9,7 @@
 abstract class <#A: kotlin/Any, #B: kotlin/Any> app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor { // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor|null[0]
     abstract fun deleteRows(kotlin/Int, kotlin/Int) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.deleteRows|deleteRows(kotlin.Int;kotlin.Int){}[0]
     abstract fun insertRows(kotlin/Int, kotlin/Int) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.insertRows|insertRows(kotlin.Int;kotlin.Int){}[0]
-    abstract fun setContent(#A, app.cash.redwood.widget/Widget<#B>?) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.setContent|setContent(1:0;app.cash.redwood.widget.Widget<1:1>?){}[0]
+    abstract fun setContent(#A, #B?, app.cash.redwood/Modifier) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.setContent|setContent(1:0;1:1?;app.cash.redwood.Modifier){}[0]
     constructor <init>() // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.<init>|<init>(){}[0]
     final class <#A1: kotlin/Any, #B1: kotlin/Any> Binding { // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding|null[0]
         final fun unbind() // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.unbind|unbind(){}[0]
@@ -32,6 +32,7 @@ abstract class <#A: kotlin/Any, #B: kotlin/Any> app.cash.redwood.lazylayout.widg
     final val size // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.size|{}size[0]
         final fun <get-size>(): kotlin/Int // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.size.<get-size>|<get-size>(){}[0]
     open fun createPlaceholder(#B): #B? // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.createPlaceholder|createPlaceholder(1:1){}[0]
+    open fun isSizeOnlyPlaceholder(#B): kotlin/Boolean // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.isSizeOnlyPlaceholder|isSizeOnlyPlaceholder(1:1){}[0]
 }
 abstract class app.cash.redwood.lazylayout.widget/LazyListScrollProcessor { // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor|null[0]
     abstract fun contentSize(): kotlin/Int // app.cash.redwood.lazylayout.widget/LazyListScrollProcessor.contentSize|contentSize(){}[0]

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/FakeUpdateProcessor.kt
@@ -16,7 +16,8 @@
 package app.cash.redwood.lazylayout.widget
 
 import app.cash.redwood.Modifier
-import app.cash.redwood.widget.Widget
+import app.cash.redwood.lazylayout.widget.FakeUpdateProcessor.StringCell
+import app.cash.redwood.lazylayout.widget.FakeUpdateProcessor.StringContent
 
 /**
  * This fake simulates a real scroll window, which is completely independent of the window of loaded
@@ -53,7 +54,7 @@ import app.cash.redwood.widget.Widget
  * 8 inclusive, with only 5 and 6 loaded. The elements at 4 and 5 have been updated-in-place, which
  * is why they're at version 2.
  */
-class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCell, String>() {
+class FakeUpdateProcessor : LazyListUpdateProcessor<StringCell, StringContent>() {
   private var dataSize = 0
   private var scrollWindowOffset = 0
   private val scrollWindowCells = mutableListOf<StringCell>()
@@ -111,11 +112,9 @@ class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCe
     }
   }
 
-  override fun setContent(view: StringCell, content: Widget<String>?) {
-    content as StringWidget?
-
+  override fun setContent(view: StringCell, content: StringContent?, modifier: Modifier) {
     // It is an error for `content` to already have a parent cell.
-    val previous = view.content as StringWidget?
+    val previous = view.content
     require(content?.parentCell == null)
     if (previous != null) {
       previous.parentCell = null
@@ -179,16 +178,15 @@ class FakeUpdateProcessor : LazyListUpdateProcessor<FakeUpdateProcessor.StringCe
   }
 
   class StringCell(
-    val binding: Binding<StringCell, String>,
+    val binding: Binding<StringCell, StringContent>,
   ) {
     var version = 0
-    var content: Widget<String>? = null
+    var content: StringContent? = null
   }
 
-  class StringWidget(
-    override var value: String,
-  ) : Widget<String> {
+  class StringContent(
+    var value: String,
+  ) {
     internal var parentCell: StringCell? = null
-    override var modifier: Modifier = Modifier
   }
 }

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
@@ -15,7 +15,9 @@
  */
 package app.cash.redwood.lazylayout.widget
 
-import app.cash.redwood.lazylayout.widget.FakeUpdateProcessor.StringWidget
+import app.cash.redwood.Modifier
+import app.cash.redwood.lazylayout.widget.FakeUpdateProcessor.StringContent
+import app.cash.redwood.widget.Widget
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
@@ -24,7 +26,7 @@ class LazyListUpdateProcessorTest {
   private val processor = FakeUpdateProcessor()
     .apply {
       for (i in 0 until 10) {
-        placeholder.insert(i, StringWidget("."))
+        placeholder.insert(i, ".")
       }
     }
 
@@ -58,11 +60,11 @@ class LazyListUpdateProcessorTest {
   fun moveScrollWindowDownAndUp() {
     processor.itemsBefore(3)
     processor.itemsAfter(4)
-    processor.items.insert(0, StringWidget("D"))
-    processor.items.insert(1, StringWidget("E"))
-    processor.items.insert(2, StringWidget("F"))
-    processor.items.insert(3, StringWidget("G"))
-    processor.items.insert(4, StringWidget("H"))
+    processor.items.insert(0, "D")
+    processor.items.insert(1, "E")
+    processor.items.insert(2, "F")
+    processor.items.insert(3, "G")
+    processor.items.insert(4, "H")
     processor.onEndChanges()
 
     processor.scrollTo(0, 5)
@@ -101,11 +103,11 @@ class LazyListUpdateProcessorTest {
   fun moveLoadedWindowDownAndUpWithScrollPositionAtFront() {
     processor.itemsBefore(0)
     processor.itemsAfter(7)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
-    processor.items.insert(2, StringWidget("C"))
-    processor.items.insert(3, StringWidget("D"))
-    processor.items.insert(4, StringWidget("E"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
+    processor.items.insert(2, "C")
+    processor.items.insert(3, "D")
+    processor.items.insert(4, "E")
     processor.onEndChanges()
 
     processor.scrollTo(0, 4)
@@ -113,8 +115,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(2)
     processor.itemsAfter(5)
-    processor.items.insert(5, StringWidget("F"))
-    processor.items.insert(6, StringWidget("G"))
+    processor.items.insert(5, "F")
+    processor.items.insert(6, "G")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.onEndChanges()
@@ -122,8 +124,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(4)
     processor.itemsAfter(3)
-    processor.items.insert(5, StringWidget("H"))
-    processor.items.insert(6, StringWidget("I"))
+    processor.items.insert(5, "H")
+    processor.items.insert(6, "I")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.onEndChanges()
@@ -131,8 +133,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(6)
     processor.itemsAfter(1)
-    processor.items.insert(5, StringWidget("J"))
-    processor.items.insert(6, StringWidget("K"))
+    processor.items.insert(5, "J")
+    processor.items.insert(6, "K")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.onEndChanges()
@@ -140,8 +142,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(4)
     processor.itemsAfter(3)
-    processor.items.insert(0, StringWidget("E"))
-    processor.items.insert(1, StringWidget("F"))
+    processor.items.insert(0, "E")
+    processor.items.insert(1, "F")
     processor.items.remove(5, 1)
     processor.items.remove(5, 1)
     processor.onEndChanges()
@@ -149,8 +151,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(2)
     processor.itemsAfter(5)
-    processor.items.insert(0, StringWidget("C"))
-    processor.items.insert(1, StringWidget("D"))
+    processor.items.insert(0, "C")
+    processor.items.insert(1, "D")
     processor.items.remove(5, 1)
     processor.items.remove(5, 1)
     processor.onEndChanges()
@@ -158,8 +160,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(0)
     processor.itemsAfter(7)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
     processor.items.remove(5, 1)
     processor.items.remove(5, 1)
     processor.onEndChanges()
@@ -174,11 +176,11 @@ class LazyListUpdateProcessorTest {
   fun moveLoadedWindowDownAndUpWithScrollPositionAtEnd() {
     processor.itemsBefore(0)
     processor.itemsAfter(7)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
-    processor.items.insert(2, StringWidget("C"))
-    processor.items.insert(3, StringWidget("D"))
-    processor.items.insert(4, StringWidget("E"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
+    processor.items.insert(2, "C")
+    processor.items.insert(3, "D")
+    processor.items.insert(4, "E")
     processor.onEndChanges()
 
     processor.scrollTo(8, 4)
@@ -186,8 +188,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(2)
     processor.itemsAfter(5)
-    processor.items.insert(5, StringWidget("F"))
-    processor.items.insert(6, StringWidget("G"))
+    processor.items.insert(5, "F")
+    processor.items.insert(6, "G")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.onEndChanges()
@@ -195,8 +197,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(4)
     processor.itemsAfter(3)
-    processor.items.insert(5, StringWidget("H"))
-    processor.items.insert(6, StringWidget("I"))
+    processor.items.insert(5, "H")
+    processor.items.insert(6, "I")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.onEndChanges()
@@ -204,8 +206,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(6)
     processor.itemsAfter(1)
-    processor.items.insert(5, StringWidget("J"))
-    processor.items.insert(6, StringWidget("K"))
+    processor.items.insert(5, "J")
+    processor.items.insert(6, "K")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.onEndChanges()
@@ -213,15 +215,15 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(7)
     processor.itemsAfter(0)
-    processor.items.insert(5, StringWidget("L"))
+    processor.items.insert(5, "L")
     processor.items.remove(0, 1)
     processor.onEndChanges()
     assertThat(processor.toString()).isEqualTo("[8...] Iv2 Jv2 Kv2 Lv2")
 
     processor.itemsBefore(5)
     processor.itemsAfter(2)
-    processor.items.insert(0, StringWidget("G"))
-    processor.items.insert(1, StringWidget("H"))
+    processor.items.insert(0, "G")
+    processor.items.insert(1, "H")
     processor.items.remove(5, 1)
     processor.items.remove(5, 1)
     processor.onEndChanges()
@@ -229,8 +231,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(3)
     processor.itemsAfter(4)
-    processor.items.insert(0, StringWidget("E"))
-    processor.items.insert(1, StringWidget("F"))
+    processor.items.insert(0, "E")
+    processor.items.insert(1, "F")
     processor.items.remove(5, 1)
     processor.items.remove(5, 1)
     processor.onEndChanges()
@@ -238,8 +240,8 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(1)
     processor.itemsAfter(6)
-    processor.items.insert(0, StringWidget("C"))
-    processor.items.insert(1, StringWidget("D"))
+    processor.items.insert(0, "C")
+    processor.items.insert(1, "D")
     processor.items.remove(5, 1)
     processor.items.remove(5, 1)
     processor.onEndChanges()
@@ -250,16 +252,16 @@ class LazyListUpdateProcessorTest {
   fun moveLoadedWindowDownAndUp2() {
     // Load the first 10.
     processor.itemsAfter(10)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
-    processor.items.insert(2, StringWidget("C"))
-    processor.items.insert(3, StringWidget("D"))
-    processor.items.insert(4, StringWidget("E"))
-    processor.items.insert(5, StringWidget("F"))
-    processor.items.insert(6, StringWidget("G"))
-    processor.items.insert(7, StringWidget("H"))
-    processor.items.insert(8, StringWidget("I"))
-    processor.items.insert(9, StringWidget("J"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
+    processor.items.insert(2, "C")
+    processor.items.insert(3, "D")
+    processor.items.insert(4, "E")
+    processor.items.insert(5, "F")
+    processor.items.insert(6, "G")
+    processor.items.insert(7, "H")
+    processor.items.insert(8, "I")
+    processor.items.insert(9, "J")
     processor.onEndChanges()
     processor.scrollTo(8, 5)
     assertThat(processor.toString()).isEqualTo("[8...] I J . . . [...7]")
@@ -267,11 +269,11 @@ class LazyListUpdateProcessorTest {
     // Load the middle 10.
     processor.itemsBefore(5)
     processor.itemsAfter(5)
-    processor.items.insert(10, StringWidget("K"))
-    processor.items.insert(11, StringWidget("L"))
-    processor.items.insert(12, StringWidget("M"))
-    processor.items.insert(13, StringWidget("N"))
-    processor.items.insert(14, StringWidget("O"))
+    processor.items.insert(10, "K")
+    processor.items.insert(11, "L")
+    processor.items.insert(12, "M")
+    processor.items.insert(13, "N")
+    processor.items.insert(14, "O")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
@@ -283,11 +285,11 @@ class LazyListUpdateProcessorTest {
     // Load the bottom 10.
     processor.itemsBefore(10)
     processor.itemsAfter(0)
-    processor.items.insert(10, StringWidget("P"))
-    processor.items.insert(11, StringWidget("Q"))
-    processor.items.insert(12, StringWidget("R"))
-    processor.items.insert(13, StringWidget("S"))
-    processor.items.insert(14, StringWidget("T"))
+    processor.items.insert(10, "P")
+    processor.items.insert(11, "Q")
+    processor.items.insert(12, "R")
+    processor.items.insert(13, "S")
+    processor.items.insert(14, "T")
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
     processor.items.remove(0, 1)
@@ -299,11 +301,11 @@ class LazyListUpdateProcessorTest {
     // Load the middle 10.
     processor.itemsBefore(5)
     processor.itemsAfter(5)
-    processor.items.insert(0, StringWidget("F"))
-    processor.items.insert(1, StringWidget("G"))
-    processor.items.insert(2, StringWidget("H"))
-    processor.items.insert(3, StringWidget("I"))
-    processor.items.insert(4, StringWidget("J"))
+    processor.items.insert(0, "F")
+    processor.items.insert(1, "G")
+    processor.items.insert(2, "H")
+    processor.items.insert(3, "I")
+    processor.items.insert(4, "J")
     processor.items.remove(10, 1)
     processor.items.remove(10, 1)
     processor.items.remove(10, 1)
@@ -315,11 +317,11 @@ class LazyListUpdateProcessorTest {
     // Load the first 10.
     processor.itemsBefore(0)
     processor.itemsAfter(10)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
-    processor.items.insert(2, StringWidget("C"))
-    processor.items.insert(3, StringWidget("D"))
-    processor.items.insert(4, StringWidget("E"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
+    processor.items.insert(2, "C")
+    processor.items.insert(3, "D")
+    processor.items.insert(4, "E")
     processor.items.remove(10, 1)
     processor.items.remove(10, 1)
     processor.items.remove(10, 1)
@@ -333,9 +335,9 @@ class LazyListUpdateProcessorTest {
   fun itemsBeforeGrowsAndShrinks() {
     processor.itemsBefore(5)
     processor.itemsAfter(5)
-    processor.items.insert(0, StringWidget("F"))
-    processor.items.insert(1, StringWidget("G"))
-    processor.items.insert(2, StringWidget("H"))
+    processor.items.insert(0, "F")
+    processor.items.insert(1, "G")
+    processor.items.insert(2, "H")
     processor.onEndChanges()
 
     processor.scrollTo(4, 5)
@@ -354,9 +356,9 @@ class LazyListUpdateProcessorTest {
   fun itemsAfterGrowsAndShrinks() {
     processor.itemsBefore(5)
     processor.itemsAfter(5)
-    processor.items.insert(0, StringWidget("F"))
-    processor.items.insert(1, StringWidget("G"))
-    processor.items.insert(2, StringWidget("H"))
+    processor.items.insert(0, "F")
+    processor.items.insert(1, "G")
+    processor.items.insert(2, "H")
     processor.onEndChanges()
 
     processor.scrollTo(4, 5)
@@ -375,9 +377,9 @@ class LazyListUpdateProcessorTest {
   fun noncontiguousScrollUp() {
     processor.itemsBefore(4)
     processor.itemsAfter(4)
-    processor.items.insert(0, StringWidget("E"))
-    processor.items.insert(1, StringWidget("F"))
-    processor.items.insert(2, StringWidget("G"))
+    processor.items.insert(0, "E")
+    processor.items.insert(1, "F")
+    processor.items.insert(2, "G")
     processor.onEndChanges()
 
     processor.scrollTo(4, 3)
@@ -388,9 +390,9 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(0)
     processor.itemsAfter(8)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
-    processor.items.insert(2, StringWidget("C"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
+    processor.items.insert(2, "C")
     processor.items.remove(3, 3)
     processor.onEndChanges()
 
@@ -401,9 +403,9 @@ class LazyListUpdateProcessorTest {
   fun noncontiguousScrollDown() {
     processor.itemsBefore(4)
     processor.itemsAfter(4)
-    processor.items.insert(0, StringWidget("E"))
-    processor.items.insert(1, StringWidget("F"))
-    processor.items.insert(2, StringWidget("G"))
+    processor.items.insert(0, "E")
+    processor.items.insert(1, "F")
+    processor.items.insert(2, "G")
     processor.onEndChanges()
 
     processor.scrollTo(4, 3)
@@ -414,9 +416,9 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(8)
     processor.itemsAfter(0)
-    processor.items.insert(0, StringWidget("I"))
-    processor.items.insert(1, StringWidget("J"))
-    processor.items.insert(2, StringWidget("K"))
+    processor.items.insert(0, "I")
+    processor.items.insert(1, "J")
+    processor.items.insert(2, "K")
     processor.items.remove(3, 3)
     processor.onEndChanges()
 
@@ -427,9 +429,9 @@ class LazyListUpdateProcessorTest {
   fun adjacentScrollUp() {
     processor.itemsBefore(3)
     processor.itemsAfter(3)
-    processor.items.insert(0, StringWidget("D"))
-    processor.items.insert(1, StringWidget("E"))
-    processor.items.insert(2, StringWidget("F"))
+    processor.items.insert(0, "D")
+    processor.items.insert(1, "E")
+    processor.items.insert(2, "F")
     processor.onEndChanges()
 
     processor.scrollTo(3, 3)
@@ -440,9 +442,9 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(0)
     processor.itemsAfter(6)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
-    processor.items.insert(2, StringWidget("C"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
+    processor.items.insert(2, "C")
     processor.items.remove(3, 3)
     processor.onEndChanges()
 
@@ -453,9 +455,9 @@ class LazyListUpdateProcessorTest {
   fun adjacentScrollDown() {
     processor.itemsBefore(3)
     processor.itemsAfter(3)
-    processor.items.insert(0, StringWidget("D"))
-    processor.items.insert(1, StringWidget("E"))
-    processor.items.insert(2, StringWidget("F"))
+    processor.items.insert(0, "D")
+    processor.items.insert(1, "E")
+    processor.items.insert(2, "F")
     processor.onEndChanges()
 
     processor.scrollTo(3, 3)
@@ -466,9 +468,9 @@ class LazyListUpdateProcessorTest {
 
     processor.itemsBefore(6)
     processor.itemsAfter(0)
-    processor.items.insert(0, StringWidget("G"))
-    processor.items.insert(1, StringWidget("H"))
-    processor.items.insert(2, StringWidget("I"))
+    processor.items.insert(0, "G")
+    processor.items.insert(1, "H")
+    processor.items.insert(2, "I")
     processor.items.remove(3, 3)
     processor.onEndChanges()
 
@@ -480,9 +482,9 @@ class LazyListUpdateProcessorTest {
   fun noncontiguousScrollUpRemoveChangeFirst() {
     processor.itemsBefore(4)
     processor.itemsAfter(4)
-    processor.items.insert(0, StringWidget("E"))
-    processor.items.insert(1, StringWidget("F"))
-    processor.items.insert(2, StringWidget("G"))
+    processor.items.insert(0, "E")
+    processor.items.insert(1, "F")
+    processor.items.insert(2, "G")
     processor.onEndChanges()
 
     processor.scrollTo(4, 3)
@@ -494,9 +496,9 @@ class LazyListUpdateProcessorTest {
     processor.itemsBefore(0)
     processor.itemsAfter(8)
     processor.items.remove(0, 3)
-    processor.items.insert(0, StringWidget("A"))
-    processor.items.insert(1, StringWidget("B"))
-    processor.items.insert(2, StringWidget("C"))
+    processor.items.insert(0, "A")
+    processor.items.insert(1, "B")
+    processor.items.insert(2, "C")
     processor.onEndChanges()
 
     assertThat(processor.toString()).isEqualTo("Av2 Bv2 Cv2 [...8]")
@@ -506,9 +508,9 @@ class LazyListUpdateProcessorTest {
   fun noncontiguousScrollDownRemoveChangeFirst() {
     processor.itemsBefore(4)
     processor.itemsAfter(4)
-    processor.items.insert(0, StringWidget("E"))
-    processor.items.insert(1, StringWidget("F"))
-    processor.items.insert(2, StringWidget("G"))
+    processor.items.insert(0, "E")
+    processor.items.insert(1, "F")
+    processor.items.insert(2, "G")
     processor.onEndChanges()
 
     processor.scrollTo(4, 3)
@@ -520,9 +522,9 @@ class LazyListUpdateProcessorTest {
     processor.itemsBefore(8)
     processor.itemsAfter(0)
     processor.items.remove(0, 3)
-    processor.items.insert(0, StringWidget("I"))
-    processor.items.insert(1, StringWidget("J"))
-    processor.items.insert(2, StringWidget("K"))
+    processor.items.insert(0, "I")
+    processor.items.insert(1, "J")
+    processor.items.insert(2, "K")
     processor.onEndChanges()
 
     assertThat(processor.toString()).isEqualTo("[8...] Iv2 Jv2 Kv2")
@@ -532,10 +534,10 @@ class LazyListUpdateProcessorTest {
   fun removeMiddleLoadedItemThatIsBound() {
     processor.itemsBefore(8)
     processor.itemsAfter(8)
-    processor.items.insert(0, StringWidget("I"))
-    processor.items.insert(1, StringWidget("J"))
-    processor.items.insert(2, StringWidget("K"))
-    processor.items.insert(3, StringWidget("L"))
+    processor.items.insert(0, "I")
+    processor.items.insert(1, "J")
+    processor.items.insert(2, "K")
+    processor.items.insert(3, "L")
     processor.onEndChanges()
 
     processor.scrollTo(6, 8)
@@ -550,10 +552,10 @@ class LazyListUpdateProcessorTest {
   fun removeMiddleLoadedItemThatIsNotBound() {
     processor.itemsBefore(8)
     processor.itemsAfter(8)
-    processor.items.insert(0, StringWidget("I"))
-    processor.items.insert(1, StringWidget("J"))
-    processor.items.insert(2, StringWidget("K"))
-    processor.items.insert(3, StringWidget("L"))
+    processor.items.insert(0, "I")
+    processor.items.insert(1, "J")
+    processor.items.insert(2, "K")
+    processor.items.insert(3, "L")
     processor.onEndChanges()
 
     processor.scrollTo(2, 4)
@@ -562,5 +564,14 @@ class LazyListUpdateProcessorTest {
     processor.items.remove(2, 1) // 'K'.
     processor.onEndChanges()
     assertThat(processor.toString()).isEqualTo("[2...] . . . . [...13]")
+  }
+
+  private fun Widget.Children<StringContent>.insert(index: Int, value: String) {
+    val content = StringContent(value)
+    val widget = object : Widget<StringContent> {
+      override val value = content
+      override var modifier: Modifier = Modifier
+    }
+    insert(index, widget)
   }
 }


### PR DESCRIPTION
Holding widget bindings creates a retain cycle. Switching these to views instead breaks the cycle.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
