### PR TITLE
Set clear as background color for cells in UIViewLazyList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Changed:
 Fixed:
 - Using a `data object` for a widget of modifier no longer causes schema parsing to crash.
 - Ensuring `LazyList`'s `itemsBefore` and `itemsAfter` properties are always within `[0, itemCount]`, to prevent `IndexOutOfBoundsException` crashes.
-- Removing clear background colors from `UIViewLazyList` cells, now that background color modifiers are supported, since clear backgrounds negatively impact performance.
 - Updating a flex container's margin now works correctly for Yoga-based layouts.
 
 

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -295,6 +295,8 @@ internal class LazyListContainerCell(
   override fun willMoveToSuperview(newSuperview: UIView?) {
     super.willMoveToSuperview(newSuperview)
 
+    backgroundColor = UIColor.clearColor
+
     // Confirm the cell is bound when it's about to be displayed.
     if (superview == null && newSuperview != null) {
       require(binding!!.isBound) { "about to display a cell that isn't bound!" }


### PR DESCRIPTION
To avoid a problem of lazy-list rows briefly flashing white when recomposing content, this completes the revert of https://github.com/cashapp/redwood/pull/2146 (which was partially reverted by https://github.com/cashapp/redwood/pull/2152).