### PR TITLE
Add a TreehouseApp parameter to Spec.bindServices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Fixed:
 Upgraded:
 - Zipline 1.14.0
 
+Breaking:
+  -`TreehouseApp.Spec.bindServices()` now accepts a `TreehouseApp` parameter.
+
 
 ## [0.12.0] - 2024-06-18
 [0.12.0]: https://github.com/cashapp/redwood/releases/tag/0.12.0

--- a/redwood-treehouse-host/api/android/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/android/redwood-treehouse-host.api
@@ -100,7 +100,7 @@ public abstract interface class app/cash/redwood/treehouse/TreehouseApp$Factory 
 
 public abstract class app/cash/redwood/treehouse/TreehouseApp$Spec {
 	public fun <init> ()V
-	public abstract fun bindServices (Lapp/cash/zipline/Zipline;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bindServices (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/zipline/Zipline;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun create (Lapp/cash/zipline/Zipline;)Lapp/cash/redwood/treehouse/AppService;
 	public fun getFreshnessChecker ()Lapp/cash/zipline/loader/FreshnessChecker;
 	public fun getLoadCodeFromNetworkOnly ()Z

--- a/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
@@ -100,7 +100,7 @@ public abstract interface class app/cash/redwood/treehouse/TreehouseApp$Factory 
 
 public abstract class app/cash/redwood/treehouse/TreehouseApp$Spec {
 	public fun <init> ()V
-	public abstract fun bindServices (Lapp/cash/zipline/Zipline;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bindServices (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/zipline/Zipline;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun create (Lapp/cash/zipline/Zipline;)Lapp/cash/redwood/treehouse/AppService;
 	public fun getFreshnessChecker ()Lapp/cash/zipline/loader/FreshnessChecker;
 	public fun getLoadCodeFromNetworkOnly ()Z

--- a/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
+++ b/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
@@ -99,7 +99,7 @@ abstract class <#A: app.cash.redwood.treehouse/AppService> app.cash.redwood.tree
             open fun <get-serializersModule>(): kotlinx.serialization.modules/SerializersModule // app.cash.redwood.treehouse/TreehouseApp.Spec.serializersModule.<get-serializersModule>|<get-serializersModule>(){}[0]
 
         abstract fun create(app.cash.zipline/Zipline): #A1 // app.cash.redwood.treehouse/TreehouseApp.Spec.create|create(app.cash.zipline.Zipline){}[0]
-        abstract suspend fun bindServices(app.cash.zipline/Zipline) // app.cash.redwood.treehouse/TreehouseApp.Spec.bindServices|bindServices(app.cash.zipline.Zipline){}[0]
+        abstract suspend fun bindServices(app.cash.redwood.treehouse/TreehouseApp<#A1>, app.cash.zipline/Zipline) // app.cash.redwood.treehouse/TreehouseApp.Spec.bindServices|bindServices(app.cash.redwood.treehouse.TreehouseApp<1:0>;app.cash.zipline.Zipline){}[0]
     }
 }
 

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTester.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTester.kt
@@ -109,7 +109,10 @@ internal class TreehouseTester(
     override val loadCodeFromNetworkOnly: Boolean
       get() = true
 
-    override suspend fun bindServices(zipline: Zipline) {
+    override suspend fun bindServices(
+      treehouseApp: TreehouseApp<TestAppPresenter>,
+      zipline: Zipline,
+    ) {
       zipline.bind("HostApi", hostApi)
     }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -138,7 +138,7 @@ internal class RealTreehouseApp<A : AppService> private constructor(
       serializersModule = spec.serializersModule,
       freshnessChecker = spec.freshnessChecker,
     ) { zipline ->
-      spec.bindServices(zipline)
+      spec.bindServices(this, zipline)
     }
   }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -148,7 +148,14 @@ public abstract class TreehouseApp<A : AppService> : AutoCloseable {
     public open val loadCodeFromNetworkOnly: Boolean
       get() = false
 
-    public abstract suspend fun bindServices(zipline: Zipline)
+    /**
+     * Make services available to guest application on [zipline], typically by making one or more
+     * calls to [Zipline.bind].
+     */
+    public abstract suspend fun bindServices(
+      treehouseApp: TreehouseApp<A>,
+      zipline: Zipline,
+    )
 
     public abstract fun create(zipline: Zipline): A
   }

--- a/samples/emoji-search/launcher/src/commonMain/kotlin/com/example/redwood/emojisearch/launcher/EmojiSearchAppSpec.kt
+++ b/samples/emoji-search/launcher/src/commonMain/kotlin/com/example/redwood/emojisearch/launcher/EmojiSearchAppSpec.kt
@@ -35,7 +35,10 @@ class EmojiSearchAppSpec(
     override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long) = true
   }
 
-  override suspend fun bindServices(zipline: Zipline) {
+  override suspend fun bindServices(
+    treehouseApp: TreehouseApp<EmojiSearchPresenter>,
+    zipline: Zipline,
+  ) {
     zipline.bind<HostApi>("HostApi", hostApi)
   }
 

--- a/test-app/launcher/src/commonMain/kotlin/com/example/redwood/testapp/launcher/TestAppSpec.kt
+++ b/test-app/launcher/src/commonMain/kotlin/com/example/redwood/testapp/launcher/TestAppSpec.kt
@@ -33,7 +33,10 @@ class TestAppSpec(
     override fun isFresh(manifest: ZiplineManifest, freshAtEpochMs: Long) = true
   }
 
-  override suspend fun bindServices(zipline: Zipline) {
+  override suspend fun bindServices(
+    treehouseApp: TreehouseApp<TestAppPresenter>,
+    zipline: Zipline,
+  ) {
     zipline.bind<HostApi>("HostApi", hostApi)
   }
 


### PR DESCRIPTION
Now that we've got different dispatchers per app, I expect it'll be helpful to have those dispatchers available when binding services.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
