### PR TITLE
Apply the UIKit LazyList separator style every time the view appears.

### DIFF
--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -178,7 +178,8 @@ internal open class UIViewLazyList :
   }
 
   private val tableViewDelegate: UITableViewDelegateProtocol =
-    object : UITableViewController(UITableViewStyle.UITableViewStylePlain),
+    object :
+      UITableViewController(UITableViewStyle.UITableViewStylePlain),
       UITableViewDelegateProtocol {
       override fun scrollViewDidScroll(scrollView: UIScrollView) {
         if (ignoreScrollUpdates) return // Only notify of user scrolls.

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -54,6 +54,7 @@ import platform.UIKit.UITableViewAutomaticDimension
 import platform.UIKit.UITableViewCell
 import platform.UIKit.UITableViewCellSeparatorStyle.UITableViewCellSeparatorStyleNone
 import platform.UIKit.UITableViewCellStyle
+import platform.UIKit.UITableViewController
 import platform.UIKit.UITableViewDataSourceProtocol
 import platform.UIKit.UITableViewDelegateProtocol
 import platform.UIKit.UITableViewRowAnimationNone
@@ -177,7 +178,8 @@ internal open class UIViewLazyList :
   }
 
   private val tableViewDelegate: UITableViewDelegateProtocol =
-    object : NSObject(), UITableViewDelegateProtocol {
+    object : UITableViewController(UITableViewStyle.UITableViewStylePlain),
+      UITableViewDelegateProtocol {
       override fun scrollViewDidScroll(scrollView: UIScrollView) {
         if (ignoreScrollUpdates) return // Only notify of user scrolls.
 
@@ -200,6 +202,11 @@ internal open class UIViewLazyList :
       override fun scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {
         ignoreScrollUpdates = false
       }
+
+      override fun viewWillAppear(animated: Boolean) {
+        super.viewWillAppear(animated)
+        tableView.separatorStyle = UITableViewCellSeparatorStyleNone
+      }
     }
 
   init {
@@ -207,7 +214,6 @@ internal open class UIViewLazyList :
       dataSource = this@UIViewLazyList.dataSource
       delegate = tableViewDelegate
       rowHeight = UITableViewAutomaticDimension
-      separatorStyle = UITableViewCellSeparatorStyleNone
       backgroundColor = UIColor.clearColor
 
       registerClass(

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -54,7 +54,6 @@ import platform.UIKit.UITableViewAutomaticDimension
 import platform.UIKit.UITableViewCell
 import platform.UIKit.UITableViewCellSeparatorStyle.UITableViewCellSeparatorStyleNone
 import platform.UIKit.UITableViewCellStyle
-import platform.UIKit.UITableViewController
 import platform.UIKit.UITableViewDataSourceProtocol
 import platform.UIKit.UITableViewDelegateProtocol
 import platform.UIKit.UITableViewRowAnimationNone
@@ -178,9 +177,7 @@ internal open class UIViewLazyList :
   }
 
   private val tableViewDelegate: UITableViewDelegateProtocol =
-    object :
-      UITableViewController(UITableViewStyle.UITableViewStylePlain),
-      UITableViewDelegateProtocol {
+    object : NSObject(), UITableViewDelegateProtocol {
       override fun scrollViewDidScroll(scrollView: UIScrollView) {
         if (ignoreScrollUpdates) return // Only notify of user scrolls.
 
@@ -203,11 +200,6 @@ internal open class UIViewLazyList :
       override fun scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {
         ignoreScrollUpdates = false
       }
-
-      override fun viewWillAppear(animated: Boolean) {
-        super.viewWillAppear(animated)
-        tableView.separatorStyle = UITableViewCellSeparatorStyleNone
-      }
     }
 
   init {
@@ -215,6 +207,7 @@ internal open class UIViewLazyList :
       dataSource = this@UIViewLazyList.dataSource
       delegate = tableViewDelegate
       rowHeight = UITableViewAutomaticDimension
+      separatorStyle = UITableViewCellSeparatorStyleNone
       backgroundColor = UIColor.clearColor
 
       registerClass(
@@ -303,6 +296,9 @@ internal class LazyListContainerCell(
     super.willMoveToSuperview(newSuperview)
 
     backgroundColor = UIColor.clearColor
+    if (newSuperview is UITableView) {
+      newSuperview.separatorStyle = UITableViewCellSeparatorStyleNone
+    }
 
     // Confirm the cell is bound when it's about to be displayed.
     if (superview == null && newSuperview != null) {


### PR DESCRIPTION
This should hopefully fix an issue where we were seeing the dividers appear in some cases.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
