### PR TITLE
Publish a BOM of all subprojects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New:
 - Added a basic DOM-based `LazyList` implementation.
 -`TreehouseApp.close()` stops the app and prevents it from being started again later.
 - Added `UiConfiguration.layoutDirection` to support reading the host's layout direction.
-- New `retrofit-bom` artifact can be used to ensure all Redwood artifacts use the same version. See [Gradle's documentation](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import) on how to use the BOM in your build.
+- New `redwood-bom` artifact can be used to ensure all Redwood artifacts use the same version. See [Gradle's documentation](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import) on how to use the BOM in your build.
 
 Changed:
 - The `app.cash.redwood` Gradle plugin has been removed. This plugin did two things: apply the Compose compiler and add a dependency on the `redwood-compose` artifact. The Compose compiler can now be added by applying the `org.jetbrains.kotlin.plugin.compose` Gradle plugin. Dependencies on Redwood artifacts can be added manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ New:
 - Added a basic DOM-based `LazyList` implementation.
 -`TreehouseApp.close()` stops the app and prevents it from being started again later.
 - Added `UiConfiguration.layoutDirection` to support reading the host's layout direction.
+- New `retrofit-bom` artifact can be used to ensure all Redwood artifacts use the same version. See [Gradle's documentation](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import) on how to use the BOM in your build.
 
 Changed:
 - The `app.cash.redwood` Gradle plugin has been removed. This plugin did two things: apply the Compose compiler and add a dependency on the `redwood-compose` artifact. The Compose compiler can now be added by applying the `org.jetbrains.kotlin.plugin.compose` Gradle plugin. Dependencies on Redwood artifacts can be added manually.

--- a/redwood-bom/build.gradle
+++ b/redwood-bom/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.vanniktech.maven.publish.JavaPlatform
+
+apply plugin: 'java-platform'
+
+redwoodBuild {
+  publishing()
+}
+
+mavenPublishing {
+  configure(new JavaPlatform())
+}
+
+dependencies {
+  constraints {
+    rootProject.subprojects { subproject ->
+      subproject.plugins.withId('com.vanniktech.maven.publish') {
+        // Exclude self project from BOM.
+        if (subproject != this.project) {
+          api subproject
+        }
+      }
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,6 +43,7 @@ enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
 
 rootProject.name = 'redwood'
 
+include ':redwood-bom'
 include ':redwood-compose'
 include ':redwood-composeui'
 include ':redwood-gradle-plugin'


### PR DESCRIPTION
Since we can change the API in backwards-incompatible ways across modules, this ensures all your modules are using the expected version.

Closes #2100 

![Screenshot 2024-06-13 at 2 30 39 PM](https://github.com/cashapp/redwood/assets/66577/b559b254-a7cc-4bac-9aae-37ba1c326957)

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
