### PR TITLE
Update Zipline to 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Breaking:
 
 Upgraded:
 - Kotlin 2.0.0
-- Zipline 1.11.0
+- Zipline 1.12.0
 - kotlinx.serialization 1.7.0
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-activity = "1.9.0"
 androidx-compose-ui = "1.6.8"
 jbCompose = "1.6.11"
 lint = "31.5.0"
-zipline = "1.11.0"
+zipline = "1.12.0"
 coil = "3.0.0-alpha06"
 okio = "3.9.0"
 


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
