### PR TITLE
Ensuring LazyList's itemsBefore and itemsAfter property are always within [0, itemCount], to prevent IndexOutOfBoundsException crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 
 Fixed:
 - Using a `data object` for a widget of modifier no longer causes schema parsing to crash.
+- Ensuring `LazyList`'s `itemsBefore` and `itemsAfter` properties are always within `[0, itemCount]`, to prevent `IndexOutOfBoundsException` crashes.
 
 
 ## [0.12.0] - 2024-06-18

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyList.kt
@@ -47,7 +47,7 @@ internal fun LazyList(
       state.onUserScroll(localFirstVisibleItemIndex, localLastVisibleItemIndex)
     },
     itemsBefore = loadRange.first,
-    itemsAfter = itemCount - loadRange.count() - loadRange.first,
+    itemsAfter = (itemCount - loadRange.count() - loadRange.first).coerceIn(0, itemCount),
     width = width,
     height = height,
     margin = margin,
@@ -87,7 +87,7 @@ internal fun RefreshableLazyList(
   RefreshableLazyList(
     isVertical,
     itemsBefore = loadRange.first,
-    itemsAfter = itemCount - loadRange.count() - loadRange.first,
+    itemsAfter = (itemCount - loadRange.count() - loadRange.first).coerceIn(0, itemCount),
     onViewportChanged = { localFirstVisibleItemIndex, localLastVisibleItemIndex ->
       state.onUserScroll(localFirstVisibleItemIndex, localLastVisibleItemIndex)
     },

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
@@ -185,8 +185,8 @@ public open class LazyListState {
       }
     }
 
-    begin = begin.coerceAtLeast(0)
-    end = end.coerceAtMost(itemCount).coerceAtLeast(0)
+    begin = begin.coerceIn(0, itemCount)
+    end = end.coerceIn(0, itemCount)
 
     this.firstIndexFromPrevious2 = firstIndexFromPrevious1
     this.firstIndexFromPrevious1 = firstIndex


### PR DESCRIPTION
This is meant to address issue #2140 on the guest side

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
