### PR TITLE
Target ES2015 in our samples

### DIFF
--- a/samples/counter/browser/build.gradle
+++ b/samples/counter/browser/build.gradle
@@ -10,6 +10,10 @@ kotlin {
     moduleName = 'counter-browser'
     browser()
     binaries.executable()
+
+    compilerOptions {
+      target = 'es2015'
+    }
   }
 
   sourceSets {

--- a/samples/emoji-search/browser/build.gradle
+++ b/samples/emoji-search/browser/build.gradle
@@ -10,6 +10,10 @@ kotlin {
     moduleName = 'emoji-search-browser'
     browser()
     binaries.executable()
+
+    compilerOptions {
+      target = 'es2015'
+    }
   }
 
   sourceSets {

--- a/test-app/browser/build.gradle
+++ b/test-app/browser/build.gradle
@@ -10,6 +10,10 @@ kotlin {
     moduleName = 'test-app'
     browser()
     binaries.executable()
+
+    compilerOptions {
+      target = 'es2015'
+    }
   }
 
   sourceSets {


### PR DESCRIPTION
Counter:

 - Before:

   ```
   du -hs samples/counter/browser/build/kotlin-webpack/js/productionExecutable/counter.js 
   400K	samples/counter/browser/build/kotlin-webpack/js/productionExecutable/counter.js
   ```

 - After:

   ```
   du -hs samples/counter/browser/build/kotlin-webpack/js/productionExecutable/counter.js 
   352K	samples/counter/browser/build/kotlin-webpack/js/productionExecutable/counter.js
   ```

Emoji:

 - Before:

   ```
   du -hs samples/emoji-search/browser/build/kotlin-webpack/js/productionExecutable/emoji-search.js
   628K	samples/emoji-search/browser/build/kotlin-webpack/js/productionExecutable/emoji-search.js
   ```

 - After:

   ```
   du -hs samples/emoji-search/browser/build/kotlin-webpack/js/productionExecutable/emoji-search.js
   548K	samples/emoji-search/browser/build/kotlin-webpack/js/productionExecutable/emoji-search.js
   ```

Test app:

 - Before:

   ```
   du -hs test-app/browser/build/kotlin-webpack/js/productionExecutable/test-app.js 
   856K	test-app/browser/build/kotlin-webpack/js/productionExecutable/test-app.js
   ```

 - After:

   ```
   du -hs test-app/browser/build/kotlin-webpack/js/productionExecutable/test-app.js 
   712K	test-app/browser/build/kotlin-webpack/js/productionExecutable/test-app.js
   ```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
