### PR TITLE
Run common JS tests in NodeJS except where required

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.buildsupport
 
+import app.cash.redwood.buildsupport.JsTests.NodeJs
 import app.cash.redwood.buildsupport.TargetGroup.Common
 import app.cash.redwood.buildsupport.TargetGroup.CommonWithAndroid
 import app.cash.redwood.buildsupport.TargetGroup.Tooling
@@ -293,12 +294,12 @@ class RedwoodBuildPlugin : Plugin<Project> {
 }
 
 private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodBuildExtension {
-  override fun targets(group: TargetGroup) {
-    when (group) {
+  override fun targets(modifiedGroup: ModifiedTargetGroup) {
+    when (modifiedGroup.group) {
       Common -> {
         project.applyKotlinMultiplatform {
           iosTargets()
-          js().browser()
+          modifiedGroup[JsTests, NodeJs].applyTo(js())
           jvm()
         }
         // Needed for lint in downstream Android projects to analyze this dependency.
@@ -309,7 +310,7 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
         project.applyKotlinMultiplatform {
           androidTarget().publishLibraryVariants("release")
           iosTargets()
-          js().browser()
+          modifiedGroup[JsTests, NodeJs].applyTo(js())
           jvm()
         }
       }
@@ -373,6 +374,10 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
         }
       }
     }
+  }
+
+  override fun targets(group: TargetGroup) {
+    targets(ModifiedTargetGroup(group, emptyMap()))
   }
 
   override fun publishing() {

--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -1,7 +1,9 @@
+import app.cash.redwood.buildsupport.JsTests
+
 import static app.cash.redwood.buildsupport.TargetGroup.CommonWithAndroid
 
 redwoodBuild {
-  targets(CommonWithAndroid)
+  targets(CommonWithAndroid + JsTests.Browser)
   publishing()
 }
 

--- a/redwood-widget/build.gradle
+++ b/redwood-widget/build.gradle
@@ -1,7 +1,9 @@
+import app.cash.redwood.buildsupport.JsTests
+
 import static app.cash.redwood.buildsupport.TargetGroup.CommonWithAndroid
 
 redwoodBuild {
-  targets(CommonWithAndroid)
+  targets(CommonWithAndroid + JsTests.Browser)
   publishing()
 }
 


### PR DESCRIPTION
This builds a little modifier system to our targets where certain aspects can be customized. In this case, the only modifier is where JS tests run. The two modules which depend on actual browser APIs get an actual browser test target. The others run on NodeJS.

Before:

    $ gw :redwood-protocol:tasks --all | \grep 'Run all js tests'
    jsBrowserTest - Run all js tests inside browser using karma and webpack

After:

    $ gw :redwood-protocol:tasks --all | \grep 'Run all js tests'
    jsNodeTest - Run all js tests inside nodejs using the builtin test framework

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
