### PR TITLE
Aggressively break retain cycles in UIViewLazyList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changed:
 - Nothing yet!
 
 Fixed:
-- Nothing yet!
+- Breaking the last remaining retain cycle in `UIViewLazyList`.
 
 
 ## [0.14.0] - 2024-08-29

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutAfterDetach[LTR]_after.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutAfterDetach[LTR]_after.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58fc65253abbb1b795b08a105943ebfbea474fc63f20d37928f45806bc537ccc
-size 44146
+oid sha256:66934a5b499e5d8fc1d71e71a4e1cadc40c8a7e597442ec17761171d35104d0e
+size 20682

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutAfterDetach[RTL]_after.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutAfterDetach[RTL]_after.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fce03d5d03606610aed1b96040b608ec1568a87c24ddf71a9da5de3bd9c7db3b
-size 44220
+oid sha256:270869d376b54a59a02687790a977a1806fd9b662bbc687efd8833f2732ef9b7
+size 20989

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -28,6 +28,8 @@ public abstract class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor
 	public final fun bind (ILjava/lang/Object;)Lapp/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Binding;
 	protected fun createPlaceholder (Ljava/lang/Object;)Ljava/lang/Object;
 	protected abstract fun deleteRows (II)V
+	protected fun detach ()V
+	protected fun detach (Ljava/lang/Object;)V
 	public final fun getBindings ()Ljava/util/List;
 	public final fun getItems ()Lapp/cash/redwood/widget/Widget$Children;
 	public final fun getOrCreateView (ILkotlin/jvm/functions/Function1;)Ljava/lang/Object;
@@ -43,6 +45,7 @@ public abstract class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor
 
 public final class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Binding {
 	public final fun bind (Ljava/lang/Object;)V
+	public final fun detach ()V
 	public final fun getView ()Ljava/lang/Object;
 	public final fun isBound ()Z
 	public final fun unbind ()V

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -78,6 +78,8 @@ abstract class <#A: kotlin/Any, #B: kotlin/Any> app.cash.redwood.lazylayout.widg
     final fun itemsBefore(kotlin/Int) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.itemsBefore|itemsBefore(kotlin.Int){}[0]
     final fun onEndChanges() // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.onEndChanges|onEndChanges(){}[0]
     open fun createPlaceholder(#B): #B? // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.createPlaceholder|createPlaceholder(1:1){}[0]
+    open fun detach(#A) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.detach|detach(1:0){}[0]
+    open fun detach() // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.detach|detach(){}[0]
     open fun isSizeOnlyPlaceholder(#B): kotlin/Boolean // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.isSizeOnlyPlaceholder|isSizeOnlyPlaceholder(1:1){}[0]
 
     final class <#A1: kotlin/Any, #B1: kotlin/Any> Binding { // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding|null[0]
@@ -88,6 +90,7 @@ abstract class <#A: kotlin/Any, #B: kotlin/Any> app.cash.redwood.lazylayout.widg
             final fun <get-view>(): #A1? // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.view.<get-view>|<get-view>(){}[0]
 
         final fun bind(#A1) // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.bind|bind(1:0){}[0]
+        final fun detach() // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.detach|detach(){}[0]
         final fun unbind() // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.unbind|unbind(){}[0]
     }
 }


### PR DESCRIPTION
We had a cycle between the reference-counted UITableView and the garbage-collected UIViewLazyList. This cycle caused everything reachable from the UITableView to leak, including the widgets held by the cells.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
