### PR TITLE
Remove code supporting old memory model

### DIFF
--- a/test-app/ios-uikit/TestApp/IosHostApi.swift
+++ b/test-app/ios-uikit/TestApp/IosHostApi.swift
@@ -27,15 +27,9 @@ class IosHostApi : HostApi {
             request.addValue(value, forHTTPHeaderField: name)
         }
         let task = client.dataTask(with: request) { data, response, error in
-            // The KMM memory model doesn't do shared objects well, so Zipline expects the callback
-            // on the same thread that the download was initiated from. This happens to be the main
-            // thread, so we can bounce back to that thread for now.
-            // Switching to the new KMM memory model may remove the need for this.
-            DispatchQueue.main.async {
-                completionHandler(data.map {
-                    return String(decoding: $0, as: UTF8.self)
-                }, error)
-            }
+            completionHandler(data.map {
+                return String(decoding: $0, as: UTF8.self)
+            }, error)
         }
 
         task.resume()


### PR DESCRIPTION
Still works:

<img width="612" alt="Screenshot 2024-06-18 at 11 29 36 AM" src="https://github.com/cashapp/redwood/assets/66577/c6407dfc-1b27-4cca-8c33-08f5e278c623">

Closes #2120 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
