### PR TITLE
Require latest of snapshot testing library

### DIFF
--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj/project.pbxproj
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj/project.pbxproj
@@ -411,7 +411,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.16.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This works around a bug on virtualized hosts which don't have Metal always failing to compare images.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
