### PR TITLE
Use `Array` in `UiEvent`

### DIFF
--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -48,16 +48,12 @@ public abstract class app/cash/redwood/protocol/host/ProtocolNode {
 }
 
 public final class app/cash/redwood/protocol/host/UiEvent {
-	public synthetic fun <init> (IILjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (IILjava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getArgs ()Ljava/util/List;
+	public synthetic fun <init> (II[Ljava/lang/Object;[Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getArgs ()[Ljava/lang/Object;
 	public final fun getId-0HhLjSo ()I
-	public final fun getSerializationStrategies ()Ljava/util/List;
+	public final fun getSerializationStrategies ()[Lkotlinx/serialization/SerializationStrategy;
 	public final fun getTag-RNF89mI ()I
-	public fun hashCode ()I
 	public final fun toProtocol (Lkotlinx/serialization/json/Json;)Lapp/cash/redwood/protocol/Event;
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class app/cash/redwood/protocol/host/UiEventSink {

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -71,21 +71,18 @@ final class <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolChildren { /
 }
 
 final class app.cash.redwood.protocol.host/UiEvent { // app.cash.redwood.protocol.host/UiEvent|null[0]
-    constructor <init>(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/EventTag, kotlin.collections/List<kotlin/Any?> = ..., kotlin.collections/List<kotlinx.serialization/SerializationStrategy<kotlin/Any?>> = ...) // app.cash.redwood.protocol.host/UiEvent.<init>|<init>(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.EventTag;kotlin.collections.List<kotlin.Any?>;kotlin.collections.List<kotlinx.serialization.SerializationStrategy<kotlin.Any?>>){}[0]
+    constructor <init>(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/EventTag, kotlin/Array<kotlin/Any?>?, kotlin/Array<kotlinx.serialization/SerializationStrategy<kotlin/Any?>>?) // app.cash.redwood.protocol.host/UiEvent.<init>|<init>(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.EventTag;kotlin.Array<kotlin.Any?>?;kotlin.Array<kotlinx.serialization.SerializationStrategy<kotlin.Any?>>?){}[0]
 
     final val args // app.cash.redwood.protocol.host/UiEvent.args|{}args[0]
-        final fun <get-args>(): kotlin.collections/List<kotlin/Any?> // app.cash.redwood.protocol.host/UiEvent.args.<get-args>|<get-args>(){}[0]
+        final fun <get-args>(): kotlin/Array<kotlin/Any?>? // app.cash.redwood.protocol.host/UiEvent.args.<get-args>|<get-args>(){}[0]
     final val id // app.cash.redwood.protocol.host/UiEvent.id|{}id[0]
         final fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.host/UiEvent.id.<get-id>|<get-id>(){}[0]
     final val serializationStrategies // app.cash.redwood.protocol.host/UiEvent.serializationStrategies|{}serializationStrategies[0]
-        final fun <get-serializationStrategies>(): kotlin.collections/List<kotlinx.serialization/SerializationStrategy<kotlin/Any?>> // app.cash.redwood.protocol.host/UiEvent.serializationStrategies.<get-serializationStrategies>|<get-serializationStrategies>(){}[0]
+        final fun <get-serializationStrategies>(): kotlin/Array<kotlinx.serialization/SerializationStrategy<kotlin/Any?>>? // app.cash.redwood.protocol.host/UiEvent.serializationStrategies.<get-serializationStrategies>|<get-serializationStrategies>(){}[0]
     final val tag // app.cash.redwood.protocol.host/UiEvent.tag|{}tag[0]
         final fun <get-tag>(): app.cash.redwood.protocol/EventTag // app.cash.redwood.protocol.host/UiEvent.tag.<get-tag>|<get-tag>(){}[0]
 
-    final fun equals(kotlin/Any?): kotlin/Boolean // app.cash.redwood.protocol.host/UiEvent.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // app.cash.redwood.protocol.host/UiEvent.hashCode|hashCode(){}[0]
     final fun toProtocol(kotlinx.serialization.json/Json): app.cash.redwood.protocol/Event // app.cash.redwood.protocol.host/UiEvent.toProtocol|toProtocol(kotlinx.serialization.json.Json){}[0]
-    final fun toString(): kotlin/String // app.cash.redwood.protocol.host/UiEvent.toString|toString(){}[0]
 }
 
 final val app.cash.redwood.protocol.host/hostRedwoodVersion // app.cash.redwood.protocol.host/hostRedwoodVersion|{}hostRedwoodVersion[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/UiEvent.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/UiEvent.kt
@@ -19,7 +19,6 @@ import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.EventTag
 import app.cash.redwood.protocol.Id
-import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json
 
@@ -27,27 +26,24 @@ import kotlinx.serialization.json.Json
  * A version of [Event] whose arguments have not yet been serialized to JSON and is thus
  * cheap to create on the UI thread.
  */
-@Poko
 public class UiEvent(
   public val id: Id,
   public val tag: EventTag,
-  public val args: List<Any?> = emptyList(),
-  public val serializationStrategies: List<SerializationStrategy<Any?>> = emptyList(),
+  public val args: Array<Any?>?,
+  public val serializationStrategies: Array<SerializationStrategy<Any?>>?,
 ) {
-  init {
-    check(args.size == serializationStrategies.size) {
-      "Properties 'args' and 'serializationStrategies' must have the same size. " +
-        "Found ${args.size} and ${serializationStrategies.size}"
-    }
-  }
-
   /** Serialize [args] into a JSON model using [serializationStrategies] into an [Event]. */
   public fun toProtocol(json: Json): Event {
     return Event(
       id = id,
       tag = tag,
-      args = List(args.size) {
-        json.encodeToJsonElement(serializationStrategies[it], args[it])
+      args = if (args == null) {
+        emptyList()
+      } else {
+        val serializationStrategies = serializationStrategies!!
+        List(args.size) { i ->
+          json.encodeToJsonElement(serializationStrategies[i], args[i])
+        }
       },
     )
   }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -556,11 +556,11 @@ private class OnClick(
       UiEvent(
         id,
         EventTag(3),
-        listOf(
+        arrayOf(
           arg0,
           arg1,
         ),
-        listOf(
+        arrayOf(
           serializer_0,
           serializer_1,
         ),
@@ -607,14 +607,14 @@ private fun generateEventHandler(
 
   if (serializers.isEmpty()) {
     invoke.addCode(
-      "eventSink.sendEvent(%T(id, %T(%L)))",
+      "eventSink.sendEvent(%T(id, %T(%L), null, null))",
       ProtocolHost.UiEvent,
       Protocol.EventTag,
       trait.tag,
     )
   } else {
     invoke.addCode(
-      "eventSink.sendEvent(⇥\n%T(⇥\nid,\n%T(%L),\nlistOf(⇥\n%L,\n⇤),\nlistOf(⇥\n%L,\n⇤),\n⇤),\n⇤)",
+      "eventSink.sendEvent(⇥\n%T(⇥\nid,\n%T(%L),\narrayOf(⇥\n%L,\n⇤),\narrayOf(⇥\n%L,\n⇤),\n⇤),\n⇤)",
       ProtocolHost.UiEvent,
       Protocol.EventTag,
       trait.tag,

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
@@ -40,7 +40,7 @@ internal class FakeProtocolNode(
   override fun apply(change: PropertyChange, eventSink: UiEventSink) {
     widget.label = (change.value as JsonPrimitive).content
     widget.onClick = {
-      eventSink.sendEvent(UiEvent(Id(1), EventTag(1)))
+      eventSink.sendEvent(UiEvent(Id(1), EventTag(1), null, null))
     }
   }
 


### PR DESCRIPTION
There's no need to use a `List`. This object lives for a very short time, it's values are created and read only once (and only by our code, not user code), and drop generated `equals`/`hashCode`/`toString` which aren't used where Array might be problematic.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
