### PR TITLE
Revert "New Widget.detach() is a user function called at detach time"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 New:
 - Added a basic DOM-based LazyList implementation.
 -`TreehouseApp.close()` stops the app and prevents it from being started again later.
--`Widget.detach()` is called when a widget will receive no further updates from the presenter.
 - Added `UiConfiguration.layoutDirection` to support reading the host's layout direction.
 
 Changed:

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/WidgetDetachingTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/WidgetDetachingTest.kt
@@ -32,7 +32,6 @@ import assertk.assertions.isSameInstanceAs
 import com.example.redwood.testapp.compose.TestRow
 import com.example.redwood.testapp.compose.Text
 import com.example.redwood.testapp.compose.reuse
-import com.example.redwood.testapp.widget.Text
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
@@ -54,20 +53,14 @@ class WidgetDetachingTest {
 
       awaitSnapshot()
       val protocolText = widgetBridge.extractProtocolText()
-      val protocolTextWidget = protocolText.widget as Text<*>?
-      assertThat(protocolTextWidget).isNotNull()
+      assertThat(protocolText.widget).isNotNull()
 
       step++
       awaitSnapshot()
-      val thrownOnAccessWidget = assertFailsWith<IllegalStateException> {
+      val thrown = assertFailsWith<IllegalStateException> {
         protocolText.widget
       }
-      assertThat(thrownOnAccessWidget).hasMessage("detached")
-
-      val thrownOnMutateWidget = assertFailsWith<IllegalStateException> {
-        protocolTextWidget?.text("goodbye")
-      }
-      assertThat(thrownOnMutateWidget).hasMessage("detached")
+      assertThat(thrown).hasMessage("detached")
     }
   }
 
@@ -86,20 +79,14 @@ class WidgetDetachingTest {
 
       awaitSnapshot()
       val protocolText = widgetBridge.extractProtocolText()
-      val protocolTextWidget = protocolText.widget as Text<*>?
-      assertThat(protocolTextWidget).isNotNull()
+      assertThat(protocolText.widget).isNotNull()
 
       step++
       awaitSnapshot()
-      val thrownOnAccessWidget = assertFailsWith<IllegalStateException> {
+      val thrown = assertFailsWith<IllegalStateException> {
         protocolText.widget
       }
-      assertThat(thrownOnAccessWidget).hasMessage("detached")
-
-      val thrownOnMutateWidget = assertFailsWith<IllegalStateException> {
-        protocolTextWidget?.text("goodbye")
-      }
-      assertThat(thrownOnMutateWidget).hasMessage("detached")
+      assertThat(thrown).hasMessage("detached")
     }
   }
 

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -506,7 +506,6 @@ internal fun generateProtocolNode(
                 }
               }
             }
-            .addStatement("_widget?.detach()")
             .addStatement("_widget = null")
             .build(),
         )

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -163,8 +163,6 @@ internal fun generateMutableWidgetFactory(schema: Schema): FileSpec {
 
 /*
 internal class MutableButton : Button<WidgetValue> {
-  private var detached: Boolean = false
-
   public override val value: WidgetValue
     get() = ButtonValue(modifier, text, enabled!!, maxLength!!)
 
@@ -175,17 +173,11 @@ internal class MutableButton : Button<WidgetValue> {
   private var maxLength: Int? = null
 
   public override fun text(text: String?) {
-    check(!detached) { "detached" }
     this.text = text
   }
 
   public override fun enabled(enabled: Boolean) {
-    check(!detached) { "detached" }
     this.enabled = enabled
-  }
-
-  public override fun detach() {
-    this.detached = true
   }
 }
 */
@@ -198,13 +190,6 @@ internal fun generateMutableWidget(schema: Schema, widget: Widget): FileSpec {
       TypeSpec.classBuilder(mutableWidgetType)
         .addModifiers(INTERNAL)
         .addSuperinterface(schema.widgetType(widget).parameterizedBy(RedwoodTesting.WidgetValue))
-        .addProperty(
-          PropertySpec.builder("detached", BOOLEAN)
-            .addModifiers(PRIVATE)
-            .mutable(true)
-            .initializer("false")
-            .build(),
-        )
         .addProperty(
           PropertySpec.builder("value", RedwoodTesting.WidgetValue)
             .addModifiers(OVERRIDE)
@@ -266,8 +251,7 @@ internal fun generateMutableWidget(schema: Schema, widget: Widget): FileSpec {
                   FunSpec.builder(trait.name)
                     .addModifiers(OVERRIDE)
                     .addParameter(trait.name, type)
-                    .addStatement("check(!detached) { %S }", "detached")
-                    .addStatement("this.%N = %N", trait.name, trait.name)
+                    .addCode("this.%N = %N", trait.name, trait.name)
                     .build(),
                 )
               }
@@ -287,12 +271,6 @@ internal fun generateMutableWidget(schema: Schema, widget: Widget): FileSpec {
             }
           }
         }
-        .addFunction(
-          FunSpec.builder("detach")
-            .addModifiers(OVERRIDE)
-            .addStatement("this.detached = true")
-            .build(),
-        )
         .build(),
     )
     .build()

--- a/redwood-widget/api/android/redwood-widget.api
+++ b/redwood-widget/api/android/redwood-widget.api
@@ -86,7 +86,6 @@ public final class app/cash/redwood/widget/ViewGroupChildren : app/cash/redwood/
 }
 
 public abstract interface class app/cash/redwood/widget/Widget {
-	public fun detach ()V
 	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
 	public abstract fun getValue ()Ljava/lang/Object;
 	public abstract fun setModifier (Lapp/cash/redwood/Modifier;)V

--- a/redwood-widget/api/jvm/redwood-widget.api
+++ b/redwood-widget/api/jvm/redwood-widget.api
@@ -64,7 +64,6 @@ public abstract interface class app/cash/redwood/widget/SavedStateRegistry {
 }
 
 public abstract interface class app/cash/redwood/widget/Widget {
-	public fun detach ()V
 	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
 	public abstract fun getValue ()Ljava/lang/Object;
 	public abstract fun setModifier (Lapp/cash/redwood/Modifier;)V

--- a/redwood-widget/api/redwood-widget.klib.api
+++ b/redwood-widget/api/redwood-widget.klib.api
@@ -33,7 +33,6 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.widget/Widget { // app.cash
     abstract var modifier // app.cash.redwood.widget/Widget.modifier|{}modifier[0]
         abstract fun <get-modifier>(): app.cash.redwood/Modifier // app.cash.redwood.widget/Widget.modifier.<get-modifier>|<get-modifier>(){}[0]
         abstract fun <set-modifier>(app.cash.redwood/Modifier) // app.cash.redwood.widget/Widget.modifier.<set-modifier>|<set-modifier>(app.cash.redwood.Modifier){}[0]
-    open fun detach() // app.cash.redwood.widget/Widget.detach|detach(){}[0]
 }
 abstract interface <#A: kotlin/Any> app.cash.redwood.widget/WidgetFactoryOwner // app.cash.redwood.widget/WidgetFactoryOwner|null[0]
 abstract interface <#A: kotlin/Any> app.cash.redwood.widget/WidgetSystem { // app.cash.redwood.widget/WidgetSystem|null[0]

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -39,16 +39,6 @@ public interface Widget<W : Any> {
   public var modifier: Modifier
 
   /**
-   * Clear event listeners **without** triggering an update to the displayed UI.
-   *
-   * After this is called there will be no further updates to properties or children.
-   *
-   * This function is not recursive.
-   */
-  public fun detach() {
-  }
-
-  /**
    * An interface for manipulating a widget's list of children.
    *
    * Arguments to these methods can be assumed to be validated against the current state of the

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/ImageBinding.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/ImageBinding.swift
@@ -65,10 +65,6 @@ class ImageBinding: Image {
     private func didTapImage() {
         onClick?()
     }
-
-    func detach() {
-        onClick = nil
-    }
 }
 
 private class ImageView: UIImageView {

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/TextBinding.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/TextBinding.swift
@@ -34,7 +34,4 @@ class TextBinding: Text {
         // this function will update the bounds and trigger relayout in the parent.
         root.sizeToFit()
     }
-
-    func detach() {
-    }
 }

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/TextInputBinding.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/TextInputBinding.swift
@@ -76,8 +76,4 @@ class TextInputBinding: TextInput {
 
     var modifier: Modifier = ExposedKt.modifier()
     var value: Any { root }
-
-    func detach() {
-        onChange = nil
-    }
 }

--- a/test-app/ios-uikit/TestApp/ButtonBinding.swift
+++ b/test-app/ios-uikit/TestApp/ButtonBinding.swift
@@ -49,8 +49,4 @@ class ButtonBinding: Button {
     @objc func clicked() {
         self.onClick?()
     }
-
-    func detach() {
-        onClick = nil
-    }
 }

--- a/test-app/ios-uikit/TestApp/TextBinding.swift
+++ b/test-app/ios-uikit/TestApp/TextBinding.swift
@@ -34,7 +34,4 @@ class TextBinding: Text {
         // this function will update the bounds and trigger relayout in the parent.
         root.sizeToFit()
     }
-
-    func detach() {
-    }
 }


### PR DESCRIPTION
This reverts commit 51276629ba02f5dcd9a6393e03379f11a4351152.

This was added as an attempt to work around problems between Swift's reference counting and Kotlin's garbage collector. We've since found a simpler solution that doesn't require as much code.

Closes #2084 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
