### PR TITLE
Update node IDs when recycling widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changed:
 
 Fixed:
 - Breaking `content: UIView` retain cycle in `UIViewLazyList`'s `LazyListContainerCell`.
+- Update `ProtocolNode` widget IDs when recycling widgets. This was causing pooled nodes to be leaked.
 
 
 ## [0.13.0] - 2024-07-25

--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -41,6 +41,7 @@ public abstract class app/cash/redwood/protocol/host/ProtocolNode {
 	public final fun getId-0HhLjSo ()I
 	public abstract fun getWidget ()Lapp/cash/redwood/widget/Widget;
 	public final fun getWidgetTag-BlhN7y0 ()I
+	public final fun setId-ou3jOuA (I)V
 	public final fun updateModifier (Lapp/cash/redwood/Modifier;)V
 	public abstract fun visitIds (Lkotlin/jvm/functions/Function1;)V
 }

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -34,10 +34,12 @@ abstract class <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolNode { //
 
     abstract val widget // app.cash.redwood.protocol.host/ProtocolNode.widget|{}widget[0]
         abstract fun <get-widget>(): app.cash.redwood.widget/Widget<#A> // app.cash.redwood.protocol.host/ProtocolNode.widget.<get-widget>|<get-widget>(){}[0]
-    final val id // app.cash.redwood.protocol.host/ProtocolNode.id|{}id[0]
-        final fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.host/ProtocolNode.id.<get-id>|<get-id>(){}[0]
     final val widgetTag // app.cash.redwood.protocol.host/ProtocolNode.widgetTag|{}widgetTag[0]
         final fun <get-widgetTag>(): app.cash.redwood.protocol/WidgetTag // app.cash.redwood.protocol.host/ProtocolNode.widgetTag.<get-widgetTag>|<get-widgetTag>(){}[0]
+
+    final var id // app.cash.redwood.protocol.host/ProtocolNode.id|{}id[0]
+        final fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.host/ProtocolNode.id.<get-id>|<get-id>(){}[0]
+        final fun <set-id>(app.cash.redwood.protocol/Id) // app.cash.redwood.protocol.host/ProtocolNode.id.<set-id>|<set-id>(app.cash.redwood.protocol.Id){}[0]
 
     abstract fun apply(app.cash.redwood.protocol/PropertyChange, app.cash.redwood.protocol/EventSink) // app.cash.redwood.protocol.host/ProtocolNode.apply|apply(app.cash.redwood.protocol.PropertyChange;app.cash.redwood.protocol.EventSink){}[0]
     abstract fun children(app.cash.redwood.protocol/ChildrenTag): app.cash.redwood.protocol.host/ProtocolChildren<#A>? // app.cash.redwood.protocol.host/ProtocolNode.children|children(app.cash.redwood.protocol.ChildrenTag){}[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -353,6 +353,9 @@ public class HostProtocolAdapter<W : Any>(
         "Insert attempted to replace existing widget with ID $widgetId"
       }
 
+      val skippedCreate = changesAndNulls[changeIndexForCreate] as Create
+      pooled.id = skippedCreate.id
+
       // Remove the corresponding changes that we avoided by node reuse. We don't clear the 'Add'
       // that adds the node to its new parent.
       changesAndNulls[changeIndexForCreate] = null

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
@@ -33,7 +33,8 @@ import kotlin.math.min
  */
 @RedwoodCodegenApi
 public abstract class ProtocolNode<W : Any>(
-  public val id: Id,
+  /** Updated in place when a node is reused due to pooling. */
+  public var id: Id,
   public val widgetTag: WidgetTag,
 ) {
   public abstract val widget: Widget<W>


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
