### PR TITLE
Deduplicate schema dependency loading

### DIFF
--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
@@ -190,24 +190,7 @@ public fun parseProtocolSchema(
   disposable.dispose()
 
   val dependencyClassLoader = URLClassLoader(dependencies.map { it.toURI().toURL() }.toTypedArray())
-  val dependencySchemas = schema.taggedDependencies.entries
-    .associate { (dependencyTag, dependencyType) ->
-      require(dependencyTag != 0) {
-        "Dependency $dependencyType tag must not be non-zero"
-      }
-
-      val dependency = loadProtocolSchema(
-        type = dependencyType,
-        classLoader = dependencyClassLoader,
-        tag = dependencyTag,
-      )
-      dependencyTag to dependency
-    }
-
-  val schemaSet = ParsedProtocolSchemaSet(
-    schema,
-    dependencySchemas.values.associateBy { it.type },
-  )
+  val schemaSet = loadProtocolSchemaDependencies(schema, dependencyClassLoader)
 
   val duplicatedWidgets = schemaSet.all
     .flatMap { it.widgets.map { widget -> widget to it } }

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -947,7 +947,7 @@ class SchemaParserTest(
     assertFailure { parser.parse(SchemaDependencyTagZero::class) }
       .isInstanceOf<IllegalArgumentException>()
       .hasMessage(
-        "Dependency app.cash.redwood.layout.RedwoodLayout tag must not be non-zero",
+        "Dependency app.cash.redwood.layout.RedwoodLayout tag must be non-zero",
       )
   }
 


### PR DESCRIPTION
We need to support this in both JSON-based and FIR-based loading, so extract a common function for the logic.

Refs #19

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
