### PR TITLE
Use dashes for version catalog version ref

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,8 +38,8 @@ spotlessPlugin = "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.29.0"
 buildConfigPlugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
 
-androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx.activity" }
-androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx.activity" }
+androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version = "1.7.0" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose-ui" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-ui" }


### PR DESCRIPTION
This ensures the IDE doesn't think the version is unused. Both forms seem to work.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
