### PR TITLE
Use a different thread for each TreehouseApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Fixed:
 - Don't crash in `LazyList` when a scroll and content change occur in the same update.
 - Updating a flex container's margin now works correctly for Yoga-based layouts.
 
+Breaking:
+- The `TreehouseApp.Factory.dispatchers` property is removed, and callers should migrate to `TreehouseApp.dispatchers`. With this update each `TreehouseApp` has its own private thread so a shared `dispatchers` property no longer fits our implementation.
+
 Upgraded:
 - Zipline 1.14.0
 

--- a/redwood-treehouse-host/api/android/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/android/redwood-treehouse-host.api
@@ -95,7 +95,6 @@ public abstract class app/cash/redwood/treehouse/TreehouseApp : java/lang/AutoCl
 public abstract interface class app/cash/redwood/treehouse/TreehouseApp$Factory : java/lang/AutoCloseable {
 	public abstract fun create (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;)Lapp/cash/redwood/treehouse/TreehouseApp;
 	public static synthetic fun create$default (Lapp/cash/redwood/treehouse/TreehouseApp$Factory;Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/TreehouseApp;
-	public abstract fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
 }
 
 public abstract class app/cash/redwood/treehouse/TreehouseApp$Spec {

--- a/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
@@ -95,7 +95,6 @@ public abstract class app/cash/redwood/treehouse/TreehouseApp : java/lang/AutoCl
 public abstract interface class app/cash/redwood/treehouse/TreehouseApp$Factory : java/lang/AutoCloseable {
 	public abstract fun create (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;)Lapp/cash/redwood/treehouse/TreehouseApp;
 	public static synthetic fun create$default (Lapp/cash/redwood/treehouse/TreehouseApp$Factory;Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/treehouse/TreehouseApp$Spec;Lapp/cash/redwood/treehouse/EventListener$Factory;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/TreehouseApp;
-	public abstract fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
 }
 
 public abstract class app/cash/redwood/treehouse/TreehouseApp$Spec {

--- a/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
+++ b/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
@@ -78,9 +78,6 @@ abstract class <#A: app.cash.redwood.treehouse/AppService> app.cash.redwood.tree
     abstract fun stop() // app.cash.redwood.treehouse/TreehouseApp.stop|stop(){}[0]
 
     abstract interface Factory : kotlin/AutoCloseable { // app.cash.redwood.treehouse/TreehouseApp.Factory|null[0]
-        abstract val dispatchers // app.cash.redwood.treehouse/TreehouseApp.Factory.dispatchers|{}dispatchers[0]
-            abstract fun <get-dispatchers>(): app.cash.redwood.treehouse/TreehouseDispatchers // app.cash.redwood.treehouse/TreehouseApp.Factory.dispatchers.<get-dispatchers>|<get-dispatchers>(){}[0]
-
         abstract fun <#A2: app.cash.redwood.treehouse/AppService> create(kotlinx.coroutines/CoroutineScope, app.cash.redwood.treehouse/TreehouseApp.Spec<#A2>, app.cash.redwood.treehouse/EventListener.Factory = ...): app.cash.redwood.treehouse/TreehouseApp<#A2> // app.cash.redwood.treehouse/TreehouseApp.Factory.create|create(kotlinx.coroutines.CoroutineScope;app.cash.redwood.treehouse.TreehouseApp.Spec<0:0>;app.cash.redwood.treehouse.EventListener.Factory){0§<app.cash.redwood.treehouse.AppService>}[0]
     }
 

--- a/redwood-treehouse-host/src/androidInstrumentedTest/kotlin/app/cash/redwood/treehouse/AndroidTreehouseDispatchersTest.kt
+++ b/redwood-treehouse-host/src/androidInstrumentedTest/kotlin/app/cash/redwood/treehouse/AndroidTreehouseDispatchersTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
-class AndroidTreehouseDispatchersTest : AbstractTreehouseDispatchersTest() {
-  override val treehouseDispatchers: TreehouseDispatchers = AndroidTreehouseDispatchers()
+internal class AndroidTreehouseDispatchersTest : AbstractTreehouseDispatchersTest() {
+  override fun newTreehouseDispatchers(applicationName: String) =
+    AndroidTreehouseDispatchers(applicationName)
 }

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/AndroidTreehousePlatform.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/AndroidTreehousePlatform.kt
@@ -45,4 +45,7 @@ internal class AndroidTreehousePlatform(
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = loaderEventListener,
   )
+
+  override fun newDispatchers(applicationName: String): TreehouseDispatchers =
+    AndroidTreehouseDispatchers(applicationName)
 }

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -19,11 +19,13 @@ import android.content.Context
 import app.cash.zipline.loader.LoaderEventListener
 import app.cash.zipline.loader.ManifestVerifier
 import app.cash.zipline.loader.asZiplineHttpClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okhttp3.OkHttpClient
 import okio.FileSystem
 import okio.Path
 
 @Suppress("FunctionName")
+@OptIn(ExperimentalCoroutinesApi::class) // CloseableCoroutineDispatcher is experimental.
 public fun TreehouseAppFactory(
   context: Context,
   httpClient: OkHttpClient,
@@ -37,7 +39,6 @@ public fun TreehouseAppFactory(
   stateStore: StateStore = MemoryStateStore(),
 ): TreehouseApp.Factory = RealTreehouseApp.Factory(
   platform = AndroidTreehousePlatform(context),
-  dispatchers = AndroidTreehouseDispatchers(),
   httpClient = httpClient.asZiplineHttpClient(),
   frameClockFactory = AndroidChoreographerFrameClock.Factory(),
   manifestVerifier = manifestVerifier,
@@ -45,6 +46,7 @@ public fun TreehouseAppFactory(
   embeddedDir = embeddedDir,
   cacheName = cacheName,
   cacheMaxSizeInBytes = cacheMaxSizeInBytes,
+  ziplineLoaderDispatcher = ziplineLoaderDispatcher(),
   loaderEventListener = loaderEventListener,
   concurrentDownloads = concurrentDownloads,
   stateStore = stateStore,

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/FakeZiplineLoaderDispatcher.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/FakeZiplineLoaderDispatcher.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import java.util.concurrent.Executor
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CloseableCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.test.TestScope
+
+@OptIn(ExperimentalCoroutinesApi::class) // CloseableCoroutineDispatcher is experimental.
+internal class FakeZiplineLoaderDispatcher(
+  testScope: TestScope,
+) : CloseableCoroutineDispatcher() {
+  private val delegate = testScope.dispatcher()
+
+  var closed = false
+    private set
+
+  override fun dispatch(context: CoroutineContext, block: Runnable) {
+    delegate.dispatch(context, block)
+  }
+
+  override val executor: Executor
+    get() = error("unexpected call")
+
+  override fun close() {
+    closed = true
+  }
+}

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/LeaksTest.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/LeaksTest.kt
@@ -189,20 +189,21 @@ class LeaksTest {
   }
 
   @Test
-  fun dispatchersNotClosedByApp() = runTest {
-    val dispatchers = FakeDispatchers(this)
-    val app = TreehouseTester(this, dispatchers).loadApp()
+  fun treehouseDispatchersClosedByApp() = runTest {
+    val treehouseTester = TreehouseTester(this)
+    val app = treehouseTester.loadApp()
+    assertThat(treehouseTester.openTreehouseDispatchersCount).isEqualTo(1)
     app.close()
-    assertThat(dispatchers.isClosed).isFalse()
+    assertThat(treehouseTester.openTreehouseDispatchersCount).isEqualTo(0)
+    assertThat(treehouseTester.ziplineLoaderDispatcher.closed).isFalse()
   }
 
   @Test
-  fun dispatchersNotLeakedByAppFactory() = runTest {
-    val dispatchers = FakeDispatchers(this)
-    val factory = TreehouseTester(this, dispatchers).treehouseAppFactory
-    assertThat(dispatchers.isClosed).isFalse()
-    factory.close()
-    assertThat(dispatchers.isClosed).isTrue()
+  fun ziplineLoaderDispatcherClosedByAppFactory() = runTest {
+    val treehouseTester = TreehouseTester(this)
+    assertThat(treehouseTester.ziplineLoaderDispatcher.closed).isFalse()
+    treehouseTester.treehouseAppFactory.close()
+    assertThat(treehouseTester.ziplineLoaderDispatcher.closed).isTrue()
   }
 
   /**

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -104,8 +104,6 @@ public abstract class TreehouseApp<A : AppService> : AutoCloseable {
    */
   @ObjCName("TreehouseAppFactory", exact = true)
   public interface Factory : AutoCloseable {
-    public val dispatchers: TreehouseDispatchers
-
     public fun <A : AppService> create(
       appScope: CoroutineScope,
       spec: Spec<A>,

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseDispatchers.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseDispatchers.kt
@@ -25,6 +25,9 @@ import kotlinx.coroutines.CoroutineDispatcher
  *  * [zipline] executes dispatched tasks on the thread where downloaded code executes.
  *
  * This class makes it easier to specify invariants on which dispatcher is expected for which work.
+ *
+ * Each [TreehouseApp] gets its own instance of this class and has its own private Zipline thread.
+ * All apps share the same UI thread.
  */
 @ObjCName("TreehouseDispatchers", exact = true)
 public interface TreehouseDispatchers : AutoCloseable {
@@ -48,10 +51,9 @@ public interface TreehouseDispatchers : AutoCloseable {
 
   /**
    * Release the threads owned by this instance. On most platforms this will not release the UI
-   * thread, as it is not owned by this instance.
+   * thread as it is not owned by this instance.
    *
-   * Most applications should not to call this; instead they should allow these dispatchers to
-   * run until the process exits. This may be useful in tests.
+   * This is called by [TreehouseApp.close].
    */
   public override fun close()
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehousePlatform.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehousePlatform.kt
@@ -24,4 +24,8 @@ internal interface TreehousePlatform {
     maxSizeInBytes: Long,
     loaderEventListener: LoaderEventListener,
   ): ZiplineCache
+
+  fun newDispatchers(
+    applicationName: String,
+  ): TreehouseDispatchers
 }

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/IosTreehousePlatform.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/IosTreehousePlatform.kt
@@ -32,4 +32,7 @@ internal class IosTreehousePlatform : TreehousePlatform {
     maxSizeInBytes = maxSizeInBytes,
     loaderEventListener = loaderEventListener,
   )
+
+  override fun newDispatchers(applicationName: String): TreehouseDispatchers =
+    IosTreehouseDispatchers(applicationName)
 }

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryIos.kt
@@ -18,10 +18,12 @@ package app.cash.redwood.treehouse
 import app.cash.zipline.loader.LoaderEventListener
 import app.cash.zipline.loader.ManifestVerifier
 import app.cash.zipline.loader.ZiplineHttpClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okio.FileSystem
 import okio.Path
 
 @Suppress("FunctionName")
+@OptIn(ExperimentalCoroutinesApi::class) // CloseableCoroutineDispatcher is experimental.
 public fun TreehouseAppFactory(
   httpClient: ZiplineHttpClient,
   manifestVerifier: ManifestVerifier,
@@ -34,7 +36,6 @@ public fun TreehouseAppFactory(
   stateStore: StateStore = MemoryStateStore(),
 ): TreehouseApp.Factory = RealTreehouseApp.Factory(
   platform = IosTreehousePlatform(),
-  dispatchers = IosTreehouseDispatchers(),
   httpClient = httpClient,
   frameClockFactory = IosDisplayLinkClock,
   manifestVerifier = manifestVerifier,
@@ -42,6 +43,7 @@ public fun TreehouseAppFactory(
   embeddedDir = embeddedDir,
   cacheName = cacheName,
   cacheMaxSizeInBytes = cacheMaxSizeInBytes,
+  ziplineLoaderDispatcher = ziplineLoaderDispatcher(),
   loaderEventListener = loaderEventListener,
   concurrentDownloads = concurrentDownloads,
   stateStore = stateStore,

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchersTest.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/IosTreehouseDispatchersTest.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 class IosTreehouseDispatchersTest : AbstractTreehouseDispatchersTest() {
-  private val iosTreehouseDispatchers = IosTreehouseDispatchers()
+  private val iosTreehouseDispatchers = IosTreehouseDispatchers("appName")
   override val treehouseDispatchers: TreehouseDispatchers get() = iosTreehouseDispatchers
 
   /** We haven't set done the work to dispatch to the UI thread on iOS tests. */


### PR DESCRIPTION
This should prevent different apps from competing with each other for CPU resources, especially during the first few seconds of the host app's launch, when there's a bunch of CPU-bound work to do.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
