### PR TITLE
Update Zipline to 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Fixed:
 - Updating a flex container's margin now works correctly for Yoga-based layouts.
 
 Upgraded:
-- Zipline 1.14.0
+- Zipline 1.15.0
 
 
 ## [0.12.0] - 2024-06-18

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-activity = "1.9.0"
 androidx-compose-ui = "1.6.8"
 jbCompose = "1.6.11"
 lint = "31.5.1"
-zipline = "1.14.0"
+zipline = "1.15.0"
 coil = "3.0.0-alpha08"
 okio = "3.9.0"
 


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
