### PR TITLE
Fix a host crash in LazyListUpdateProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changed:
 Fixed:
 - Using a `data object` for a widget of modifier no longer causes schema parsing to crash.
 - Ensuring `LazyList`'s `itemsBefore` and `itemsAfter` properties are always within `[0, itemCount]`, to prevent `IndexOutOfBoundsException` crashes.
+- Don't crash in `LazyList` when a scroll and content change occur in the same update.
 - Updating a flex container's margin now works correctly for Yoga-based layouts.
 
 Upgraded:

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
@@ -307,7 +307,7 @@ public abstract class LazyListUpdateProcessor<V : Any, W : Any> {
       itemsAfter.addRange(0, itemsBefore, splitIndex, count)
       itemsBefore.removeRange(splitIndex, splitIndex + count)
     } else if (splitIndex > itemsBefore.size) {
-      val count = splitIndex - itemsBefore.size
+      val count = minOf(splitIndex - itemsBefore.size, itemsAfter.size)
       itemsBefore.addRange(itemsBefore.size, itemsAfter, 0, count)
       itemsAfter.removeRange(0, count)
     }


### PR DESCRIPTION
I introduced a bug in the mechanism that attempts to replace animated inserts and removes with update-in-place transitions.

The crash occurs when the before window shrinks while the total number of elements is growing. The previous code naively assumed the before window shrinking would always be a scroll, but it can coincide with a content change.

Closes: https://github.com/cashapp/redwood/issues/2172

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
