### PR TITLE
Upgrade to Paparazzi 1.3.2

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -38,6 +38,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.publish.PublishingExtension
@@ -205,6 +206,24 @@ class RedwoodBuildPlugin : Plugin<Project> {
         // Disable the release build type for sample applications because we never need it.
         if (it.buildType == "release") {
           it.enable = false
+        }
+      }
+    }
+
+    // Work around Guava problem. See https://github.com/cashapp/paparazzi/issues/906.
+    plugins.withId("app.cash.paparazzi") {
+      dependencies.constraints {
+        it.add("testImplementation", "com.google.guava:guava") {
+          it.attributes {
+            it.attribute(
+              TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+              objects.named(TargetJvmEnvironment::class.java, TargetJvmEnvironment.STANDARD_JVM),
+            )
+          }
+          it.because(
+            "LayoutLib and sdk-common depend on Guava's -jre published variant." +
+              "See https://github.com/cashapp/paparazzi/issues/906.",
+          )
         }
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,7 +78,7 @@ paging-compose-common = { module = "app.cash.paging:paging-compose-common", vers
 zipline = { module = "app.cash.zipline:zipline", version.ref = "zipline" }
 zipline-gradlePlugin = { module = "app.cash.zipline:zipline-gradle-plugin", version.ref = "zipline" }
 zipline-loader = { module = "app.cash.zipline:zipline-loader", version.ref = "zipline" }
-paparazzi-gradlePlugin = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version = "1.3.1" }
+paparazzi-gradlePlugin = "app.cash.paparazzi:paparazzi-gradle-plugin:1.3.2"
 jimfs = "com.google.jimfs:jimfs:1.3.0"
 coil-compose = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-core = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }


### PR DESCRIPTION
This is not the latest, but it's the first to require the workaround. Renovate will do the rest (and we may need to update screenshots for those even newer versions).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
