### PR TITLE
Use a more efficient representation for the children lookup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ androidx-gradlePluginLints = "androidx.lint:lint-gradle:1.0.0-alpha02"
 
 google-material = { module = "com.google.android.material:material", version = "1.12.0" }
 
+jetbrains-compose-collection = { module = "org.jetbrains.compose.collection-internal:collection", version.ref = "jbCompose" }
 jetbrains-compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "jbCompose" }
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "jbCompose" }
 jetbrains-compose-material = { module = "org.jetbrains.compose.material:material", version.ref = "jbCompose" }

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -136,4 +136,5 @@ buildConfig {
 
   packageName('app.cash.redwood.gradle')
   buildConfigField("String", "redwoodVersion", "\"${project.version}\"")
+  buildConfigField("String", "androidxCollectionCoordinates", "\"${libs.jetbrains.compose.collection.get()}\"")
 }

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodGeneratorPlugin.kt
@@ -70,11 +70,12 @@ public abstract class RedwoodGeneratorPlugin(
   public enum class Strategy(
     internal val generatorFlag: String,
     internal val dependencyArtifactId: String,
+    internal vararg val implementationDependencies: String,
   ) {
     Compose("--compose", "redwood-compose"),
     Modifiers("--modifier", "redwood-runtime"),
     ProtocolGuest("--protocol-guest", "redwood-protocol-guest"),
-    ProtocolHost("--protocol-host", "redwood-protocol-host"),
+    ProtocolHost("--protocol-host", "redwood-protocol-host", androidxCollectionCoordinates),
     Testing("--testing", "redwood-testing"),
     Widget("--widget", "redwood-widget"),
   }
@@ -122,6 +123,9 @@ public abstract class RedwoodGeneratorPlugin(
         sourceSet.kotlin.srcDir(generate)
         sourceSet.dependencies {
           api(project.redwoodDependency(strategy.dependencyArtifactId))
+          for (implementationDependency in strategy.implementationDependencies) {
+            implementation(implementationDependency)
+          }
         }
       }
     }

--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -1,7 +1,7 @@
 public abstract interface class app/cash/redwood/protocol/host/GeneratedProtocolFactory : app/cash/redwood/protocol/host/ProtocolFactory {
 	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
 	public abstract fun createNode-kyz2zXs (II)Lapp/cash/redwood/protocol/host/ProtocolNode;
-	public abstract fun widgetChildren-WCEpcRY (I)Ljava/util/List;
+	public abstract fun widgetChildren-WCEpcRY (I)[I
 }
 
 public final class app/cash/redwood/protocol/host/HostProtocolAdapter : app/cash/redwood/protocol/ChangesSink {

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -13,7 +13,7 @@ abstract fun interface app.cash.redwood.protocol.host/UiEventSink { // app.cash.
 abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/GeneratedProtocolFactory : app.cash.redwood.protocol.host/ProtocolFactory<#A> { // app.cash.redwood.protocol.host/GeneratedProtocolFactory|null[0]
     abstract fun createModifier(app.cash.redwood.protocol/ModifierElement): app.cash.redwood/Modifier // app.cash.redwood.protocol.host/GeneratedProtocolFactory.createModifier|createModifier(app.cash.redwood.protocol.ModifierElement){}[0]
     abstract fun createNode(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/WidgetTag): app.cash.redwood.protocol.host/ProtocolNode<#A>? // app.cash.redwood.protocol.host/GeneratedProtocolFactory.createNode|createNode(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.WidgetTag){}[0]
-    abstract fun widgetChildren(app.cash.redwood.protocol/WidgetTag): kotlin.collections/List<app.cash.redwood.protocol/ChildrenTag> // app.cash.redwood.protocol.host/GeneratedProtocolFactory.widgetChildren|widgetChildren(app.cash.redwood.protocol.WidgetTag){}[0]
+    abstract fun widgetChildren(app.cash.redwood.protocol/WidgetTag): kotlin/IntArray? // app.cash.redwood.protocol.host/GeneratedProtocolFactory.widgetChildren|widgetChildren(app.cash.redwood.protocol.WidgetTag){}[0]
 }
 
 abstract interface app.cash.redwood.protocol.host/ProtocolMismatchHandler { // app.cash.redwood.protocol.host/ProtocolMismatchHandler|null[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
@@ -58,6 +58,11 @@ public interface GeneratedProtocolFactory<W : Any> : ProtocolFactory<W> {
    */
   public fun createModifier(element: ModifierElement): Modifier
 
-  /** Look up known children tags for the given widget [tag]. */
-  public fun widgetChildren(tag: WidgetTag): List<ChildrenTag>
+  /**
+   * Look up known children tags for the given widget [tag]. These are stored as a bare [IntArray]
+   * for efficiency, but are otherwise an array of [ChildrenTag] instances.
+   *
+   * @return `null` when widget has no children
+   */
+  public fun widgetChildren(tag: WidgetTag): IntArray?
 }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.tooling.codegen
 
-import app.cash.redwood.tooling.codegen.Protocol.ChildrenTag
 import app.cash.redwood.tooling.codegen.Protocol.Id
 import app.cash.redwood.tooling.codegen.Protocol.WidgetTag
 import app.cash.redwood.tooling.schema.ProtocolSchema
@@ -32,12 +31,11 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.INT_ARRAY
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.LambdaTypeName
-import com.squareup.kotlinpoet.MAP
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -56,15 +54,15 @@ public class ExampleProtocolFactory<W : Any>(
   private val json: Json = Json.Default,
   private val mismatchHandler: ProtocolMismatchHandler = ProtocolMismatchHandler.Throwing,
 ) : GeneratedProtocolFactory<W> {
-  private val childrenTags: Map<WidgetTag, List<ChildrenTag>> = mapOf(
-        WidgetTag(1) to listOf(ChildrenTag(1)),
-        WidgetTag(3) to listOf(ChildrenTag(1)),
-        WidgetTag(1_000_001) to listOf(ChildrenTag(1), ChildrenTag(2)),
-        WidgetTag(1_000_002) to listOf(ChildrenTag(1)),
-      )
+  private val childrenTags: IntObjectMap<IntArray> = MutableIntObjectMap(4).apply {
+        put(1, intArrayOf(1))
+        put(3, intArrayOf(1))
+        put(1_000_001, intArrayOf(1, 2))
+        put(1_000_002, intArrayOf(1))
+      }
 
-  override fun widgetChildren(tag: WidgetTag): List<ChildrenTag> {
-    return childrenTags[tag] ?: emptyList()
+  override fun widgetChildren(tag: WidgetTag): IntArray? {
+    return childrenTags[tag.value]
   }
 
   override fun createNode(id: Id, tag: WidgetTag): ProtocolNode<W>? = when (tag.value) {
@@ -142,30 +140,34 @@ internal fun generateProtocolFactory(
         .addProperty(
           PropertySpec.builder(
             "childrenTags",
-            MAP.parameterizedBy(WidgetTag, LIST.parameterizedBy(ChildrenTag).copy(nullable = true)),
+            AndroidxCollection.IntObjectMap.parameterizedBy(INT_ARRAY),
             PRIVATE,
           )
             .initializer(
               buildCodeBlock {
-                val mapOf = MemberName("kotlin.collections", "mapOf")
-                val listOf = MemberName("kotlin.collections", "listOf")
-                add("%M(⇥\n", mapOf)
-                for (dependency in schemaSet.all.sortedBy { it.widgets.firstOrNull()?.tag ?: 0 }) {
-                  for (widget in dependency.widgets.filter { it.traits.any { it is ProtocolChildren } }.sortedBy { it.tag }) {
-                    add(
-                      "%T(%L) to %M(%L),\n",
-                      WidgetTag,
-                      widget.tag,
-                      listOf,
-                      widget.traits
-                        .filterIsInstance<ProtocolChildren>()
-                        .sortedBy { it.tag }
-                        .map { CodeBlock.of("%T(%L)", ChildrenTag, it.tag) }
-                        .joinToCode(),
-                    )
-                  }
+                val allParentWidgets = schemaSet.all
+                  .flatMap { it.widgets }
+                  .filter { it.traits.any { it is ProtocolChildren } }
+                  .sortedBy { it.tag }
+
+                beginControlFlow(
+                  "%T<%T>(%L).apply",
+                  AndroidxCollection.MutableIntObjectMap,
+                  INT_ARRAY,
+                  allParentWidgets.size,
+                )
+                for (parentWidget in allParentWidgets) {
+                  addStatement(
+                    "put(%L, %M(%L))",
+                    parentWidget.tag,
+                    MemberName("kotlin", "intArrayOf"),
+                    parentWidget.traits
+                      .filterIsInstance<ProtocolChildren>()
+                      .sortedBy { it.tag }
+                      .joinToCode { CodeBlock.of("%L", it.tag) },
+                  )
                 }
-                add("⇤)\n")
+                endControlFlow()
               },
             )
             .build(),
@@ -174,8 +176,8 @@ internal fun generateProtocolFactory(
           FunSpec.builder("widgetChildren")
             .addModifiers(OVERRIDE)
             .addParameter("tag", WidgetTag)
-            .returns(LIST.parameterizedBy(ChildrenTag))
-            .addStatement("return childrenTags[tag] ?: emptyList()")
+            .returns(INT_ARRAY.copy(nullable = true))
+            .addStatement("return childrenTags[tag.value]")
             .build(),
         )
         .addFunction(
@@ -183,7 +185,6 @@ internal fun generateProtocolFactory(
             .addModifiers(OVERRIDE)
             .addParameter("id", Id)
             .addParameter("tag", WidgetTag)
-            .addAnnotation(Redwood.RedwoodCodegenApi)
             .returns(
               ProtocolHost.ProtocolNode.parameterizedBy(typeVariableW)
                 .copy(nullable = true),

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -94,6 +94,11 @@ internal object ComposeRuntime {
   val Stable = ClassName("androidx.compose.runtime", "Stable")
 }
 
+internal object AndroidxCollection {
+  val IntObjectMap = ClassName("androidx.collection", "IntObjectMap")
+  val MutableIntObjectMap = ClassName("androidx.collection", "MutableIntObjectMap")
+}
+
 internal fun composableLambda(
   receiver: TypeName?,
 ): TypeName {

--- a/redwood-treehouse-host/build.gradle
+++ b/redwood-treehouse-host/build.gradle
@@ -37,6 +37,7 @@ kotlin {
         implementation libs.kotlinx.coroutines.test
         implementation libs.okio
         implementation libs.turbine
+        implementation libs.jetbrains.compose.collection
         implementation projects.redwoodLayoutTesting
         implementation projects.redwoodLazylayoutTesting
         implementation projects.testApp.schema.protocolHost

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/leaks/JvmHeap.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/leaks/JvmHeap.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse.leaks
 
+import androidx.collection.IntObjectMap
 import app.cash.redwood.treehouse.EventLog
 import java.lang.ref.WeakReference
 import java.lang.reflect.Field
@@ -63,6 +64,9 @@ internal object JvmHeap : Heap {
         Edge("key", instance.key),
         Edge("value", instance.value),
       )
+      instance is IntObjectMap<*> -> {
+        references(buildList { instance.forEachValue(::add) })
+      }
       instance is StateFlow<*> -> listOf(
         Edge("value", instance.value),
       )

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNodeFactory.kt
@@ -17,7 +17,6 @@ package app.cash.redwood.treehouse
 
 import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
-import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.ModifierElement
 import app.cash.redwood.protocol.WidgetTag
@@ -30,5 +29,5 @@ internal class FakeProtocolNodeFactory : GeneratedProtocolFactory<FakeWidget> {
   override val widgetSystem: WidgetSystem<FakeWidget> = FakeWidgetSystem()
   override fun createNode(id: Id, tag: WidgetTag): ProtocolNode<FakeWidget> = FakeProtocolNode(id, tag)
   override fun createModifier(element: ModifierElement): Modifier = Modifier
-  override fun widgetChildren(tag: WidgetTag): List<ChildrenTag> = emptyList()
+  override fun widgetChildren(tag: WidgetTag): IntArray? = null
 }


### PR DESCRIPTION
Use primitive-specialized collections from AndroidX collection.

With 24 keys and 37 values…

Before (`Map<WidgetTag, List<ChildrenTag>>`)

      64 bytes // LinkedHashMap
     144 bytes //  Node[] 16 + 4*(24/.75)
     960 bytes //  LinkedHashMap$Entry 40*24
     384 bytes // WidgetTag 16*24
     576 bytes // ArrayList 24*24
     532 bytes //   Object[] 16*24 + 4*37
     592 bytes // ChildrenTag 16*37
    ----------
    3302 bytes total

After (`IntObjectMap<IntArray>`)

     32 bytes // IntObjectMap
     40 bytes //   long[] 16 + 8*(24/8)
    112 bytes //   int[] 16 + 4*24
    112 bytes //   Object[] 16 + 4*24
    532 bytes // int[] 16*24 + 4*37
    ---------
    828 bytes total

…and obviously greater locality and all that helps as well.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
