### PR TITLE
Add a hook to close EventListener.Factory instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Unreleased]: https://github.com/cashapp/redwood/compare/0.13.0...HEAD
 
 New:
-- Nothing yet!
+- `EventListener.Factory.close()` is called by `TreehouseApp.close()` to release any resources held by the factory.
 
 Changed:
 - Nothing yet!

--- a/redwood-treehouse-host/api/android/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/android/redwood-treehouse-host.api
@@ -64,7 +64,7 @@ public final class app/cash/redwood/treehouse/EventListener$Companion {
 	public final fun getNONE ()Lapp/cash/redwood/treehouse/EventListener$Factory;
 }
 
-public abstract interface class app/cash/redwood/treehouse/EventListener$Factory {
+public abstract interface class app/cash/redwood/treehouse/EventListener$Factory : java/lang/AutoCloseable {
 	public abstract fun create (Lapp/cash/redwood/treehouse/TreehouseApp;Ljava/lang/String;)Lapp/cash/redwood/treehouse/EventListener;
 }
 

--- a/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/jvm/redwood-treehouse-host.api
@@ -64,7 +64,7 @@ public final class app/cash/redwood/treehouse/EventListener$Companion {
 	public final fun getNONE ()Lapp/cash/redwood/treehouse/EventListener$Factory;
 }
 
-public abstract interface class app/cash/redwood/treehouse/EventListener$Factory {
+public abstract interface class app/cash/redwood/treehouse/EventListener$Factory : java/lang/AutoCloseable {
 	public abstract fun create (Lapp/cash/redwood/treehouse/TreehouseApp;Ljava/lang/String;)Lapp/cash/redwood/treehouse/EventListener;
 }
 

--- a/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
+++ b/redwood-treehouse-host/api/redwood-treehouse-host.klib.api
@@ -175,7 +175,7 @@ open class app.cash.redwood.treehouse/EventListener { // app.cash.redwood.treeho
     open fun unknownWidget(app.cash.redwood.protocol/WidgetTag) // app.cash.redwood.treehouse/EventListener.unknownWidget|unknownWidget(app.cash.redwood.protocol.WidgetTag){}[0]
     open fun ziplineCreated(app.cash.zipline/Zipline) // app.cash.redwood.treehouse/EventListener.ziplineCreated|ziplineCreated(app.cash.zipline.Zipline){}[0]
 
-    abstract fun interface Factory { // app.cash.redwood.treehouse/EventListener.Factory|null[0]
+    abstract interface Factory : kotlin/AutoCloseable { // app.cash.redwood.treehouse/EventListener.Factory|null[0]
         abstract fun create(app.cash.redwood.treehouse/TreehouseApp<*>, kotlin/String?): app.cash.redwood.treehouse/EventListener // app.cash.redwood.treehouse/EventListener.Factory.create|create(app.cash.redwood.treehouse.TreehouseApp<*>;kotlin.String?){}[0]
     }
 

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/RetainEverythingEventListenerFactory.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/RetainEverythingEventListenerFactory.kt
@@ -45,4 +45,8 @@ class RetainEverythingEventListenerFactory(
   override fun codeUnloaded() {
     eventLog += "codeUnloaded"
   }
+
+  override fun close() {
+    eventLog += "EventListener.Factory.close()"
+  }
 }

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTesterTest.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTesterTest.kt
@@ -43,5 +43,6 @@ class TreehouseTesterTest {
     assertThat(buttonValue.text).isEqualTo("This is TreehouseTesterTestHappyPathStep2")
 
     treehouseApp.stop()
+    treehouseApp.close()
   }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeHost.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeHost.kt
@@ -106,7 +106,7 @@ internal abstract class CodeHost<A : AppService>(
     codeUpdatesScope.collectCodeUpdates(eventListenerFactory)
   }
 
-  /** This function may only be invoked on [TreehouseDispatchers.zipline]. */
+  /** This function may only be invoked on [TreehouseDispatchers.ui]. */
   fun stop() {
     dispatchers.checkUi()
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/EventListener.kt
@@ -21,7 +21,6 @@ import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.ModifierTag
 import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
-import app.cash.redwood.treehouse.EventListener.Factory
 import app.cash.zipline.Call
 import app.cash.zipline.CallResult
 import app.cash.zipline.Zipline
@@ -367,7 +366,15 @@ public open class EventListener {
   ) {
   }
 
-  public fun interface Factory {
+  /**
+   * Creates new instances of [EventListener].
+   *
+   * A new [EventListener] will be created for each code load attempt: there may be multiple
+   * instances for a single [TreehouseApp] due to hot reloading.
+   *
+   * This factory will be closed when the [TreehouseApp] it belongs to is closed.
+   */
+  public interface Factory : AutoCloseable {
     /**
      * Returns an event listener that receives the events of a specific code session. Each code
      * session includes a single [Zipline] instance, unless code loading fails, in which case there
@@ -380,8 +387,10 @@ public open class EventListener {
   }
 
   public companion object {
-    public val NONE: Factory = Factory { _, _ ->
-      EventListener()
+    public val NONE: Factory = object : Factory {
+      override fun create(app: TreehouseApp<*>, manifestUrl: String?) = EventListener()
+      override fun close() {
+      }
     }
   }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -177,6 +177,7 @@ internal class RealTreehouseApp<A : AppService> private constructor(
 
     closed = true
     spec = null
+    eventListenerFactory?.close()
     eventListenerFactory = null
     stop()
     dispatchers.close()

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeEventListener.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeEventListener.kt
@@ -29,6 +29,10 @@ class FakeEventListener(
   ) : EventListener.Factory {
     override fun create(app: TreehouseApp<*>, manifestUrl: String?) =
       FakeEventListener(eventLog, app)
+
+    override fun close() {
+      eventLog += "EventListener.Factory.close()"
+    }
   }
 
   override fun codeLoadStart(): Any? {

--- a/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
@@ -174,7 +174,11 @@ class EmojiSearchActivity : ComponentActivity() {
           },
         ),
       ),
-      eventListenerFactory = { _, _ -> appEventListener },
+      eventListenerFactory = object : EventListener.Factory {
+        override fun create(app: TreehouseApp<*>, manifestUrl: String?) = appEventListener
+        override fun close() {
+        }
+      },
     )
 
     treehouseApp.start()

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/EmojiSearchActivity.kt
@@ -178,7 +178,11 @@ class EmojiSearchActivity : ComponentActivity() {
         manifestUrl = manifestUrlFlow,
         hostApi = RealHostApi(this@EmojiSearchActivity, httpClient),
       ),
-      eventListenerFactory = { _, _ -> appEventListener },
+      eventListenerFactory = object : EventListener.Factory {
+        override fun create(app: TreehouseApp<*>, manifestUrl: String?) = appEventListener
+        override fun close() {
+        }
+      },
     )
 
     treehouseApp.start()

--- a/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/EmojiSearchLauncher.kt
+++ b/samples/emoji-search/ios-shared/src/commonMain/kotlin/com/example/redwood/emojisearch/ios/EmojiSearchLauncher.kt
@@ -85,7 +85,11 @@ class EmojiSearchLauncher(
         manifestUrl = manifestUrlFlow,
         hostApi = hostApi,
       ),
-      eventListenerFactory = { app, manifestUrl -> eventListener },
+      eventListenerFactory = object : EventListener.Factory {
+        override fun create(app: TreehouseApp<*>, manifestUrl: String?) = eventListener
+        override fun close() {
+        }
+      },
     )
 
     treehouseApp.start()

--- a/test-app/android-views/src/main/kotlin/com/example/redwood/testapp/android/views/TestAppActivity.kt
+++ b/test-app/android-views/src/main/kotlin/com/example/redwood/testapp/android/views/TestAppActivity.kt
@@ -146,7 +146,11 @@ class TestAppActivity : ComponentActivity() {
         manifestUrl = manifestUrlFlow,
         hostApi = RealHostApi(httpClient),
       ),
-      eventListenerFactory = { _, _ -> appEventListener },
+      eventListenerFactory = object : EventListener.Factory {
+        override fun create(app: TreehouseApp<*>, manifestUrl: String?) = appEventListener
+        override fun close() {
+        }
+      },
     )
 
     treehouseApp.start()

--- a/test-app/ios-shared/src/commonMain/kotlin/com/example/redwood/testapp/ios/TestAppLauncher.kt
+++ b/test-app/ios-shared/src/commonMain/kotlin/com/example/redwood/testapp/ios/TestAppLauncher.kt
@@ -67,7 +67,11 @@ class TestAppLauncher(
         manifestUrl = manifestUrlFlow,
         hostApi = hostApi,
       ),
-      eventListenerFactory = { app, manifestUrl -> eventListener },
+      eventListenerFactory = object : EventListener.Factory {
+        override fun create(app: TreehouseApp<*>, manifestUrl: String?) = eventListener
+        override fun close() {
+        }
+      },
     )
 
     treehouseApp.start()


### PR DESCRIPTION
These things potentially hold resources and so should be closeable.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
