### PR TITLE
Update IosTreehouseDispatchersTest

### DIFF
--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchers.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchers.kt
@@ -26,10 +26,12 @@ import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.runBlocking
 import platform.Foundation.NSThread
 
-internal class IosTreehouseDispatchers : TreehouseDispatchers {
+internal class IosTreehouseDispatchers(
+  ziplineDispatcher: SingleThreadCoroutineDispatcher = SingleThreadCoroutineDispatcher(),
+) : TreehouseDispatchers {
   override val ui: CoroutineDispatcher get() = Dispatchers.Main
 
-  private val _zipline = SingleThreadCoroutineDispatcher().also {
+  private val _zipline = ziplineDispatcher.also {
     it.thread.start()
   }
 
@@ -49,7 +51,7 @@ internal class IosTreehouseDispatchers : TreehouseDispatchers {
 }
 
 /** A CoroutineDispatcher that's confined to a single thread, appropriate for executing QuickJS. */
-private class SingleThreadCoroutineDispatcher : CloseableCoroutineDispatcher() {
+internal class SingleThreadCoroutineDispatcher : CloseableCoroutineDispatcher() {
   /**
    * On Apple platforms we need to explicitly set the stack size for background threads; otherwise
    * we get the default of 512 KiB which isn't sufficient for our QuickJS programs.

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchers.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchers.kt
@@ -47,11 +47,13 @@ internal class IosTreehouseDispatchers :
       }
     }
   }.apply {
-    this.name = "Treehouse"
+    name = "Treehouse"
 
     // On Apple platforms we need to explicitly set the stack size for background threads; otherwise
     // we get the default of 512 KiB which isn't sufficient for our QuickJS programs.
-    this.stackSize = ZIPLINE_THREAD_STACK_SIZE.convert()
+    stackSize = ZIPLINE_THREAD_STACK_SIZE.convert()
+
+    start()
   }
 
   override val zipline: CoroutineDispatcher get() = this

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchersTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchersTest.kt
@@ -15,10 +15,45 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.turbine.withTurbineTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.DurationUnit.SECONDS
+import kotlin.time.toDuration
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.test.runTest
+import platform.Foundation.NSThread
+
 class IosTreehouseDispatchersTest : AbstractTreehouseDispatchersTest() {
-  override val treehouseDispatchers: TreehouseDispatchers = IosTreehouseDispatchers()
+  private val ziplineDispatcher = SingleThreadCoroutineDispatcher()
+  override val treehouseDispatchers: TreehouseDispatchers = IosTreehouseDispatchers(ziplineDispatcher = ziplineDispatcher)
 
   /** We haven't set done the work to dispatch to the UI thread on iOS tests. */
   override val ignoreTestsThatExecuteOnUiThread: Boolean
     get() = true
+
+  @Test
+  fun closeFinishesZiplineThreadWithoutExecutingSubsequentRunnable() = runTest {
+    val loggedRunnableIds = mutableListOf<Char>()
+    val runnable = { id: Char -> Runnable { loggedRunnableIds.add(id) } }
+
+    awaitZiplineThread(isExecuting = true)
+    treehouseDispatchers.zipline.dispatch(coroutineContext, runnable('a'))
+    treehouseDispatchers.zipline.dispatch(coroutineContext, runnable('b'))
+    treehouseDispatchers.close()
+    treehouseDispatchers.zipline.dispatch(coroutineContext, runnable('c'))
+    awaitZiplineThread(isExecuting = false)
+
+    assertTrue(ziplineDispatcher.thread.isFinished())
+    assertEquals(listOf('a', 'b'), loggedRunnableIds)
+  }
+
+  private suspend fun awaitZiplineThread(isExecuting: Boolean) {
+    withTurbineTimeout(1.toDuration(SECONDS)) {
+      while (ziplineDispatcher.thread.isExecuting() != isExecuting) {
+        NSThread.sleepForTimeInterval(0.005)
+      }
+    }
+  }
 }


### PR DESCRIPTION
This confirms the current behavior works as expected and helps reduce the risk of a future regression: https://github.com/cashapp/redwood/issues/2104.
