### PR TITLE
In UIViewLazyList, make the UITableView's background color clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changed:
 Fixed:
 - Using a `data object` for a widget of modifier no longer causes schema parsing to crash.
 - Ensuring `LazyList`'s `itemsBefore` and `itemsAfter` properties are always within `[0, itemCount]`, to prevent `IndexOutOfBoundsException` crashes.
-- Removing clear background colors from `UIViewLazyList`, now that background color modifiers are supported, since clear backgrounds negatively impact performance.
+- Removing clear background colors from `UIViewLazyList` cells, now that background color modifiers are supported, since clear backgrounds negatively impact performance.
 - Updating a flex container's margin now works correctly for Yoga-based layouts.
 
 

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -208,6 +208,7 @@ internal open class UIViewLazyList :
       delegate = tableViewDelegate
       rowHeight = UITableViewAutomaticDimension
       separatorStyle = UITableViewCellSeparatorStyleNone
+      backgroundColor = UIColor.clearColor
 
       registerClass(
         cellClass = LazyListContainerCell(UITableViewCellStyle.UITableViewCellStyleDefault, REUSE_IDENTIFIER)


### PR DESCRIPTION
This is a partial revert of PR #2146; we still want the individual cells to have non-clear backgrounds for performance reasons, but the underlying table should be clear

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
