### PR TITLE
Don't crash reading modifiers after widgets are detached

### DIFF
--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutAfterDetach[LTR].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutAfterDetach[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90fde4468742362f5c2e408fc1ff58ad749cb942e2ae9140ad8dc9a32daf47a8
+size 18693

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutAfterDetach[RTL].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutAfterDetach[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9c2bf6293378019e378716baf1d7a7836d5d7b5ba0a3fa0f23d4af60baf10ee
+size 18886

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutAfterDetach[LTR].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutAfterDetach[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ab6b00bdf2a45954a0984465859414c01139071816f6387a9ae51104214c04
+size 21061

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutAfterDetach[RTL].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutAfterDetach[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:262c0229d32c9e5f06397426015d6c0f8656974bf0c7ce9a4ef027c92eae8135
+size 22226

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
@@ -364,6 +364,26 @@ abstract class AbstractBoxTest<T : Any> {
     verifySnapshot(widget.value, "Empty")
   }
 
+  /** The view shouldn't crash if its displayed after being detached. */
+  @Test
+  fun testLayoutAfterDetach() {
+    val widget = box().apply {
+      width(Constraint.Wrap)
+      height(Constraint.Wrap)
+      horizontalAlignment(CrossAxisAlignment.Start)
+      verticalAlignment(CrossAxisAlignment.Start)
+      children.insert(
+        0,
+        text().apply {
+          text(mediumText())
+          bgColor(Green)
+        },
+      )
+      children.detach()
+    }
+    verifySnapshot(widget.value)
+  }
+
   private fun coloredText(modifier: Modifier = Modifier, text: String, color: Int) = text().apply {
     text(text)
     bgColor(color)

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -547,6 +547,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     outerContainer.add(innerContainer1)
     outerContainer.add(innerContainer2)
     innerContainer2.modifier = Modifier.then(FlexImpl(1.0))
+    outerContainer.children.onModifierUpdated(1, innerContainer2)
     verifySnapshot(outerContainer)
   }
 
@@ -579,6 +580,19 @@ abstract class AbstractFlexContainerTest<T : Any> {
     container.children.onModifierUpdated(0, first)
     container.onEndChanges()
     verifySnapshot(container, "Empty")
+  }
+
+  /** The view shouldn't crash if its displayed after being detached. */
+  @Test
+  fun testLayoutAfterDetach() {
+    val container = flexContainer(FlexDirection.Row).apply {
+      width(Constraint.Fill)
+      height(Constraint.Fill)
+      add(text(mediumText()))
+      onEndChanges()
+      children.detach()
+    }
+    verifySnapshot(container)
   }
 }
 

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testLayoutAfterDetach.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testLayoutAfterDetach.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b6ba12ff47637286a65cce7d6f592992b28fa1418f74d40c4052a9b8dbe3a0
+size 57793

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testLayoutAfterDetach.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testLayoutAfterDetach.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca8eb4e6acb0c3b5081f4612044fcb6c6f060201a2d25f6de04de3779a292130
+size 102322

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -88,7 +88,7 @@ internal class UIViewBox : Box<UIView> {
 
     val children = UIViewChildren(
       container = this,
-      insert = { view, index ->
+      insert = { view, _, index ->
         insertSubview(view, index.convert<NSInteger>())
         view.setNeedsLayout()
       },

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -31,25 +31,31 @@ import platform.darwin.NSInteger
 internal class UIViewFlexContainer(
   direction: FlexDirection,
 ) : YogaFlexContainer<UIView>, ChangeListener {
+  private val modifiers = mutableListOf<Modifier>()
   private val yogaView: YogaUIView = YogaUIView(
     applyModifier = { node, index ->
-      node.applyModifier(children.widgets[index].modifier, Density.Default)
+      node.applyModifier(modifiers[index], Density.Default)
     },
   )
   override val rootNode: Node get() = yogaView.rootNode
   override val density: Density get() = Density.Default
   override val value: UIView get() = yogaView
-  override val children = UIViewChildren(
+  override val children: UIViewChildren = UIViewChildren(
     container = value,
-    insert = { view, index ->
+    insert = { view, modifier, index ->
+      modifiers.add(index, modifier)
       yogaView.rootNode.children.add(index, view.asNode())
       value.insertSubview(view, index.convert<NSInteger>())
     },
     remove = { index, count ->
+      modifiers.remove(index, count)
       yogaView.rootNode.children.remove(index, count)
       Array(count) {
         value.typedSubviews[index].also(UIView::removeFromSuperview)
       }
+    },
+    updateModifier = { modifier, index ->
+      modifiers[index] = modifier
     },
   )
   override var modifier: Modifier = Modifier

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutAfterDetach[LTR].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutAfterDetach[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb82ea89f8ab3cb760f786c9d54a1630155d26195f4ba09e416d8e4e65b4f86e
+size 18964

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutAfterDetach[RTL].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutAfterDetach[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a1621a0cd03e72ef26fc6c1b4edd1712b94e74fded7f1d9825011533f6e72dd
+size 19242

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutAfterDetach[LTR].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutAfterDetach[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4ffa020b5ecb22fed2c498860f0e0a764f696225d7ff92c64d7d8b4ccd6a4ff
+size 21320

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutAfterDetach[RTL].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutAfterDetach[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:314bbb1518f0bec142f8406c2a774343d7314bb720456d6e1c8491e8a5299c49
+size 22550

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutAfterDetach[LTR].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutAfterDetach[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:647cf2b14689e37a06a80070f9b7253bc1718c26bb657b5221bb6826f53312e3
+size 18692

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutAfterDetach[RTL].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutAfterDetach[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0250e78b7dbc594bd2a258486aa93fd6d7dc96fa46f379662341301628b978fe
+size 18882

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_testLayoutAfterDetach[LTR].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_testLayoutAfterDetach[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e95979210d72b4a30c8a4dd13b096af90cc1c3d5093d54a5f5829df7ed1434d7
+size 18963

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_testLayoutAfterDetach[RTL].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListTest_testLayoutAfterDetach[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c3039addb8b58f2efb6e4037a4e85b0457890a2cca620e26a119727c8d5192c
+size 19231

--- a/redwood-widget/api/redwood-widget.klib.api
+++ b/redwood-widget/api/redwood-widget.klib.api
@@ -81,7 +81,7 @@ final class <#A: kotlin/Any> app.cash.redwood.widget/MutableListChildren : app.c
 }
 // Targets: [ios]
 final class app.cash.redwood.widget/UIViewChildren : app.cash.redwood.widget/Widget.Children<platform.UIKit/UIView> { // app.cash.redwood.widget/UIViewChildren|null[0]
-    constructor <init>(platform.UIKit/UIView, kotlin/Function2<platform.UIKit/UIView, kotlin/Int, kotlin/Unit> =..., kotlin/Function2<kotlin/Int, kotlin/Int, kotlin/Array<platform.UIKit/UIView>> =...) // app.cash.redwood.widget/UIViewChildren.<init>|<init>(platform.UIKit.UIView;kotlin.Function2<platform.UIKit.UIView,kotlin.Int,kotlin.Unit>;kotlin.Function2<kotlin.Int,kotlin.Int,kotlin.Array<platform.UIKit.UIView>>){}[0]
+    constructor <init>(platform.UIKit/UIView, kotlin/Function3<platform.UIKit/UIView, app.cash.redwood/Modifier, kotlin/Int, kotlin/Unit> =..., kotlin/Function2<kotlin/Int, kotlin/Int, kotlin/Array<platform.UIKit/UIView>> =..., kotlin/Function2<app.cash.redwood/Modifier, kotlin/Int, kotlin/Unit> =...) // app.cash.redwood.widget/UIViewChildren.<init>|<init>(platform.UIKit.UIView;kotlin.Function3<platform.UIKit.UIView,app.cash.redwood.Modifier,kotlin.Int,kotlin.Unit>;kotlin.Function2<kotlin.Int,kotlin.Int,kotlin.Array<platform.UIKit.UIView>>;kotlin.Function2<app.cash.redwood.Modifier,kotlin.Int,kotlin.Unit>){}[0]
     final fun detach() // app.cash.redwood.widget/UIViewChildren.detach|detach(){}[0]
     final fun insert(kotlin/Int, app.cash.redwood.widget/Widget<platform.UIKit/UIView>) // app.cash.redwood.widget/UIViewChildren.insert|insert(kotlin.Int;app.cash.redwood.widget.Widget<platform.UIKit.UIView>){}[0]
     final fun move(kotlin/Int, kotlin/Int, kotlin/Int) // app.cash.redwood.widget/UIViewChildren.move|move(kotlin.Int;kotlin.Int;kotlin.Int){}[0]


### PR DESCRIPTION
We support rendering a widget after Redwood detaches from it. Make this work by never assuming the widget count equals the subject view's child count.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
