### PR TITLE
Preventing IndexOutOfBoundsException in LazyListUpdateProcessor's maybeShiftLoadedWindow method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 
 Fixed:
 - Using a `data object` for a widget of modifier no longer causes schema parsing to crash.
+- Preventing `IndexOutOfBoundsException` in `LazyListUpdateProcessor`'s `maybeShiftLoadedWindow` method.
 
 
 ## [0.12.0] - 2024-06-18

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
@@ -302,7 +302,7 @@ public abstract class LazyListUpdateProcessor<V : Any, W : Any> {
   private fun maybeShiftLoadedWindow(splitIndex: Int) {
     if (loadedItems.size != 0) return
 
-    if (splitIndex < itemsBefore.size) {
+    if (splitIndex < itemsBefore.size && itemsAfter.size > 0) {
       val count = itemsBefore.size - splitIndex
       itemsAfter.addRange(0, itemsBefore, splitIndex, count)
       itemsBefore.removeRange(splitIndex, splitIndex + count)


### PR DESCRIPTION
This is meant to address issue #2140

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
