### PR TITLE
Don't leak TreehouseApp.Spec after the app is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Fixed:
 - Breaking `content: UIView` retain cycle in `UIViewLazyList`'s `LazyListContainerCell`.
 - Update `ProtocolNode` widget IDs when recycling widgets. This was causing pooled nodes to be leaked.
 
+Breaking:
+- The `TreehouseApp.spec` property is removed. Most callers should be able to use `TreehouseApp.name` instead. This is necessary to avoid a retain cycle.
+
 
 ## [0.13.0] - 2024-07-25
 [0.13.0]: https://github.com/cashapp/redwood/releases/tag/0.13.0

--- a/redwood-treehouse-host/api/android/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/android/redwood-treehouse-host.api
@@ -85,7 +85,7 @@ public abstract class app/cash/redwood/treehouse/TreehouseApp : java/lang/AutoCl
 	public abstract fun createContent (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;)Lapp/cash/redwood/treehouse/Content;
 	public static synthetic fun createContent$default (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/Content;
 	public abstract fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
-	public abstract fun getSpec ()Lapp/cash/redwood/treehouse/TreehouseApp$Spec;
+	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getZipline ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun restart ()V
 	public abstract fun start ()V

--- a/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
@@ -85,7 +85,7 @@ public abstract class app/cash/redwood/treehouse/TreehouseApp : java/lang/AutoCl
 	public abstract fun createContent (Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;)Lapp/cash/redwood/treehouse/Content;
 	public static synthetic fun createContent$default (Lapp/cash/redwood/treehouse/TreehouseApp;Lapp/cash/redwood/treehouse/TreehouseContentSource;Lapp/cash/redwood/treehouse/CodeListener;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/Content;
 	public abstract fun getDispatchers ()Lapp/cash/redwood/treehouse/TreehouseDispatchers;
-	public abstract fun getSpec ()Lapp/cash/redwood/treehouse/TreehouseApp$Spec;
+	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getZipline ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun restart ()V
 	public abstract fun start ()V

--- a/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
+++ b/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
@@ -66,8 +66,8 @@ abstract class <#A: app.cash.redwood.treehouse/AppService> app.cash.redwood.tree
 
     abstract val dispatchers // app.cash.redwood.treehouse/TreehouseApp.dispatchers|{}dispatchers[0]
         abstract fun <get-dispatchers>(): app.cash.redwood.treehouse/TreehouseDispatchers // app.cash.redwood.treehouse/TreehouseApp.dispatchers.<get-dispatchers>|<get-dispatchers>(){}[0]
-    abstract val spec // app.cash.redwood.treehouse/TreehouseApp.spec|{}spec[0]
-        abstract fun <get-spec>(): app.cash.redwood.treehouse/TreehouseApp.Spec<#A> // app.cash.redwood.treehouse/TreehouseApp.spec.<get-spec>|<get-spec>(){}[0]
+    abstract val name // app.cash.redwood.treehouse/TreehouseApp.name|{}name[0]
+        abstract fun <get-name>(): kotlin/String // app.cash.redwood.treehouse/TreehouseApp.name.<get-name>|<get-name>(){}[0]
     abstract val zipline // app.cash.redwood.treehouse/TreehouseApp.zipline|{}zipline[0]
         abstract fun <get-zipline>(): kotlinx.coroutines.flow/StateFlow<app.cash.zipline/Zipline?> // app.cash.redwood.treehouse/TreehouseApp.zipline.<get-zipline>|<get-zipline>(){}[0]
 

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTester.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTester.kt
@@ -112,7 +112,7 @@ internal class TreehouseTester(
   val openTreehouseDispatchersCount: Int
     get() = returnedTreehouseDispatchers.count { !it.isClosed }
 
-  private val appSpec = object : TreehouseApp.Spec<TestAppPresenter>() {
+  var spec: TreehouseApp.Spec<TestAppPresenter> = object : TreehouseApp.Spec<TestAppPresenter>() {
     override val name: String
       get() = "test_app"
     override val manifestUrl: Flow<String>
@@ -135,7 +135,7 @@ internal class TreehouseTester(
   fun loadApp(): TreehouseApp<TestAppPresenter> {
     return treehouseAppFactory.create(
       appScope = testScope,
-      spec = appSpec,
+      spec = spec,
       eventListenerFactory = eventListenerFactory,
     )
   }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseApp.kt
@@ -46,7 +46,7 @@ import kotlinx.serialization.modules.SerializersModule
  */
 @ObjCName("TreehouseApp", exact = true)
 public abstract class TreehouseApp<A : AppService> : AutoCloseable {
-  public abstract val spec: Spec<A>
+  public abstract val name: String
   public abstract val dispatchers: TreehouseDispatchers
 
   /**

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeListener.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeListener.kt
@@ -19,14 +19,14 @@ class FakeCodeListener(
   private val eventLog: EventLog,
 ) : CodeListener() {
   override fun onInitialCodeLoading(app: TreehouseApp<*>, view: TreehouseView<*>) {
-    eventLog += "onInitialCodeLoading(${app.spec.name}, $view)"
+    eventLog += "onInitialCodeLoading(${app.name}, $view)"
   }
 
   override fun onCodeLoaded(app: TreehouseApp<*>, view: TreehouseView<*>, initial: Boolean) {
-    eventLog += "onCodeLoaded(${app.spec.name}, $view, initial = $initial)"
+    eventLog += "onCodeLoaded(${app.name}, $view, initial = $initial)"
   }
 
   override fun onCodeDetached(app: TreehouseApp<*>, view: TreehouseView<*>, exception: Throwable?) {
-    eventLog += "onCodeDetached(${app.spec.name}, $view, $exception)"
+    eventLog += "onCodeDetached(${app.name}, $view, $exception)"
   }
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeEventListener.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeEventListener.kt
@@ -32,27 +32,27 @@ class FakeEventListener(
   }
 
   override fun codeLoadStart(): Any? {
-    eventLog += "${app.spec.name}.codeLoadStart()"
+    eventLog += "${app.name}.codeLoadStart()"
     return null
   }
 
   override fun codeLoadSuccess(manifest: ZiplineManifest, zipline: Zipline, startValue: Any?) {
-    eventLog += "${app.spec.name}.codeLoadSuccess()"
+    eventLog += "${app.name}.codeLoadSuccess()"
   }
 
   override fun codeLoadFailed(exception: Exception, startValue: Any?) {
-    eventLog += "${app.spec.name}.codeLoadFailed()"
+    eventLog += "${app.name}.codeLoadFailed()"
   }
 
   override fun codeUnloaded() {
-    eventLog += "${app.spec.name}.codeUnloaded()"
+    eventLog += "${app.name}.codeUnloaded()"
   }
 
   override fun unknownEvent(widgetTag: WidgetTag, tag: EventTag) {
-    eventLog += "${app.spec.name}.unknownEvent($widgetTag, $tag)"
+    eventLog += "${app.name}.unknownEvent($widgetTag, $tag)"
   }
 
   override fun uncaughtException(exception: Throwable) {
-    eventLog += "${app.spec.name}.uncaughtException($exception)"
+    eventLog += "${app.name}.uncaughtException($exception)"
   }
 }


### PR DESCRIPTION
The TreehouseApp.Spec is a user-provided object and could
therefore reference Swift objects that transitively reference
Kotlin objects, introducing a retain cycle. It's simplest to
not retain the Spec.

Closes: https://github.com/cashapp/redwood/issues/2259

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
