### PR TITLE
Add a quick mechanism to walk widget children

### DIFF
--- a/redwood-layout-widget/api/redwood-layout-widget.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.api
@@ -44,9 +44,14 @@ public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwne
 }
 
 public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
+	public static final field Companion Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem$Companion;
 	public fun <init> (Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;)V
 	public fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 	public fun getRedwoodLayout ()Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;
+}
+
+public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem$Companion {
+	public final fun allChildren (Lapp/cash/redwood/widget/Widget;)Ljava/util/List;
 }
 
 public abstract interface class app/cash/redwood/layout/widget/Row : app/cash/redwood/widget/Widget {

--- a/redwood-layout-widget/api/redwood-layout-widget.klib.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.klib.api
@@ -80,4 +80,8 @@ final class <#A: kotlin/Any> app.cash.redwood.layout.widget/RedwoodLayoutWidgetS
         final fun <get-RedwoodLayout>(): app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactory<#A> // app.cash.redwood.layout.widget/RedwoodLayoutWidgetSystem.RedwoodLayout.<get-RedwoodLayout>|<get-RedwoodLayout>(){}[0]
 
     final fun apply(#A, app.cash.redwood/Modifier.UnscopedElement) // app.cash.redwood.layout.widget/RedwoodLayoutWidgetSystem.apply|apply(1:0;app.cash.redwood.Modifier.UnscopedElement){}[0]
+
+    final object Companion { // app.cash.redwood.layout.widget/RedwoodLayoutWidgetSystem.Companion|null[0]
+        final fun <#A2: kotlin/Any> allChildren(app.cash.redwood.widget/Widget<#A2>): kotlin.collections/List<app.cash.redwood.widget/Widget<#A2>> // app.cash.redwood.layout.widget/RedwoodLayoutWidgetSystem.Companion.allChildren|allChildren(app.cash.redwood.widget.Widget<0:0>){0§<kotlin.Any>}[0]
+    }
 }

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -62,9 +62,14 @@ public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFac
 }
 
 public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSystem : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
+	public static final field Companion Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSystem$Companion;
 	public fun <init> (Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;)V
 	public fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 	public fun getRedwoodLazyLayout ()Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;
+}
+
+public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSystem$Companion {
+	public final fun allChildren (Lapp/cash/redwood/widget/Widget;)Ljava/util/List;
 }
 
 public abstract interface class app/cash/redwood/lazylayout/widget/RefreshableLazyList : app/cash/redwood/widget/Widget {

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -110,4 +110,8 @@ final class <#A: kotlin/Any> app.cash.redwood.lazylayout.widget/RedwoodLazyLayou
         final fun <get-RedwoodLazyLayout>(): app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactory<#A> // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetSystem.RedwoodLazyLayout.<get-RedwoodLazyLayout>|<get-RedwoodLazyLayout>(){}[0]
 
     final fun apply(#A, app.cash.redwood/Modifier.UnscopedElement) // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetSystem.apply|apply(1:0;app.cash.redwood.Modifier.UnscopedElement){}[0]
+
+    final object Companion { // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetSystem.Companion|null[0]
+        final fun <#A2: kotlin/Any> allChildren(app.cash.redwood.widget/Widget<#A2>): kotlin.collections/List<app.cash.redwood.widget/Widget<#A2>> // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetSystem.Companion.allChildren|allChildren(app.cash.redwood.widget.Widget<0:0>){0§<kotlin.Any>}[0]
+    }
 }


### PR DESCRIPTION
This is not the final design, but it at least unblocks the use case.

I'm not adding it to the change log because this API shape will not last long.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
