### PR TITLE
Seal the protocol factory interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New:
 - Source-based schema parser is now the default. Can be disabled in your schema module with `redwood { useFir = false }`.
 
 Changed:
-- Nothing yet!
+- `ProtocolFactory` interface is now sealed as arbitrary subtypes were never supported. Only schema-generated subtypes should be used.
 
 Fixed:
 - Nothing yet!

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -12,11 +12,6 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/GeneratedProt
     abstract fun widgetChildren(app.cash.redwood.protocol/WidgetTag): kotlin.collections/List<app.cash.redwood.protocol/ChildrenTag> // app.cash.redwood.protocol.host/GeneratedProtocolFactory.widgetChildren|widgetChildren(app.cash.redwood.protocol.WidgetTag){}[0]
 }
 
-abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolFactory { // app.cash.redwood.protocol.host/ProtocolFactory|null[0]
-    abstract val widgetSystem // app.cash.redwood.protocol.host/ProtocolFactory.widgetSystem|{}widgetSystem[0]
-        abstract fun <get-widgetSystem>(): app.cash.redwood.widget/WidgetSystem<#A> // app.cash.redwood.protocol.host/ProtocolFactory.widgetSystem.<get-widgetSystem>|<get-widgetSystem>(){}[0]
-}
-
 abstract interface app.cash.redwood.protocol.host/ProtocolMismatchHandler { // app.cash.redwood.protocol.host/ProtocolMismatchHandler|null[0]
     abstract fun onUnknownChildren(app.cash.redwood.protocol/WidgetTag, app.cash.redwood.protocol/ChildrenTag) // app.cash.redwood.protocol.host/ProtocolMismatchHandler.onUnknownChildren|onUnknownChildren(app.cash.redwood.protocol.WidgetTag;app.cash.redwood.protocol.ChildrenTag){}[0]
     abstract fun onUnknownModifier(app.cash.redwood.protocol/ModifierTag) // app.cash.redwood.protocol.host/ProtocolMismatchHandler.onUnknownModifier|onUnknownModifier(app.cash.redwood.protocol.ModifierTag){}[0]
@@ -27,6 +22,11 @@ abstract interface app.cash.redwood.protocol.host/ProtocolMismatchHandler { // a
         final val Throwing // app.cash.redwood.protocol.host/ProtocolMismatchHandler.Companion.Throwing|{}Throwing[0]
             final fun <get-Throwing>(): app.cash.redwood.protocol.host/ProtocolMismatchHandler // app.cash.redwood.protocol.host/ProtocolMismatchHandler.Companion.Throwing.<get-Throwing>|<get-Throwing>(){}[0]
     }
+}
+
+sealed interface <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolFactory { // app.cash.redwood.protocol.host/ProtocolFactory|null[0]
+    abstract val widgetSystem // app.cash.redwood.protocol.host/ProtocolFactory.widgetSystem|{}widgetSystem[0]
+        abstract fun <get-widgetSystem>(): app.cash.redwood.widget/WidgetSystem<#A> // app.cash.redwood.protocol.host/ProtocolFactory.widgetSystem.<get-widgetSystem>|<get-widgetSystem>(){}[0]
 }
 
 abstract class <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolNode { // app.cash.redwood.protocol.host/ProtocolNode|null[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
@@ -30,7 +30,7 @@ import kotlin.native.ObjCName
  * @see HostProtocolAdapter
  */
 @ObjCName("ProtocolFactory", exact = true)
-public interface ProtocolFactory<W : Any> {
+public sealed interface ProtocolFactory<W : Any> {
   public val widgetSystem: WidgetSystem<W>
 }
 


### PR DESCRIPTION
The only subtype should be the generated interface which is itself open to new subtypes.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
