### PR TITLE
Do not run Dokka on main build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - run: ./scripts/enforce_git_lfs.sh
-      - run: ./gradlew kotlinUpgradeYarnLock build -PredwoodNoApps
+      - run: ./gradlew kotlinUpgradeYarnLock build -PredwoodNoApps -x dokkaHtml
 
   emulator-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We install some of the artifacts into a local Maven repo to integration test the Gradle plugin. This causes Dokka to generate docs, which is soooooo slooooooooooow. Explicitly disable it to gain speed.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
