### PR TITLE
Removing clear background colors from UIViewLazyList, now that background color modifiers are supported, since clear backgrounds negatively impact performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changed:
 Fixed:
 - Using a `data object` for a widget of modifier no longer causes schema parsing to crash.
 - Ensuring `LazyList`'s `itemsBefore` and `itemsAfter` properties are always within `[0, itemCount]`, to prevent `IndexOutOfBoundsException` crashes.
+- Removing clear background colors from `UIViewLazyList`, now that background color modifiers are supported, since clear backgrounds negatively impact performance.
 
 
 ## [0.12.0] - 2024-06-18

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -208,7 +208,6 @@ internal open class UIViewLazyList :
       delegate = tableViewDelegate
       rowHeight = UITableViewAutomaticDimension
       separatorStyle = UITableViewCellSeparatorStyleNone
-      backgroundColor = UIColor.clearColor
 
       registerClass(
         cellClass = LazyListContainerCell(UITableViewCellStyle.UITableViewCellStyleDefault, REUSE_IDENTIFIER)
@@ -294,8 +293,6 @@ internal class LazyListContainerCell(
 
   override fun willMoveToSuperview(newSuperview: UIView?) {
     super.willMoveToSuperview(newSuperview)
-
-    backgroundColor = UIColor.clearColor
 
     // Confirm the cell is bound when it's about to be displayed.
     if (superview == null && newSuperview != null) {


### PR DESCRIPTION
This is a revert of PR #1853

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
