### PR TITLE
Revert "Remove Wasm JS support (#2207)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New:
 - Nothing yet!
 
 Changed:
-- Removed Wasm JS targets for common Redwood modules. They are causing CI problems, and we're not ready for Wasm anyway.
+- Nothing yet!
 
 Fixed:
 - Nothing yet!

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -302,6 +302,7 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
           iosTargets()
           modifiedGroup[JsTests, NodeJs].applyTo(js())
           jvm()
+          wasmJs().nodejs()
         }
         // Needed for lint in downstream Android projects to analyze this dependency.
         project.plugins.apply("com.android.lint")
@@ -313,6 +314,7 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
           iosTargets()
           modifiedGroup[JsTests, NodeJs].applyTo(js())
           jvm()
+          wasmJs().nodejs()
         }
       }
       Tooling -> {

--- a/redwood-compose/api/redwood-compose.klib.api
+++ b/redwood-compose/api/redwood-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Alias: ios => [iosArm64, iosSimulatorArm64, iosX64]
 // Rendering settings:
 // - Signature version: 2

--- a/redwood-layout-api/api/redwood-layout-api.klib.api
+++ b/redwood-layout-api/api/redwood-layout-api.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-layout-compose/api/redwood-layout-compose.klib.api
+++ b/redwood-layout-compose/api/redwood-layout-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-layout-modifiers/api/redwood-layout-modifiers.klib.api
+++ b/redwood-layout-modifiers/api/redwood-layout-modifiers.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-layout-testing/api/redwood-layout-testing.klib.api
+++ b/redwood-layout-testing/api/redwood-layout-testing.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-layout-widget/api/redwood-layout-widget.klib.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-lazylayout-api/api/redwood-lazylayout-api.klib.api
+++ b/redwood-lazylayout-api/api/redwood-lazylayout-api.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-lazylayout-compose/api/redwood-lazylayout-compose.klib.api
+++ b/redwood-lazylayout-compose/api/redwood-lazylayout-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-lazylayout-testing/api/redwood-lazylayout-testing.klib.api
+++ b/redwood-lazylayout-testing/api/redwood-lazylayout-testing.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-leak-detector/api/redwood-leak-detector.klib.api
+++ b/redwood-leak-detector/api/redwood-leak-detector.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-leak-detector/build.gradle
+++ b/redwood-leak-detector/build.gradle
@@ -18,6 +18,18 @@ kotlin {
       }
     }
   }
+  wasmJs {
+    nodejs {
+      testTask {
+        useMocha {
+          // We use up to 10s of wall clock time to test leaks.
+          timeout = '15s'
+          // Required for access to V8 GC function.
+          nodeJsArgs.add('--expose-gc')
+        }
+      }
+    }
+  }
 
   sourceSets {
     commonMain {

--- a/redwood-leak-detector/src/wasmJsMain/kotlin/app/cash/redwood/leaks/ConcurrentMutableList.kt
+++ b/redwood-leak-detector/src/wasmJsMain/kotlin/app/cash/redwood/leaks/ConcurrentMutableList.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("NOTHING_TO_INLINE")
+
+package app.cash.redwood.leaks
+
+internal actual typealias ConcurrentMutableList<T> = ArrayList<T>
+
+internal actual inline fun <T> concurrentMutableListOf(): ConcurrentMutableList<T> {
+  return arrayListOf()
+}
+
+internal actual inline operator fun <T> ConcurrentMutableList<T>.plusAssign(element: T) {
+  add(element)
+}
+
+internal actual inline fun <T> ConcurrentMutableList<T>.removeIf(predicate: (element: T) -> Boolean) {
+  var i = 0
+  while (i < size) {
+    if (predicate(get(i))) {
+      removeAt(i)
+    } else {
+      i++
+    }
+  }
+}

--- a/redwood-leak-detector/src/wasmJsMain/kotlin/app/cash/redwood/leaks/Gc.kt
+++ b/redwood-leak-detector/src/wasmJsMain/kotlin/app/cash/redwood/leaks/Gc.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.leaks
+
+private external val globalThis: GlobalThis
+
+private external class GlobalThis {
+  fun hasOwnProperty(name: String): Boolean
+  fun gc()
+}
+
+internal actual fun detectGc(): Gc {
+  if (globalThis.hasOwnProperty("gc")) {
+    return GlobalThisGc()
+  }
+  return Gc.None
+}
+
+private class GlobalThisGc : Gc {
+  override suspend fun collect() {
+    globalThis.gc()
+  }
+}

--- a/redwood-leak-detector/src/wasmJsMain/kotlin/app/cash/redwood/leaks/WeakReference.kt
+++ b/redwood-leak-detector/src/wasmJsMain/kotlin/app/cash/redwood/leaks/WeakReference.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("NOTHING_TO_INLINE")
+
+package app.cash.redwood.leaks
+
+internal actual inline fun hasWeakReference(): Boolean {
+  return true
+}
+
+internal actual class WeakReference<T : Any>
+private constructor(
+  private val real: WeakRef<JsReference<T>>,
+) {
+  actual constructor(referred: T) : this(WeakRef(referred.toJsReference()))
+
+  actual fun get(): T? {
+    return real.deref()?.get()
+  }
+}
+
+private external class WeakRef<T : JsAny>(reference: T) {
+  fun deref(): T?
+}

--- a/redwood-leak-detector/src/wasmJsTest/kotlin/app/cash/redwood/leaks/delayForGc.kt
+++ b/redwood-leak-detector/src/wasmJsTest/kotlin/app/cash/redwood/leaks/delayForGc.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.leaks
+
+import kotlin.time.Duration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+internal actual suspend fun delayForGc(duration: Duration) {
+  // Force a wall clock delay for JS Gc.
+  withContext(Dispatchers.Default) {
+    delay(duration)
+  }
+}

--- a/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-protocol/api/redwood-protocol.klib.api
+++ b/redwood-protocol/api/redwood-protocol.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-runtime/api/redwood-runtime.klib.api
+++ b/redwood-runtime/api/redwood-runtime.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Alias: ios => [iosArm64, iosSimulatorArm64, iosX64]
 // Rendering settings:
 // - Signature version: 2

--- a/redwood-runtime/src/wasmJsMain/kotlin/app/cash/redwood/ui/density.kt
+++ b/redwood-runtime/src/wasmJsMain/kotlin/app/cash/redwood/ui/density.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.ui
+
+internal actual const val DENSITY_MULTIPLIER = 1.0

--- a/redwood-testing/api/redwood-testing.klib.api
+++ b/redwood-testing/api/redwood-testing.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-widget-compose/api/redwood-widget-compose.klib.api
+++ b/redwood-widget-compose/api/redwood-widget-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-widget-testing/api/redwood-widget-testing.klib.api
+++ b/redwood-widget-testing/api/redwood-widget-testing.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/redwood-widget/api/redwood-widget.klib.api
+++ b/redwood-widget/api/redwood-widget.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
 // Alias: ios => [iosArm64, iosSimulatorArm64, iosX64]
 // Rendering settings:
 // - Signature version: 2


### PR DESCRIPTION
This reverts commit 3bc9242a9543f2131225d6bde5a9c09860c0c4bf. I thought it had a bug, but it was just #2210 manifesting and failing Wasm first.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
