### PR TITLE
Switch `expect`/`actual` strategy for platform collections

### DIFF
--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/PlatformList.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/PlatformList.kt
@@ -15,9 +15,11 @@
  */
 package app.cash.redwood.protocol.guest
 
+@Suppress("unused") // Type parameter used by extensions.
 internal expect class PlatformList<E>() {
   val size: Int
-  fun add(element: E)
 }
 
-internal expect fun <E> PlatformList<E>.asList(): List<E>
+internal expect inline fun <E> PlatformList<E>.add(element: E)
+
+internal expect inline fun <E> PlatformList<E>.asList(): List<E>

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/PlatformMap.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/PlatformMap.kt
@@ -17,7 +17,10 @@ package app.cash.redwood.protocol.guest
 
 internal expect class PlatformMap<K, V>() {
   operator fun get(key: K): V?
-  operator fun set(key: K, value: V)
-  operator fun contains(key: K): Boolean
-  fun remove(key: K)
 }
+
+internal expect inline operator fun <K, V> PlatformMap<K, V>.set(key: K, value: V)
+
+internal expect inline operator fun <K, V> PlatformMap<K, V>.contains(key: K): Boolean
+
+internal expect inline fun <K, V> PlatformMap<K, V>.remove(key: K)

--- a/redwood-protocol-guest/src/jsMain/kotlin/app/cash/redwood/protocol/guest/PlatformList.kt
+++ b/redwood-protocol-guest/src/jsMain/kotlin/app/cash/redwood/protocol/guest/PlatformList.kt
@@ -20,11 +20,14 @@ internal external class JsArray<E> {
   @JsName("length")
   val size: Int
 
-  @JsName("push")
-  fun add(element: E)
+  fun push(element: E)
 }
 
 internal actual typealias PlatformList<E> = JsArray<E>
+
+internal actual inline fun <E> PlatformList<E>.add(element: E) {
+  push(element)
+}
 
 internal actual inline fun <E> PlatformList<E>.asList(): List<E> {
   return JsArrayList(this)

--- a/redwood-protocol-guest/src/jsMain/kotlin/app/cash/redwood/protocol/guest/PlatformMap.kt
+++ b/redwood-protocol-guest/src/jsMain/kotlin/app/cash/redwood/protocol/guest/PlatformMap.kt
@@ -18,13 +18,21 @@ package app.cash.redwood.protocol.guest
 @JsName("Map")
 internal external class JsMap<K, V> {
   operator fun get(key: K): V?
-  operator fun set(key: K, value: V)
-
-  @JsName("has")
-  operator fun contains(key: K): Boolean
-
-  @JsName("delete")
-  fun remove(key: K)
+  fun set(key: K, value: V)
+  fun has(key: K): Boolean
+  fun delete(key: K)
 }
 
 internal actual typealias PlatformMap<K, V> = JsMap<K, V>
+
+internal actual inline operator fun <K, V> PlatformMap<K, V>.set(key: K, value: V) {
+  set(key, value)
+}
+
+internal actual inline operator fun <K, V> PlatformMap<K, V>.contains(key: K): Boolean {
+  return has(key)
+}
+
+internal actual inline fun <K, V> PlatformMap<K, V>.remove(key: K) {
+  delete(key)
+}

--- a/redwood-protocol-guest/src/nonJsMain/kotlin/app/cash/redwood/protocol/guest/PlatformList.kt
+++ b/redwood-protocol-guest/src/nonJsMain/kotlin/app/cash/redwood/protocol/guest/PlatformList.kt
@@ -23,6 +23,11 @@ package app.cash.redwood.protocol.guest
 )
 internal actual typealias PlatformList<E> = ArrayList<E>
 
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER") // Not true in common.
+internal actual inline fun <E> PlatformList<E>.add(element: E) {
+  add(element)
+}
+
 @Suppress(
   // Explicitly trying to be zero-overhead.
   "NOTHING_TO_INLINE",

--- a/redwood-protocol-guest/src/nonJsMain/kotlin/app/cash/redwood/protocol/guest/PlatformMap.kt
+++ b/redwood-protocol-guest/src/nonJsMain/kotlin/app/cash/redwood/protocol/guest/PlatformMap.kt
@@ -22,3 +22,16 @@ package app.cash.redwood.protocol.guest
   "ACTUAL_WITHOUT_EXPECT",
 )
 internal actual typealias PlatformMap<K, V> = LinkedHashMap<K, V>
+
+internal actual inline operator fun <K, V> PlatformMap<K, V>.set(key: K, value: V) {
+  put(key, value)
+}
+
+internal actual inline operator fun <K, V> PlatformMap<K, V>.contains(key: K): Boolean {
+  return containsKey(key)
+}
+
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER") // Not true in common.
+internal actual inline fun <K, V> PlatformMap<K, V>.remove(key: K) {
+  remove(key)
+}


### PR DESCRIPTION
Kotlin 2 won't let the `Unit`-returning `expect`s match the non-`Unit`-returning `actual`s on the JVM. As a result, all of those functions move to inline extensions.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
