### PR TITLE
Bump leak detector timeouts

### DIFF
--- a/redwood-leak-detector/build.gradle
+++ b/redwood-leak-detector/build.gradle
@@ -10,8 +10,8 @@ kotlin {
     nodejs {
       testTask {
         useMocha {
-          // We use up to 10s of wall clock time to test leaks.
-          timeout = '15s'
+          // We use up to 10s of wall clock time to test leaks. Add extra time for slow CI machines.
+          timeout = '30s'
           // Required for access to V8 GC function.
           nodeJsArgs.add('--expose-gc')
         }


### PR DESCRIPTION
CI machines are slower and sometimes take longer than 15s to run the stress tests.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
