### PR TITLE
Don't store modifiers in an adjacent List

### DIFF
--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/Node.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/Node.kt
@@ -27,6 +27,11 @@ public class Node internal constructor(
 
   // Inputs
   public val children: MutableList<Node> = Children()
+  public var context: Any?
+    get() = native.context
+    set(value) {
+      native.context = value
+    }
   public val owner: Node?
     get() = native.owner?.let(::Node)
   public var direction: Direction


### PR DESCRIPTION
There's a 'context' field in Node that's a better fit.

The problem with storing modifiers in an adjacent list is that Yoga occasionally will create a mutable copy of the layout nodes to do some layout calculation, and this mutable copy may drift from our true copy with respect to child counts.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
