### PR TITLE
Mark child views as needing layout when they resize

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -51,7 +51,7 @@ internal class UIViewFlexContainer(
     insert = { widget, view, modifier, index ->
       val node = view.asNode(context = modifier)
       if (widget is ResizableWidget<*>) {
-        widget.sizeListener = NodeSizeListener(node, this@UIViewFlexContainer)
+        widget.sizeListener = NodeSizeListener(node, view, this@UIViewFlexContainer)
       }
       yogaView.rootNode.children.add(index, node)
       value.insertSubview(view, index.convert<NSInteger>())
@@ -123,10 +123,12 @@ private fun UIView.asNode(context: Any?): Node {
 
 private class NodeSizeListener(
   private val node: Node,
+  private val view: UIView,
   private val enclosing: UIViewFlexContainer,
 ) : SizeListener {
   override fun invalidateSize() {
     if (node.markDirty()) {
+      view.setNeedsLayout()
       enclosing.invalidateSize()
     }
   }

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
@@ -15,16 +15,28 @@
  */
 package app.cash.redwood.layout.uiview
 
+import app.cash.redwood.Modifier
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
+import app.cash.redwood.layout.api.Constraint
+import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.toUIColor
 import app.cash.redwood.layout.widget.FlexContainer
 import app.cash.redwood.ui.Px
 import app.cash.redwood.widget.ChangeListener
+import app.cash.redwood.widget.ResizableWidget
+import app.cash.redwood.widget.ResizableWidget.SizeListener
 import app.cash.redwood.widget.Widget
 import app.cash.redwood.yoga.FlexDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.cinterop.CValue
 import kotlinx.cinterop.cValue
+import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGRectZero
+import platform.CoreGraphics.CGSize
+import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIColor
 import platform.UIKit.UIScrollView
 import platform.UIKit.UIView
@@ -84,18 +96,61 @@ class UIViewFlexContainerTest(
   }
 
   override fun verifySnapshot(widget: UIView, name: String?) {
+    val frame = layoutInFrame(widget)
+
+    callback.verifySnapshot(frame, name)
+    widget.removeFromSuperview()
+  }
+
+  private fun layoutInFrame(widget: UIView): UIView {
     val screenSize = CGRectMake(0.0, 0.0, 390.0, 844.0) // iPhone 14.
     widget.setFrame(screenSize)
 
     // Snapshot the container on a white background.
-    val frame = UIView().apply {
+    return UIView().apply {
       backgroundColor = UIColor.whiteColor
       setFrame(screenSize)
       addSubview(widget)
       layoutIfNeeded()
     }
+  }
 
-    callback.verifySnapshot(frame, name)
-    widget.removeFromSuperview()
+  /**
+   * Confirm that calling [ResizableWidget.SizeListener] is sufficient to trigger a subsequent call
+   * to [UIView.layoutSubviews].
+   */
+  @Test
+  fun testInvalidateSizeTriggersUIViewLayout() {
+    var layoutSubviewsCount = 0
+
+    val view = object : UIView(CGRectZero.readValue()) {
+      override fun sizeThatFits(size: CValue<CGSize>) = CGSizeMake(10.0, 10.0)
+
+      override fun layoutSubviews() {
+        layoutSubviewsCount++
+        super.layoutSubviews()
+      }
+    }
+
+    val widget = object : ResizableWidget<UIView> {
+      override val value = view
+      override var modifier: Modifier = Modifier
+      override var sizeListener: SizeListener? = null
+    }
+
+    val container = flexContainer(FlexDirection.Column).apply {
+      width(Constraint.Fill)
+      height(Constraint.Fill)
+      crossAxisAlignment(CrossAxisAlignment.Start)
+      add(widget)
+    }
+
+    layoutInFrame(container.value)
+    assertEquals(1, layoutSubviewsCount)
+
+    widget.sizeListener?.invalidateSize()
+
+    layoutInFrame(container.value)
+    assertEquals(2, layoutSubviewsCount)
   }
 }

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/DisplayLinkTarget.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/DisplayLinkTarget.kt
@@ -53,6 +53,6 @@ internal class DisplayLinkTarget(
 
   fun close() {
     displayLink?.invalidate()
-    displayLink = null
+    displayLink = null // Break a reference cycle.
   }
 }


### PR DESCRIPTION
Child views usually do this on their own, but if they don't we should trigger a layout anyway.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
