### PR TITLE
Fix application of Compose plugin arguments

### DIFF
--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodComposeExtensionImpl.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodComposeExtensionImpl.kt
@@ -19,7 +19,7 @@ import app.cash.redwood.gradle.RedwoodComposeExtension.DangerZone
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 
 internal class RedwoodComposeExtensionImpl(
   private val project: Project,
@@ -43,7 +43,7 @@ internal class RedwoodComposeExtensionImpl(
 
     project.tasks.withType(KotlinCompile::class.java).configureEach {
       val dir = project.redwoodReportDir("compose-metrics/${it.name}").get().asFile.absolutePath
-      it.compilerOptions.freeCompilerArgs.addAll(
+      it.kotlinOptions.freeCompilerArgs += listOf(
         "-P",
         "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$dir",
       )
@@ -56,7 +56,7 @@ internal class RedwoodComposeExtensionImpl(
 
     project.tasks.withType(KotlinCompile::class.java).configureEach {
       val dir = project.redwoodReportDir("compose-reports/${it.name}").get().asFile.absolutePath
-      it.compilerOptions.freeCompilerArgs.addAll(
+      it.kotlinOptions.freeCompilerArgs += listOf(
         "-P",
         "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$dir",
       )


### PR DESCRIPTION
With the previous type, they were not being copied to arguments list for targets other than JVM or Android.

Note: I'm not writing a test or anything for this, because it's all about to be deleted with the Kotlin 2.0 upgrade.

![Screenshot 2024-05-29 at 2 22 35 PM](https://github.com/cashapp/redwood/assets/66577/83d26fc3-5602-447a-b6c8-e24eff8925aa)

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
