### PR TITLE
Don't pass UIViewNoIntrinsicMetric to sizeThatFits

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewMeasureCallback.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewMeasureCallback.kt
@@ -24,7 +24,6 @@ import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIView
-import platform.UIKit.UIViewNoIntrinsicMetric
 
 internal class UIViewMeasureCallback(val view: UIView) : MeasureCallback {
   override fun measure(
@@ -35,11 +34,11 @@ internal class UIViewMeasureCallback(val view: UIView) : MeasureCallback {
     heightMode: MeasureMode,
   ): Size {
     val constrainedWidth = when (widthMode) {
-      MeasureMode.Undefined -> UIViewNoIntrinsicMetric
+      MeasureMode.Undefined -> 0.0
       else -> width.toDouble()
     }
     val constrainedHeight = when (heightMode) {
-      MeasureMode.Undefined -> UIViewNoIntrinsicMetric
+      MeasureMode.Undefined -> 0.0
       else -> height.toDouble()
     }
 


### PR DESCRIPTION
This is a reasonable value to return from a measurement but I don't think it makes sense as an argument when making a new measurement.

I've observed UIButton returning the wrong size when passed this value, and the correct size when passed 0.0. Unfortunately I'm unable to reproduce that behavior without a lot of code set up.

