### PR TITLE
Add two broken cases to test app

### DIFF
--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testapp/presenter/BrokenRowColumn.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testapp/presenter/BrokenRowColumn.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.redwood.testapp.presenter
+
+import androidx.compose.runtime.Composable
+import app.cash.redwood.Modifier
+import app.cash.redwood.layout.api.Constraint
+import app.cash.redwood.layout.api.CrossAxisAlignment
+import app.cash.redwood.layout.api.MainAxisAlignment
+import app.cash.redwood.layout.compose.Column
+import app.cash.redwood.layout.compose.Row
+import app.cash.redwood.layout.compose.Spacer
+import app.cash.redwood.ui.Margin
+import app.cash.redwood.ui.dp
+import com.example.redwood.testapp.compose.backgroundColor
+
+@Composable
+fun BrokenRowColumn(modifier: Modifier = Modifier) {
+  Column(
+    width = Constraint.Fill,
+    height = Constraint.Fill,
+    // Uncomment this to fix(?) behavior.
+    // horizontalAlignment = CrossAxisAlignment.Stretch,
+    margin = Margin(top = 24.dp),
+    modifier = modifier,
+  ) {
+    Row(
+      width = Constraint.Fill,
+      horizontalAlignment = MainAxisAlignment.Center,
+    ) {
+      Column(
+        width = Constraint.Fill,
+        height = Constraint.Fill,
+        horizontalAlignment = CrossAxisAlignment.Stretch,
+        modifier = Modifier
+          .margin(Margin(start = 24.dp, end = 24.dp))
+          .flex(1.0),
+      ) {
+        Spacer(48.dp, 48.dp, Modifier.backgroundColor(0xFFFF0000U))
+      }
+    }
+  }
+}

--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testapp/presenter/BrokenSizeUpdate.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testapp/presenter/BrokenSizeUpdate.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.redwood.testapp.presenter
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import app.cash.redwood.Modifier
+import app.cash.redwood.layout.api.Constraint.Companion.Fill
+import app.cash.redwood.layout.compose.Column
+import app.cash.redwood.ui.dp
+import com.example.redwood.testapp.compose.Text
+import com.example.redwood.testapp.compose.backgroundColor
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+
+@Composable
+fun BrokenSizeUpdate(modifier: Modifier = Modifier) {
+  var width by remember { mutableStateOf(20.dp) }
+  var height by remember { mutableStateOf(20.dp) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      delay(1.seconds)
+      width = 100.dp
+      height = 100.dp
+
+      delay(3.seconds)
+      width = 20.dp
+      height = 20.dp
+    }
+  }
+
+  Column(
+    width = Fill,
+    height = Fill,
+    modifier = modifier,
+  ) {
+    Text(
+      "hello",
+      modifier = Modifier
+        .size(width, height)
+        .backgroundColor(0xFFFF0000U),
+    )
+  }
+}

--- a/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testapp/presenter/TestApp.kt
+++ b/test-app/presenter/src/commonMain/kotlin/com/example/redwood/testapp/presenter/TestApp.kt
@@ -37,6 +37,8 @@ private val screens = buildMap<String, @Composable TestContext.() -> Unit> {
   put("UI Configuration") { UiConfigurationValues() }
   put("Box Sandbox") { BoxSandbox() }
   put("Unscoped Modifiers") { UnscopedModifiers() }
+  put("Broken Row/Column") { BrokenRowColumn() }
+  put("Broken Size Update") { BrokenSizeUpdate() }
 }
 
 @Stable


### PR DESCRIPTION
row/col squishes everything to 1px:

![row-col](https://github.com/cashapp/redwood/assets/66577/92cdf568-adae-415f-862f-6584770273b1)

size never updates:

![size](https://github.com/cashapp/redwood/assets/66577/b3c360e7-d735-4983-992c-8c28c5a893b4)

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
