### PR TITLE
Rename firstIndex to firstVisibleIndex, add lastVisibleIndex

### DIFF
--- a/redwood-lazylayout-compose/api/redwood-lazylayout-compose.api
+++ b/redwood-lazylayout-compose/api/redwood-lazylayout-compose.api
@@ -39,7 +39,8 @@ public final class app/cash/redwood/lazylayout/compose/LazyListStateKt {
 }
 
 public abstract interface class app/cash/redwood/lazylayout/compose/LoadingStrategy {
-	public abstract fun getFirstIndex ()I
+	public abstract fun getFirstVisibleIndex ()I
+	public abstract fun getLastVisibleIndex ()I
 	public abstract fun loadRange (I)Lkotlin/ranges/IntRange;
 	public abstract fun onUserScroll (II)V
 	public abstract fun scrollTo (I)V
@@ -54,8 +55,8 @@ public final class app/cash/redwood/lazylayout/compose/ScrollOptimizedLoadingStr
 	public fun <init> ()V
 	public fun <init> (IIII)V
 	public synthetic fun <init> (IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getFirstIndex ()I
-	public final fun getLastIndex ()I
+	public fun getFirstVisibleIndex ()I
+	public fun getLastVisibleIndex ()I
 	public final fun getProgrammaticScrollIndex ()Lapp/cash/redwood/lazylayout/api/ScrollItemIndex;
 	public fun loadRange (I)Lkotlin/ranges/IntRange;
 	public fun onUserScroll (II)V

--- a/redwood-lazylayout-compose/api/redwood-lazylayout-compose.klib.api
+++ b/redwood-lazylayout-compose/api/redwood-lazylayout-compose.klib.api
@@ -16,8 +16,10 @@ abstract interface app.cash.redwood.lazylayout.compose/LazyListScope { // app.ca
 }
 
 abstract interface app.cash.redwood.lazylayout.compose/LoadingStrategy { // app.cash.redwood.lazylayout.compose/LoadingStrategy|null[0]
-    abstract val firstIndex // app.cash.redwood.lazylayout.compose/LoadingStrategy.firstIndex|{}firstIndex[0]
-        abstract fun <get-firstIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/LoadingStrategy.firstIndex.<get-firstIndex>|<get-firstIndex>(){}[0]
+    abstract val firstVisibleIndex // app.cash.redwood.lazylayout.compose/LoadingStrategy.firstVisibleIndex|{}firstVisibleIndex[0]
+        abstract fun <get-firstVisibleIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/LoadingStrategy.firstVisibleIndex.<get-firstVisibleIndex>|<get-firstVisibleIndex>(){}[0]
+    abstract val lastVisibleIndex // app.cash.redwood.lazylayout.compose/LoadingStrategy.lastVisibleIndex|{}lastVisibleIndex[0]
+        abstract fun <get-lastVisibleIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/LoadingStrategy.lastVisibleIndex.<get-lastVisibleIndex>|<get-lastVisibleIndex>(){}[0]
 
     abstract fun loadRange(kotlin/Int): kotlin.ranges/IntRange // app.cash.redwood.lazylayout.compose/LoadingStrategy.loadRange|loadRange(kotlin.Int){}[0]
     abstract fun onUserScroll(kotlin/Int, kotlin/Int) // app.cash.redwood.lazylayout.compose/LoadingStrategy.onUserScroll|onUserScroll(kotlin.Int;kotlin.Int){}[0]
@@ -27,10 +29,10 @@ abstract interface app.cash.redwood.lazylayout.compose/LoadingStrategy { // app.
 final class app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy : app.cash.redwood.lazylayout.compose/LoadingStrategy { // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy|null[0]
     constructor <init>(kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ...) // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
 
-    final var firstIndex // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.firstIndex|{}firstIndex[0]
-        final fun <get-firstIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.firstIndex.<get-firstIndex>|<get-firstIndex>(){}[0]
-    final var lastIndex // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.lastIndex|{}lastIndex[0]
-        final fun <get-lastIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.lastIndex.<get-lastIndex>|<get-lastIndex>(){}[0]
+    final var firstVisibleIndex // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.firstVisibleIndex|{}firstVisibleIndex[0]
+        final fun <get-firstVisibleIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.firstVisibleIndex.<get-firstVisibleIndex>|<get-firstVisibleIndex>(){}[0]
+    final var lastVisibleIndex // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.lastVisibleIndex|{}lastVisibleIndex[0]
+        final fun <get-lastVisibleIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.lastVisibleIndex.<get-lastVisibleIndex>|<get-lastVisibleIndex>(){}[0]
     final var programmaticScrollIndex // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.programmaticScrollIndex|{}programmaticScrollIndex[0]
         final fun <get-programmaticScrollIndex>(): app.cash.redwood.lazylayout.api/ScrollItemIndex // app.cash.redwood.lazylayout.compose/ScrollOptimizedLoadingStrategy.programmaticScrollIndex.<get-programmaticScrollIndex>|<get-programmaticScrollIndex>(){}[0]
 

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LazyListState.kt
@@ -37,7 +37,7 @@ public fun rememberLazyListState(
 
 /** The default [Saver] implementation for [LazyListState]. */
 private val saver: Saver<LazyListState, *> = Saver(
-  save = { it.strategy.firstIndex },
+  save = { it.strategy.firstVisibleIndex },
   restore = {
     LazyListState().apply {
       programmaticScroll(firstIndex = it, animated = false, clobberUserScroll = false)

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LoadingStrategy.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/LoadingStrategy.kt
@@ -17,16 +17,30 @@ package app.cash.redwood.lazylayout.compose
 
 public interface LoadingStrategy {
   /**
-   * Returns the most recent first index scrolled to. This is used to save the scroll position when
-   * the view is unloaded.
+   * Returns the index of the first item that is visible on screen. The item may be partially
+   * visible.
+   *
+   * This is used to save the scroll position when the view is unloaded.
+   *
+   * This may temporarily be larger than the total number of items in the model. This will occur if
+   * the number of items in the model shrinks.
    */
-  public val firstIndex: Int
+  public val firstVisibleIndex: Int
 
-  /** Perform a programmatic scroll to [firstIndex]. */
-  public fun scrollTo(firstIndex: Int)
+  /**
+   * Returns the index of the last item that is visible on screen. The item may be partially
+   * visible.
+   *
+   * This may temporarily be larger than the total number of items in the model. This will occur if
+   * the number of items in the model shrinks.
+   */
+  public val lastVisibleIndex: Int
+
+  /** Perform a programmatic scroll to [firstVisibleIndex]. */
+  public fun scrollTo(firstVisibleIndex: Int)
 
   /** React to a user-initiated scroll to the target range. */
-  public fun onUserScroll(firstIndex: Int, lastIndex: Int)
+  public fun onUserScroll(firstVisibleIndex: Int, lastVisibleIndex: Int)
 
   /**
    * Returns the range of items to render into the view tree. This should be a slice of

--- a/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/ScrollOptimizedLoadingStrategy.kt
+++ b/redwood-lazylayout-compose/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/ScrollOptimizedLoadingStrategy.kt
@@ -53,9 +53,9 @@ public class ScrollOptimizedLoadingStrategy(
     private set
 
   /** Bounds of what the user is looking at. Everything else is placeholders! */
-  public override var firstIndex: Int by mutableIntStateOf(0)
+  public override var firstVisibleIndex: Int by mutableIntStateOf(0)
     private set
-  public var lastIndex: Int by mutableIntStateOf(0)
+  public override var lastVisibleIndex: Int by mutableIntStateOf(0)
     private set
 
   private var firstIndexFromPrevious1: Int by mutableIntStateOf(DEFAULT_SCROLL_INDEX)
@@ -65,27 +65,27 @@ public class ScrollOptimizedLoadingStrategy(
   private var beginFromPrevious1: Int by mutableIntStateOf(DEFAULT_SCROLL_INDEX)
   private var endFromPrevious1: Int by mutableStateOf(DEFAULT_SCROLL_INDEX)
 
-  override fun scrollTo(firstIndex: Int) {
-    require(firstIndex >= 0)
+  override fun scrollTo(firstVisibleIndex: Int) {
+    require(firstVisibleIndex >= 0)
 
-    val delta = (lastIndex - this.firstIndex)
-    this.firstIndex = firstIndex
-    this.lastIndex = firstIndex + delta
+    val delta = (lastVisibleIndex - this.firstVisibleIndex)
+    this.firstVisibleIndex = firstVisibleIndex
+    this.lastVisibleIndex = firstVisibleIndex + delta
   }
 
-  override fun onUserScroll(firstIndex: Int, lastIndex: Int) {
-    this.firstIndex = firstIndex
-    this.lastIndex = lastIndex
+  override fun onUserScroll(firstVisibleIndex: Int, lastVisibleIndex: Int) {
+    this.firstVisibleIndex = firstVisibleIndex
+    this.lastVisibleIndex = lastVisibleIndex
   }
 
   public override fun loadRange(itemCount: Int): IntRange {
     // Ensure that the range includes `firstIndex` through `lastIndex`.
-    var begin = firstIndex
-    var end = lastIndex
+    var begin = firstVisibleIndex
+    var end = lastVisibleIndex
 
-    val isScrollingDown = firstIndexFromPrevious1 != DEFAULT_SCROLL_INDEX && firstIndexFromPrevious1 < firstIndex
-    val isScrollingUp = firstIndexFromPrevious1 != DEFAULT_SCROLL_INDEX && firstIndexFromPrevious1 > firstIndex
-    val hasStoppedScrolling = firstIndexFromPrevious2 != DEFAULT_SCROLL_INDEX && firstIndex == firstIndexFromPrevious1
+    val isScrollingDown = firstIndexFromPrevious1 != DEFAULT_SCROLL_INDEX && firstIndexFromPrevious1 < firstVisibleIndex
+    val isScrollingUp = firstIndexFromPrevious1 != DEFAULT_SCROLL_INDEX && firstIndexFromPrevious1 > firstVisibleIndex
+    val hasStoppedScrolling = firstIndexFromPrevious2 != DEFAULT_SCROLL_INDEX && firstVisibleIndex == firstIndexFromPrevious1
     val wasScrollingDown = firstIndexFromPrevious1 > firstIndexFromPrevious2
     val wasScrollingUp = firstIndexFromPrevious1 < firstIndexFromPrevious2
 
@@ -118,8 +118,8 @@ public class ScrollOptimizedLoadingStrategy(
     }
 
     // On initial load, set lastIndex to the end of the loaded window.
-    if (lastIndex == 0) {
-      lastIndex = end
+    if (lastVisibleIndex == 0) {
+      lastVisibleIndex = end
     }
 
     // If we're contiguous with the previous visible window,
@@ -142,8 +142,8 @@ public class ScrollOptimizedLoadingStrategy(
     end = end.coerceIn(0, itemCount)
 
     this.firstIndexFromPrevious2 = firstIndexFromPrevious1
-    this.firstIndexFromPrevious1 = firstIndex
-    this.lastIndexFromPrevious1 = lastIndex
+    this.firstIndexFromPrevious1 = firstVisibleIndex
+    this.lastIndexFromPrevious1 = lastVisibleIndex
 
     this.beginFromPrevious1 = begin
     this.endFromPrevious1 = end

--- a/redwood-lazylayout-testing/api/redwood-lazylayout-testing.api
+++ b/redwood-lazylayout-testing/api/redwood-lazylayout-testing.api
@@ -1,6 +1,7 @@
 public final class app/cash/redwood/lazylayout/compose/TestLoadingStrategy : app/cash/redwood/lazylayout/compose/LoadingStrategy {
 	public fun <init> ()V
-	public fun getFirstIndex ()I
+	public fun getFirstVisibleIndex ()I
+	public fun getLastVisibleIndex ()I
 	public fun loadRange (I)Lkotlin/ranges/IntRange;
 	public fun onUserScroll (II)V
 	public fun scrollTo (I)V

--- a/redwood-lazylayout-testing/api/redwood-lazylayout-testing.klib.api
+++ b/redwood-lazylayout-testing/api/redwood-lazylayout-testing.klib.api
@@ -9,8 +9,10 @@
 final class app.cash.redwood.lazylayout.compose/TestLoadingStrategy : app.cash.redwood.lazylayout.compose/LoadingStrategy { // app.cash.redwood.lazylayout.compose/TestLoadingStrategy|null[0]
     constructor <init>() // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.<init>|<init>(){}[0]
 
-    final val firstIndex // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.firstIndex|{}firstIndex[0]
-        final fun <get-firstIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.firstIndex.<get-firstIndex>|<get-firstIndex>(){}[0]
+    final val firstVisibleIndex // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.firstVisibleIndex|{}firstVisibleIndex[0]
+        final fun <get-firstVisibleIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.firstVisibleIndex.<get-firstVisibleIndex>|<get-firstVisibleIndex>(){}[0]
+    final val lastVisibleIndex // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.lastVisibleIndex|{}lastVisibleIndex[0]
+        final fun <get-lastVisibleIndex>(): kotlin/Int // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.lastVisibleIndex.<get-lastVisibleIndex>|<get-lastVisibleIndex>(){}[0]
 
     final fun loadRange(kotlin/Int): kotlin.ranges/IntRange // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.loadRange|loadRange(kotlin.Int){}[0]
     final fun onUserScroll(kotlin/Int, kotlin/Int) // app.cash.redwood.lazylayout.compose/TestLoadingStrategy.onUserScroll|onUserScroll(kotlin.Int;kotlin.Int){}[0]

--- a/redwood-lazylayout-testing/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/TestLoadingStrategy.kt
+++ b/redwood-lazylayout-testing/src/commonMain/kotlin/app/cash/redwood/lazylayout/compose/TestLoadingStrategy.kt
@@ -28,16 +28,19 @@ import androidx.compose.runtime.setValue
 public class TestLoadingStrategy : LoadingStrategy {
   private var loadRange: IntRange by mutableStateOf(0..0)
 
-  public override val firstIndex: Int
+  public override val firstVisibleIndex: Int
     get() = loadRange.first
 
-  override fun scrollTo(firstIndex: Int) {
-    require(firstIndex >= 0)
-    loadRange = firstIndex..firstIndex + (loadRange.last - loadRange.first)
+  public override val lastVisibleIndex: Int
+    get() = loadRange.last
+
+  override fun scrollTo(firstVisibleIndex: Int) {
+    require(firstVisibleIndex >= 0)
+    loadRange = firstVisibleIndex..firstVisibleIndex + (loadRange.last - loadRange.first)
   }
 
-  override fun onUserScroll(firstIndex: Int, lastIndex: Int) {
-    loadRange = firstIndex..lastIndex
+  override fun onUserScroll(firstVisibleIndex: Int, lastVisibleIndex: Int) {
+    loadRange = firstVisibleIndex..lastVisibleIndex
   }
 
   override fun loadRange(itemCount: Int): IntRange =


### PR DESCRIPTION
I'm using longer names to disambiguate two related ranges:
 - the visible range
 - the loaded range

