### PR TITLE
Change UIViewLazyList so cells can be removed and re-added without reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New:
 
 Changed:
 - `ProtocolFactory` interface is now sealed as arbitrary subtypes were never supported. Only schema-generated subtypes should be used.
+- `UIViewLazyList` doesn't crash with a `NullPointerException` if cells are added, removed, and re-added without being reused.
 
 Fixed:
 - Nothing yet!

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -301,14 +301,13 @@ internal class LazyListContainerCell(
     }
 
     // Confirm the cell is bound when it's about to be displayed.
-    if (superview == null && newSuperview != null) {
-      require(binding!!.isBound) { "about to display a cell that isn't bound!" }
+    if (superview == null && newSuperview != null && !binding!!.isBound) {
+      binding!!.bind(this)
     }
 
     // Unbind the cell when its view is detached from the table.
     if (superview != null && newSuperview == null) {
       binding?.unbind()
-      binding = null
     }
   }
 

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -42,6 +42,7 @@ public abstract class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor
 }
 
 public final class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Binding {
+	public final fun bind (Ljava/lang/Object;)V
 	public final fun getView ()Ljava/lang/Object;
 	public final fun isBound ()Z
 	public final fun unbind ()V

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -87,6 +87,7 @@ abstract class <#A: kotlin/Any, #B: kotlin/Any> app.cash.redwood.lazylayout.widg
         final var view // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.view|{}view[0]
             final fun <get-view>(): #A1? // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.view.<get-view>|<get-view>(){}[0]
 
+        final fun bind(#A1) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.bind|bind(1:0){}[0]
         final fun unbind() // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.unbind|unbind(){}[0]
     }
 }


### PR DESCRIPTION
We observed in some test suites that table cells would observe a sequence of calls like this:

LazyListContainerCell.createView()
LazyListContainerCell.willMoveToSuperview(non-null) LazyListContainerCell.willMoveToSuperview(null)
LazyListContainerCell.willMoveToSuperview(non-null)

Note that we didn't receive a call to prepareForReuse() between the code being removed from its parent and added again. The code wasn't prepared for this sequence of calls.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
