### PR TITLE
Add Android lint to JVM-only projects

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -298,6 +298,8 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
           js().browser()
           jvm()
         }
+        // Needed for lint in downstream Android projects to analyze this dependency.
+        project.plugins.apply("com.android.lint")
       }
       CommonWithAndroid -> {
         project.plugins.apply("com.android.library")
@@ -310,6 +312,8 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       }
       Tooling -> {
         project.plugins.apply("org.jetbrains.kotlin.jvm")
+        // Needed for lint in downstream Android projects to analyze this dependency.
+        project.plugins.apply("com.android.lint")
       }
       ToolkitAllWithoutAndroid -> {
         project.applyKotlinMultiplatform {
@@ -317,6 +321,8 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
           js().browser()
           jvm()
         }
+        // Needed for lint in downstream Android projects to analyze this dependency.
+        project.plugins.apply("com.android.lint")
       }
       ToolkitAndroid -> {
         project.plugins.apply("com.android.library")


### PR DESCRIPTION
Hides a warning, and enables analysis across projects.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
