### PR TITLE
Lock UIView screenshot tests to iOS 17.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - run: ./gradlew verifyPaparazzi
 
-      - run: xcodebuild -project redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj -scheme RedwoodLayoutUIViewTests -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' test
+      - run: xcodebuild -project redwood-layout-uiview/RedwoodLayoutUIViewTests.xcodeproj -scheme RedwoodLayoutUIViewTests -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.5' test
 
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}


### PR DESCRIPTION
The GitHub actions runner image updated where iOS 18 is now the latest, leading to comparison failures for some reason. Since iOS 18 requires Xcode 16 beta right now, we'll stick on iOS 17 for now.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
