### PR TITLE
Fix Yoga styles not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Fixed:
 - Using a `data object` for a widget of modifier no longer causes schema parsing to crash.
 - Ensuring `LazyList`'s `itemsBefore` and `itemsAfter` properties are always within `[0, itemCount]`, to prevent `IndexOutOfBoundsException` crashes.
 - Removing clear background colors from `UIViewLazyList`, now that background color modifiers are supported, since clear backgrounds negatively impact performance.
+- Updating a flex container's margin now works correctly for Yoga-based layouts.
 
 
 ## [0.12.0] - 2024-06-18

--- a/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/internal/detail/CompactValue.kt
+++ b/redwood-yoga/src/commonMain/kotlin/app/cash/redwood/yoga/internal/detail/CompactValue.kt
@@ -97,7 +97,7 @@ internal class CompactValue {
     }
 
     fun equalsTo(a: CompactValue, b: CompactValue): Boolean {
-      return a.payload_.unit == b.payload_.unit
+      return a.payload_.unit == b.payload_.unit && a.payload_.value == b.payload_.value
     }
   }
 }


### PR DESCRIPTION
Consider the value of a `CompactValue` in equality comparison, not just its unit

Fixes #2026 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
