### PR TITLE
Introduce a Snapshotter interface for tests

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeSnapshotter.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeSnapshotter.kt
@@ -20,8 +20,8 @@ import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.layout.Snapshotter
 
 class ComposeSnapshotter(
-    private val paparazzi: Paparazzi,
-    private val widget: @Composable () -> Unit,
+  private val paparazzi: Paparazzi,
+  private val widget: @Composable () -> Unit,
 ) : Snapshotter {
   override fun snapshot(name: String?) {
     paparazzi.snapshot(composable = widget, name = name)

--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeSnapshotter.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeSnapshotter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.composeui
+
+import androidx.compose.runtime.Composable
+import app.cash.paparazzi.Paparazzi
+import app.cash.redwood.layout.Snapshotter
+
+class ComposeSnapshotter(
+    private val paparazzi: Paparazzi,
+    private val widget: @Composable () -> Unit,
+) : Snapshotter {
+  override fun snapshot(name: String?) {
+    paparazzi.snapshot(composable = widget, name = name)
+  }
+}

--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiBoxTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiBoxTest.kt
@@ -15,11 +15,11 @@
  */
 package app.cash.redwood.layout.composeui
 
-import app.cash.redwood.layout.Color as ColorWidget
 import androidx.compose.runtime.Composable
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.layout.AbstractBoxTest
+import app.cash.redwood.layout.Color as ColorWidget
 import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.widget.Box
 import com.android.resources.LayoutDirection

--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiBoxTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiBoxTest.kt
@@ -15,11 +15,11 @@
  */
 package app.cash.redwood.layout.composeui
 
+import app.cash.redwood.layout.Color as ColorWidget
 import androidx.compose.runtime.Composable
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.layout.AbstractBoxTest
-import app.cash.redwood.layout.Color as ColorWidget
 import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.widget.Box
 import com.android.resources.LayoutDirection
@@ -46,7 +46,5 @@ class ComposeUiBoxTest(
 
   override fun text(): Text<@Composable () -> Unit> = ComposeUiText()
 
-  override fun verifySnapshot(widget: @Composable () -> Unit, name: String?) {
-    paparazzi.snapshot(composable = widget, name = name)
-  }
+  override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)
 }

--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -60,11 +60,7 @@ class ComposeUiFlexContainerTest(
 
   override fun text() = ComposeUiText()
 
-  override fun verifySnapshot(widget: @Composable () -> Unit, name: String?) {
-    paparazzi.snapshot(name) {
-      widget()
-    }
-  }
+  override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)
 
   class ComposeTestFlexContainer private constructor(
     private val delegate: ComposeUiFlexContainer,

--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacerTest.kt
@@ -57,7 +57,5 @@ class ComposeUiSpacerTest : AbstractSpacerTest<@Composable () -> Unit>() {
     }
   }
 
-  override fun verifySnapshot(value: @Composable () -> Unit) {
-    paparazzi.snapshot(composable = value)
-  }
+  override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)
 }

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
@@ -38,12 +38,12 @@ abstract class AbstractBoxTest<T : Any> {
     height(height)
   }
 
-  abstract fun verifySnapshot(widget: T, name: String? = null)
+  abstract fun snapshotter(widget: T): Snapshotter
 
   @Test
   fun testEmpty_Defaults() {
     val widget = box()
-    verifySnapshot(widget.value)
+    snapshotter(widget.value).snapshot()
   }
 
   @Test
@@ -52,7 +52,7 @@ abstract class AbstractBoxTest<T : Any> {
       width(Constraint.Wrap)
       height(Constraint.Wrap)
     }
-    verifySnapshot(widget.value)
+    snapshotter(widget.value).snapshot()
   }
 
   @Test
@@ -61,7 +61,7 @@ abstract class AbstractBoxTest<T : Any> {
       width(Constraint.Fill)
       height(Constraint.Fill)
     }
-    verifySnapshot(widget.value)
+    snapshotter(widget.value).snapshot()
   }
 
   // testChildren
@@ -322,7 +322,7 @@ abstract class AbstractBoxTest<T : Any> {
         },
       )
     }
-    verifySnapshot(widget.value)
+    snapshotter(widget.value).snapshot()
   }
 
   @Test
@@ -345,7 +345,7 @@ abstract class AbstractBoxTest<T : Any> {
         },
       )
     }
-    verifySnapshot(widget.value)
+    snapshotter(widget.value).snapshot()
   }
 
   @Test
@@ -388,7 +388,7 @@ abstract class AbstractBoxTest<T : Any> {
         },
       )
     }
-    verifySnapshot(widget.value)
+    snapshotter(widget.value).snapshot()
   }
 
   @Test
@@ -431,7 +431,7 @@ abstract class AbstractBoxTest<T : Any> {
         },
       )
     }
-    verifySnapshot(widget.value)
+    snapshotter(widget.value).snapshot()
   }
 
   @Test
@@ -444,10 +444,11 @@ abstract class AbstractBoxTest<T : Any> {
       children.insert(1, coloredText(text = mediumText(), color = Blue))
       children.insert(2, coloredText(text = shortText(), color = Green))
     }
-    verifySnapshot(widget.value, "Margin")
+    val snapshotter = snapshotter(widget.value)
+    snapshotter.snapshot("Margin")
     redColor.modifier = Modifier
     widget.children.onModifierUpdated(0, redColor)
-    verifySnapshot(widget.value, "Empty")
+    snapshotter.snapshot("Empty")
   }
 
   /** The view shouldn't crash if its displayed after being detached. */
@@ -459,16 +460,17 @@ abstract class AbstractBoxTest<T : Any> {
       horizontalAlignment(CrossAxisAlignment.Start)
       verticalAlignment(CrossAxisAlignment.Start)
     }
+    val snapshotter = snapshotter(widget.value)
 
     // Render before calling detach().
     widget.children.insert(0, coloredText(MarginImpl(10.dp), mediumText(), Green))
     widget.children.insert(1, coloredText(MarginImpl(0.dp), shortText(), Blue))
-    verifySnapshot(widget.value, "Before")
+    snapshotter.snapshot("Before")
 
     // Detach after changes are applied but before they're rendered.
     widget.children.insert(0, coloredText(MarginImpl(20.dp), longText(), Red))
     widget.children.detach()
-    verifySnapshot(widget.value, "After")
+    snapshotter.snapshot("After")
   }
 
   @Test fun testDynamicWidgetResizing() {
@@ -479,6 +481,7 @@ abstract class AbstractBoxTest<T : Any> {
         horizontalAlignment(CrossAxisAlignment.Start)
         verticalAlignment(CrossAxisAlignment.Start)
       }
+    val snapshotter = snapshotter(container.value)
 
     val a = coloredText(text = "AAA", color = Red)
       .apply { modifier = HorizontalAlignmentImpl(CrossAxisAlignment.Start) }
@@ -489,10 +492,10 @@ abstract class AbstractBoxTest<T : Any> {
     val c = coloredText(text = "CCC", color = Green)
       .apply { modifier = HorizontalAlignmentImpl(CrossAxisAlignment.End) }
       .also { container.children.insert(2, it) }
-    verifySnapshot(container.value, "v1")
+    snapshotter.snapshot("v1")
 
     b.text("BBB_v2")
-    verifySnapshot(container.value, "v2")
+    snapshotter.snapshot("v2")
   }
 
   private fun coloredText(modifier: Modifier = Modifier, text: String, color: Int) = text().apply {

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -38,7 +38,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * currently opt-in, but will soon be the only supported mode.
    */
   open val incremental: Boolean
-    get() = true
+    get() = false
 
   abstract fun flexContainer(
     direction: FlexDirection,

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -38,7 +38,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * currently opt-in, but will soon be the only supported mode.
    */
   open val incremental: Boolean
-    get() = false
+    get() = true
 
   abstract fun flexContainer(
     direction: FlexDirection,
@@ -65,10 +65,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     return widget
   }
 
-  abstract fun verifySnapshot(
-    widget: T,
-    name: String? = null,
-  )
+  abstract fun snapshotter(widget: T): Snapshotter
 
   @Test fun testEmptyLayout_Column() {
     emptyLayout(FlexDirection.Column)
@@ -85,7 +82,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     val container = flexContainer(flexDirection)
     container.crossAxisAlignment(CrossAxisAlignment.Start)
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testLayoutWithConstraints_Column_Wrap_Wrap() {
@@ -131,7 +128,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     container.height(height)
     container.add(text(movies.first()))
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testShortLayout_Column() {
@@ -152,7 +149,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text(movie))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testLongLayout_Column() {
@@ -173,7 +170,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text(movie))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testLayoutWithMarginAndDifferentAlignments_Column() {
@@ -202,7 +199,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text(movie, modifier))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testLayoutWithCrossAxisAlignment_Column_Start() {
@@ -250,11 +247,12 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text(movie))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun columnWithUpdatedCrossAxisAlignment() {
     val container = flexContainer(FlexDirection.Column)
+    val snapshotter = snapshotter(container.value)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
     container.crossAxisAlignment(CrossAxisAlignment.Center)
@@ -262,10 +260,10 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text(movie))
     }
     container.onEndChanges()
-    verifySnapshot(container.value, "Center")
+    snapshotter.snapshot("Center")
     container.crossAxisAlignment(CrossAxisAlignment.End)
     container.onEndChanges()
-    verifySnapshot(container.value, "FlexEnd")
+    snapshotter.snapshot("FlexEnd")
   }
 
   @Test fun testColumnWithMainAxisAlignment_Center() {
@@ -293,7 +291,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text(movie))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testContainerWithFixedWidthItems() {
@@ -305,7 +303,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text("$index", WidthImpl(50.dp)))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testContainerWithFixedHeightItems() {
@@ -317,7 +315,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text("$index", HeightImpl(50.dp)))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testContainerWithFixedSizeItems() {
@@ -329,21 +327,22 @@ abstract class AbstractFlexContainerTest<T : Any> {
       container.add(text("$index", SizeImpl(50.dp, 50.dp)))
     }
     container.onEndChanges()
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testChildWithUpdatedProperty() {
     val container = flexContainer(FlexDirection.Column)
+    val snapshotter = snapshotter(container.value)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
     container.crossAxisAlignment(CrossAxisAlignment.Start)
     val widget = text("")
     container.add(widget)
     container.onEndChanges()
-    verifySnapshot(container.value, "initial")
+    snapshotter.snapshot("initial")
     widget.text(movies.first())
     container.onEndChanges()
-    verifySnapshot(container.value, "updated")
+    snapshotter.snapshot("updated")
   }
 
   @Test fun testColumnThenRow() {
@@ -382,7 +381,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       },
     )
 
-    verifySnapshot(column.value)
+    snapshotter(column.value).snapshot()
   }
 
   /** This test demonstrates that margins are lost unless `shrink(1.0)` is added. */
@@ -436,11 +435,12 @@ abstract class AbstractFlexContainerTest<T : Any> {
       },
     )
 
-    verifySnapshot(column.value)
+    snapshotter(column.value).snapshot()
   }
 
   @Test fun testDynamicElementUpdates() {
     val container = flexContainer(FlexDirection.Column)
+    val snapshotter = snapshotter(container.value)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
     container.add(text("A"))
@@ -449,15 +449,15 @@ abstract class AbstractFlexContainerTest<T : Any> {
     container.add(text("E"))
 
     container.onEndChanges()
-    verifySnapshot(container.value, "ABDE")
+    snapshotter.snapshot("ABDE")
 
     container.addAt(index = 2, widget = text("C"))
     container.onEndChanges()
-    verifySnapshot(container.value, "ABCDE")
+    snapshotter.snapshot("ABCDE")
 
     container.removeAt(index = 0)
     container.onEndChanges()
-    verifySnapshot(container.value, "BCDE")
+    snapshotter.snapshot("BCDE")
   }
 
   @Test fun testDynamicContainerSize() {
@@ -465,6 +465,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       width(Constraint.Fill)
       height(Constraint.Fill)
     }
+    val snapshotter = snapshotter(parent.value)
 
     parent.children.insert(
       0,
@@ -509,10 +510,10 @@ abstract class AbstractFlexContainerTest<T : Any> {
       },
     )
 
-    verifySnapshot(parent.value, "both")
+    snapshotter.snapshot("both")
 
     parent.children.remove(index = 1, count = 1)
-    verifySnapshot(parent.value, "single")
+    snapshotter.snapshot("single")
   }
 
   @Test fun testFlexDistributesWeightEqually() {
@@ -523,7 +524,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     container.add(text("SHORTER TEXT", FlexImpl(1.0)))
     container.add(text("A", FlexImpl(1.0)))
     container.add(text("LINE1\nLINE2\nLINE3", FlexImpl(1.0)))
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testFlexDistributesWeightUnequally() {
@@ -534,7 +535,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     container.add(text("SHORTER TEXT", FlexImpl(1.0)))
     container.add(text("A", FlexImpl(1.0)))
     container.add(text("LINE1\nLINE2\nLINE3", FlexImpl(1.0)))
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
   }
 
   @Test fun testNestedColumnsWithFlex() {
@@ -561,16 +562,14 @@ abstract class AbstractFlexContainerTest<T : Any> {
     outerContainer.add(innerContainer2)
     innerContainer2.modifier = Modifier.then(FlexImpl(1.0))
     outerContainer.children.onModifierUpdated(1, innerContainer2)
-    verifySnapshot(outerContainer.value)
+    snapshotter(outerContainer.value).snapshot()
   }
 
-  @Test
-  fun testColumnWithChildModifierChanges() {
+  @Test fun testColumnWithChildModifierChanges() {
     testContainerWithChildrenModifierChanges(FlexDirection.Column)
   }
 
-  @Test
-  fun testRowWithChildModifierChanges() {
+  @Test fun testRowWithChildModifierChanges() {
     testContainerWithChildrenModifierChanges(FlexDirection.Row)
   }
 
@@ -578,6 +577,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     flexDirection: FlexDirection,
   ) {
     val container = flexContainer(flexDirection)
+    val snapshotter = snapshotter(container.value)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
 
@@ -588,37 +588,35 @@ abstract class AbstractFlexContainerTest<T : Any> {
     container.add(text(mediumText(), backgroundColor = Green))
     container.add(text(shortText(), backgroundColor = Blue))
     container.onEndChanges()
-    verifySnapshot(container.value, "Margin")
+    snapshotter.snapshot("Margin")
     first.modifier = Modifier
     container.children.onModifierUpdated(0, first)
     container.onEndChanges()
-    verifySnapshot(container.value, "Empty")
+    snapshotter.snapshot("Empty")
   }
 
   /** The view shouldn't crash if its displayed after being detached. */
-  @Test
-  fun testLayoutAfterDetach() {
+  @Test fun testLayoutAfterDetach() {
     val container = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
     }
-    val widget = container.value // Don't access widget.value after detach().
+    val snapshotter = snapshotter(container.value)
 
     // Render before calling detach().
     container.children.insert(0, text(mediumText(), MarginImpl(10.dp), Green))
     container.children.insert(1, text(shortText(), MarginImpl(0.dp), Blue))
     container.onEndChanges()
-    verifySnapshot(widget, "Before")
+    snapshotter.snapshot("Before")
 
     // Detach after changes are applied but before they're rendered.
     container.children.insert(0, text(longText(), MarginImpl(20.dp), Red))
     container.onEndChanges()
     container.children.detach()
-    verifySnapshot(widget, "After")
+    snapshotter.snapshot("After")
   }
 
-  @Test
-  fun testOnScrollListener() {
+  @Test fun testOnScrollListener() {
     var scrolled = false
     val container = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
@@ -631,7 +629,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
     container.scroll(Px(1000.0))
 
-    verifySnapshot(container.value)
+    snapshotter(container.value).snapshot()
 
     assertTrue(scrolled)
   }
@@ -644,6 +642,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    */
   @Test fun testLayoutIsIncremental() {
     val container = flexContainer(FlexDirection.Column)
+    val snapshotter = snapshotter(container.value)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
     container.crossAxisAlignment(CrossAxisAlignment.Start)
@@ -658,13 +657,13 @@ abstract class AbstractFlexContainerTest<T : Any> {
       .apply { modifier = HeightImpl(100.dp) }
       .also { container.add(it) }
     container.onEndChanges()
-    verifySnapshot(container.value, "v1")
+    snapshotter.snapshot("v1")
     val aMeasureCountV1 = a.measureCount
     val bMeasureCountV1 = b.measureCount
     val cMeasureCountV1 = c.measureCount
 
     b.text("B v2")
-    verifySnapshot(container.value, "v2")
+    snapshotter.snapshot("v2")
     val aMeasureCountV2 = a.measureCount
     val bMeasureCountV2 = b.measureCount
     val cMeasureCountV2 = c.measureCount
@@ -675,7 +674,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       assertEquals(cMeasureCountV1, cMeasureCountV2)
     }
 
-    verifySnapshot(container.value, "v3")
+    snapshotter.snapshot("v3")
     val aMeasureCountV3 = a.measureCount
     val bMeasureCountV3 = b.measureCount
     val cMeasureCountV3 = c.measureCount
@@ -689,6 +688,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun testRecursiveLayoutIsIncremental() {
     val container = flexContainer(FlexDirection.Column)
+    val snapshotter = snapshotter(container.value)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
     container.crossAxisAlignment(CrossAxisAlignment.Start)
@@ -721,13 +721,13 @@ abstract class AbstractFlexContainerTest<T : Any> {
       .apply { modifier = HeightImpl(100.dp) }
       .also { rowC.children.insert(0, it) }
     container.onEndChanges()
-    verifySnapshot(container.value, "v1")
+    snapshotter.snapshot("v1")
     val aMeasureCountV1 = a.measureCount
     val bMeasureCountV1 = b.measureCount
     val cMeasureCountV1 = c.measureCount
 
     b.text("B v2")
-    verifySnapshot(container.value, "v2")
+    snapshotter.snapshot("v2")
     val aMeasureCountV2 = a.measureCount
     val bMeasureCountV2 = b.measureCount
     val cMeasureCountV2 = c.measureCount
@@ -738,7 +738,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       assertEquals(cMeasureCountV1, cMeasureCountV2)
     }
 
-    verifySnapshot(container.value, "v3")
+    snapshotter.snapshot("v3")
     val aMeasureCountV3 = a.measureCount
     val bMeasureCountV3 = b.measureCount
     val cMeasureCountV3 = c.measureCount

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractSpacerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractSpacerTest.kt
@@ -26,7 +26,7 @@ abstract class AbstractSpacerTest<T : Any> {
 
   abstract fun wrap(widget: Widget<T>, horizontal: Boolean): T
 
-  abstract fun verifySnapshot(value: T)
+  abstract fun snapshotter(widget: T): Snapshotter
 
   private fun widget(width: Int, height: Int): Spacer<T> = widget().apply {
     width(width.dp)
@@ -35,21 +35,21 @@ abstract class AbstractSpacerTest<T : Any> {
 
   @Test fun testZeroSpacer() {
     val widget = widget(width = 0, height = 0)
-    verifySnapshot(wrap(widget, horizontal = true))
+    snapshotter(wrap(widget, horizontal = true)).snapshot()
   }
 
   @Test fun testWidthOnlySpacer() {
     val widget = widget(width = 100, height = 0)
-    verifySnapshot(wrap(widget, horizontal = true))
+    snapshotter(wrap(widget, horizontal = true)).snapshot()
   }
 
   @Test fun testHeightOnlySpacer() {
     val widget = widget(width = 0, height = 100)
-    verifySnapshot(wrap(widget, horizontal = false))
+    snapshotter(wrap(widget, horizontal = false)).snapshot()
   }
 
   @Test fun testBothSpacer() {
     val widget = widget(width = 100, height = 100)
-    verifySnapshot(wrap(widget, horizontal = false))
+    snapshotter(wrap(widget, horizontal = false)).snapshot()
   }
 }

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/Snapshotter.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/Snapshotter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout
+
+/**
+ * Captures snapshots of a subject view.
+ *
+ * The subject of the view hierarchy must do its own layout invalidation. This is particularly
+ * important for iOS UIView layouts, where the application layer is responsible for tracking layout
+ * changes.
+ */
+interface Snapshotter {
+  fun snapshot(name: String? = null)
+}

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewBoxTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewBoxTest.kt
@@ -21,7 +21,6 @@ import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.widget.Box
 import assertk.assertThat
 import kotlin.test.Test
-import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIColor
 import platform.UIKit.UIView
@@ -44,21 +43,7 @@ class UIViewBoxTest(
     return UIViewText()
   }
 
-  override fun verifySnapshot(widget: UIView, name: String?) {
-    val screenSize = CGRectMake(0.0, 0.0, 390.0, 844.0) // iPhone 14.
-    widget.setFrame(screenSize)
-
-    // Snapshot the container on a white background.
-    val frame = UIView().apply {
-      backgroundColor = UIColor.whiteColor
-      setFrame(screenSize)
-      addSubview(widget)
-      layoutIfNeeded()
-    }
-
-    callback.verifySnapshot(frame, name)
-    widget.removeFromSuperview()
-  }
+  override fun snapshotter(widget: UIView) = UIViewSnapshotter.framed(callback, widget)
 
   @Test
   fun maxEachDimension() {

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSnapshotter.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSnapshotter.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.uiview
+
+import app.cash.redwood.layout.Snapshotter
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIColor
+import platform.UIKit.UIView
+
+/** Snapshot the subject on a white background. */
+class UIViewSnapshotter(
+  private val callback: UIViewSnapshotCallback,
+  private val subject: UIView,
+) : Snapshotter {
+
+  override fun snapshot(name: String?) {
+    layoutSubject()
+    callback.verifySnapshot(subject, name)
+  }
+
+  /** Do layout without taking a snapshot. */
+  fun layoutSubject() {
+    subject.layoutIfNeeded()
+  }
+
+  companion object {
+    fun framed(
+      callback: UIViewSnapshotCallback,
+      widget: UIView,
+    ): UIViewSnapshotter {
+      val frame = UIView()
+        .apply {
+          val screenSize = CGRectMake(0.0, 0.0, 390.0, 844.0) // iPhone 14.
+
+          backgroundColor = UIColor.whiteColor
+          setFrame(screenSize)
+
+          widget.setFrame(screenSize)
+          addSubview(widget)
+        }
+      return UIViewSnapshotter(callback, frame)
+    }
+  }
+}

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSpacerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSpacerTest.kt
@@ -51,7 +51,5 @@ class UIViewSpacerTest(
     }
   }
 
-  override fun verifySnapshot(value: UIView) {
-    callback.verifySnapshot(value, null)
-  }
+  override fun snapshotter(widget: UIView) = UIViewSnapshotter(callback, widget)
 }

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewBoxTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewBoxTest.kt
@@ -22,6 +22,7 @@ import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.layout.AbstractBoxTest
 import app.cash.redwood.layout.Color
+import app.cash.redwood.layout.Snapshotter
 import app.cash.redwood.layout.Text
 import app.cash.redwood.layout.widget.Box
 import com.android.resources.LayoutDirection
@@ -56,18 +57,19 @@ class ViewBoxTest(
     return ViewText(paparazzi.context)
   }
 
-  override fun verifySnapshot(widget: View, name: String?) {
+  override fun snapshotter(widget: View): Snapshotter {
+    // Allow children to wrap.
     val container = object : FrameLayout(paparazzi.context) {
       override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        // Allow children to wrap.
         super.onMeasure(
           MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.AT_MOST),
           MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec), MeasureSpec.AT_MOST),
         )
       }
+    }.apply {
+      addView(widget)
     }
-    container.addView(widget)
-    paparazzi.snapshot(view = container, name = name)
-    container.removeView(widget)
+
+    return ViewSnapshotter(paparazzi, container)
   }
 }

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -60,9 +60,7 @@ class ViewFlexContainerTest(
 
   override fun text() = ViewText(paparazzi.context)
 
-  override fun verifySnapshot(widget: View, name: String?) {
-    paparazzi.snapshot(widget, name)
-  }
+  override fun snapshotter(widget: View) = ViewSnapshotter(paparazzi, widget)
 
   class ViewTestFlexContainer internal constructor(
     private val delegate: ViewFlexContainer,

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewSnapshotter.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewSnapshotter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.view
+
+import android.view.View
+import app.cash.paparazzi.Paparazzi
+import app.cash.redwood.layout.Snapshotter
+
+class ViewSnapshotter(
+  private val paparazzi: Paparazzi,
+  private val view: View,
+) : Snapshotter {
+  override fun snapshot(name: String?) {
+    paparazzi.snapshot(view = view, name = name)
+  }
+}

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewSpacerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewSpacerTest.kt
@@ -51,7 +51,5 @@ class ViewSpacerTest : AbstractSpacerTest<View>() {
     }
   }
 
-  override fun verifySnapshot(value: View) {
-    paparazzi.snapshot(value)
-  }
+  override fun snapshotter(widget: View) = ViewSnapshotter(paparazzi, widget)
 }

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeSnapshotter.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeSnapshotter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.layout.composeui
+
+import androidx.compose.runtime.Composable
+import app.cash.paparazzi.Paparazzi
+import app.cash.redwood.layout.Snapshotter
+
+class ComposeSnapshotter(
+  private val paparazzi: Paparazzi,
+  private val widget: @Composable () -> Unit,
+) : Snapshotter {
+  override fun snapshot(name: String?) {
+    paparazzi.snapshot(name, widget)
+  }
+}

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.redwood.layout.composeui
 
-import app.cash.redwood.Modifier as RedwoodModifier
 import androidx.compose.foundation.background
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -28,6 +27,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.redwood.Modifier as RedwoodModifier
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
 import app.cash.redwood.layout.Text

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.layout.composeui
 
+import app.cash.redwood.Modifier as RedwoodModifier
 import androidx.compose.foundation.background
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -27,7 +28,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
-import app.cash.redwood.Modifier as RedwoodModifier
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
 import app.cash.redwood.layout.Text
@@ -99,11 +99,7 @@ class ComposeUiLazyListTest(
     }
   }
 
-  override fun verifySnapshot(widget: @Composable () -> Unit, name: String?) {
-    paparazzi.snapshot(name) {
-      widget()
-    }
-  }
+  override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)
 
   class ComposeTestFlexContainer private constructor(
     private val delegate: ComposeUiLazyList,

--- a/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
@@ -29,9 +29,6 @@ import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.ResizableWidget
 import app.cash.redwood.widget.Widget
 import app.cash.redwood.yoga.FlexDirection
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.DurationUnit
-import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UILabel
 import platform.UIKit.UIView
 
@@ -68,23 +65,7 @@ class UIViewLazyListAsFlexContainerTest(
     }
   }
 
-  override fun verifySnapshot(widget: UIView, name: String?) {
-    val screenSize = CGRectMake(0.0, 0.0, 390.0, 844.0) // iPhone 14.
-    widget.setFrame(screenSize)
-
-    // Snapshot the container on a white background.
-    val frame = UIView().apply {
-      backgroundColor = platform.UIKit.UIColor.whiteColor
-      setFrame(screenSize)
-      addSubview(widget)
-      layoutIfNeeded()
-    }
-
-    // Unfortunately even with animations forced off, UITableView's animation system breaks
-    // synchronous snapshots. The simplest workaround is to delay snapshots one frame.
-    callback.verifySnapshot(frame, name, delay = 1.milliseconds.toDouble(DurationUnit.SECONDS))
-    widget.removeFromSuperview()
-  }
+  override fun snapshotter(widget: UIView) = UIViewSnapshotter.framed(callback, widget)
 
   class ViewTestFlexContainer private constructor(
     private val delegate: LazyList<UIView>,

--- a/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewSnapshotter.kt
+++ b/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewSnapshotter.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.lazylayout.uiview
+
+import app.cash.redwood.layout.Snapshotter
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIColor
+import platform.UIKit.UIView
+
+/** Snapshot the subject on a white background. */
+class UIViewSnapshotter(
+  private val callback: UIViewSnapshotCallback,
+  private val subject: UIView,
+) : Snapshotter {
+
+  override fun snapshot(name: String?) {
+    layoutSubject()
+
+    // Unfortunately even with animations forced off, UITableView's animation system breaks
+    // synchronous snapshots. The simplest workaround is to delay snapshots one frame.
+    callback.verifySnapshot(subject, name, delay = 1.milliseconds.toDouble(DurationUnit.SECONDS))
+  }
+
+  /** Do layout without taking a snapshot. */
+  fun layoutSubject() {
+    subject.layoutIfNeeded()
+  }
+
+  companion object {
+    fun framed(
+      callback: UIViewSnapshotCallback,
+      widget: UIView,
+    ): UIViewSnapshotter {
+      val frame = UIView()
+        .apply {
+          val screenSize = CGRectMake(0.0, 0.0, 390.0, 844.0) // iPhone 14.
+
+          backgroundColor = UIColor.whiteColor
+          setFrame(screenSize)
+
+          widget.setFrame(screenSize)
+          addSubview(widget)
+        }
+      return UIViewSnapshotter(callback, frame)
+    }
+  }
+}

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
@@ -87,9 +87,7 @@ class ViewLazyListAsFlexContainerTest(
     }
   }
 
-  override fun verifySnapshot(widget: View, name: String?) {
-    paparazzi.snapshot(widget, name)
-  }
+  override fun snapshotter(widget: View) = ViewSnapshotter(paparazzi, widget)
 
   class ViewTestFlexContainer private constructor(
     private val delegate: ViewLazyList,

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewSnapshotter.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewSnapshotter.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.lazylayout.view
+
+import android.view.View
+import app.cash.paparazzi.Paparazzi
+import app.cash.redwood.layout.Snapshotter
+
+class ViewSnapshotter(
+  private val paparazzi: Paparazzi,
+  private val view: View,
+) : Snapshotter {
+  override fun snapshot(name: String?) {
+    paparazzi.snapshot(view = view, name = name)
+  }
+}


### PR DESCRIPTION
I'm attempting to test that changes to the view hierarchy don't cause unnecessary extra layouts, so I need the parent view to remain stable across multiple snapshots. This new Snapshotter interface makes that straightforward.

This is currently only implemented for 'layout' tests. I'll follow up with 'lazylayout' tests next.

