### PR TITLE
Make FIR type parsing more robust

### DIFF
--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/FqType.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/FqType.kt
@@ -127,7 +127,11 @@ public data class FqType(
   }
 }
 
-internal fun KClass<*>.toFqType(): FqType {
+internal fun KClass<*>.toFqType(
+  vararg parameterTypes: FqType,
+  variance: FqType.Variance = Invariant,
+  nullable: Boolean = false,
+): FqType {
   // We only parse public API declarations on which it should be impossible to use
   // function-local classes or anonymous classes.
   var qualifiedName = qualifiedName ?: throw AssertionError(this)
@@ -178,7 +182,7 @@ internal fun KClass<*>.toFqType(): FqType {
     }
   }
 
-  return FqType(names)
+  return FqType(names, variance, parameterTypes.toList(), nullable)
 }
 
 internal fun KType.toFqType(): FqType {
@@ -192,10 +196,10 @@ internal fun KType.toFqType(): FqType {
 }
 
 private fun KTypeProjection.toFqType(): FqType {
-  val json = type?.toFqType() ?: FqType.Star
+  val fqType = type?.toFqType() ?: FqType.Star
   return when (variance) {
-    null, INVARIANT -> json
-    IN -> json.copy(variance = In)
-    OUT -> json.copy(variance = Out)
+    null, INVARIANT -> fqType
+    IN -> fqType.copy(variance = In)
+    OUT -> fqType.copy(variance = Out)
   }
 }

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
@@ -328,8 +328,8 @@ private fun parseWidget(
         if (type.annotations.any(ExtensionFunctionType::class::isInstance)) {
           val receiverType = type.arguments.first().type
           val receiverClassifier = receiverType?.classifier
-          require(receiverClassifier is KClass<*> && receiverType.arguments.isEmpty()) {
-            "@Children ${memberType.qualifiedName}#$name lambda receiver can only be a class. Found: $receiverType"
+          require(receiverClassifier is KClass<*> && receiverType.arguments.isEmpty() && !receiverType.isMarkedNullable) {
+            "@Children ${memberType.qualifiedName}#$name lambda receiver can only be a non-null class. Found: $receiverType"
           }
           scope = receiverClassifier.toFqType()
           arguments = arguments.drop(1)


### PR DESCRIPTION
Do not use `bestGuess` when we can properly iterate the type hierarchy and extract what we need without ambiguity.

Refs #19

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
