### PR TITLE
Watch Zipline instances for leak after stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 New:
 - Source-based schema parser is now the default. The `useFir` Gradle property has been removed.
+- `TreehouseAppFactory` accepts a `LeakDetector` which can be used to notify you of reference leaks for native UI nodes, Zipline instances, Redwood's own internal wrappers, and more.
 - Introduce a `LoadingStrategy` interface to manage `LazyList` preloading.
 - Optimize encoding modifiers in Kotlin/JS.
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -168,6 +168,7 @@ internal class RealTreehouseApp<A : AppService> private constructor(
       appService = appService,
       zipline = zipline,
       appScope = appScope,
+      leakDetector = leakDetector,
     )
   }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.RedwoodVersion
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineApiMismatchException
@@ -31,6 +32,7 @@ internal class ZiplineCodeSession<A : AppService>(
   appService: A,
   private val frameClockFactory: FrameClock.Factory,
   val zipline: Zipline,
+  private val leakDetector: LeakDetector,
 ) : CodeSession<A>(
   dispatchers = dispatchers,
   eventPublisher = eventPublisher,
@@ -72,6 +74,7 @@ internal class ZiplineCodeSession<A : AppService>(
   override fun ziplineStop() {
     ziplineScope.close()
     zipline.close()
+    leakDetector.watchReference(zipline, "code session stopped")
   }
 
   override fun newServiceScope(): ServiceScope<A> {


### PR DESCRIPTION
Closes #575

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
