### PR TITLE
Publish only to Maven Central on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,7 +214,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v3
 
-      - run: ./gradlew publish
+      - run: ./gradlew publishToMavenCentral
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew publish dokkaHtmlMultiModule jsBrowserProductionWebpack
+        run: ./gradlew publishToMavenCentral dokkaHtmlMultiModule jsBrowserProductionWebpack
 
       - name: Extract release notes
         id: release_notes


### PR DESCRIPTION
This avoids publishing to the test-local repo which, while cheap, does a bunch of file I/O which is slow on Macs.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
