### PR TITLE
Don't make assumptions about the enclosing container

### DIFF
--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:010e0c99b418a88a0be69df5ae6c2735cc51ea48e1fe27b2b6b0f58de760fb5a
+size 59459

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:514c26cbab5c725b414a943f6eb4fee881047fee93fd7771fbdb30a30e42d45a
+size 12473

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d7596538a8f4b5eedd9b1edd13de217b95a0511a2e2776c32af8e1f7b203397
+size 60096

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9cbb7cfdf5886b73a832fee55c17abf494e604c8aebbb0ae0dae33fdb3cb379
+size 12570

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -749,6 +749,44 @@ abstract class AbstractFlexContainerTest<T : Any> {
       assertEquals(cMeasureCountV2, cMeasureCountV3)
     }
   }
+
+  /** Confirm that child element size changes propagate up the view hierarchy. */
+  @Test fun testRecursiveLayoutHandlesResizes() {
+    val column = flexContainer(FlexDirection.Column)
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Fill)
+        crossAxisAlignment(CrossAxisAlignment.Stretch)
+      }
+    val snapshotter = snapshotter(column.value)
+
+    val rowA = row()
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Wrap)
+      }
+      .also { column.add(it) }
+
+    val rowA1 = text("A1 ".repeat(50))
+      .apply { modifier = FlexImpl(1.0) }
+      .also { rowA.children.insert(0, it) }
+    val rowA2 = text("A-TWO ".repeat(50))
+      .apply { modifier = FlexImpl(1.0) }
+      .also { rowA.children.insert(1, it) }
+
+    val rowB = text("B1 ".repeat(5))
+      .apply {
+        modifier = Modifier
+          .then(HorizontalAlignmentImpl(CrossAxisAlignment.Center))
+      }
+      .also { column.add(it) }
+    column.onEndChanges()
+    snapshotter.snapshot("v1")
+
+    rowA1.text("A1 ".repeat(5))
+    rowA2.text("A-TWO ".repeat(5))
+    snapshotter.snapshot("v2")
+  }
 }
 
 interface TestFlexContainer<T : Any> :

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62dda2d66f2d9d29b7aec5e81fb997df3f0746cf10ef95dc52490f5c18e00f1b
+size 142970

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:637d06130ef8bc5ed439dc97b52f27ee9458b536eb16a19575c2f60c5c01a2fb
-size 79741
+oid sha256:3baca195937d9eb18bc3621ac848e92b6a1f3cef7582a7f6932f02267d543b96
+size 78387

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:637d06130ef8bc5ed439dc97b52f27ee9458b536eb16a19575c2f60c5c01a2fb
+size 79741

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -101,6 +101,7 @@ internal class UIViewFlexContainer(
         // The node was newly-dirty. Propagate that up the tree.
         val sizeListener = this.sizeListener
         if (sizeListener != null) {
+          value.setNeedsLayout()
           sizeListener.invalidateSize()
         } else {
           value.invalidateIntrinsicContentSize() // Tell the enclosing view that our size changed.

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -84,26 +84,14 @@ internal class YogaUIView(
 
     // Layout the nodes based on the calculatedLayouts above.
     for (childNode in rootNode.children) {
-      layoutNodes(childNode)
-    }
-  }
-
-  private fun layoutNodes(node: Node) {
-    val x = node.left.toDouble()
-    val y = node.top.toDouble()
-    val width = node.width.toDouble()
-    val height = node.height.toDouble()
-    node.view.setFrame(CGRectMake(x, y, width, height))
-
-    if (node.view is YogaUIView) {
-      // Optimization: for a YogaUIView nested within another YogaUIView,
-      // there's no need to call layoutNodes for its children here,
-      // as it will happen within its own layoutSubviews() pass.
-      return
-    }
-
-    for (childNode in node.children) {
-      layoutNodes(childNode)
+      childNode.view.setFrame(
+        CGRectMake(
+          x = childNode.left.toDouble(),
+          y = childNode.top.toDouble(),
+          width = childNode.width.toDouble(),
+          height = childNode.height.toDouble(),
+        ),
+      )
     }
   }
 

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
@@ -49,6 +49,13 @@ class UIViewFlexContainerTest(
   ): UIViewTestFlexContainer {
     return UIViewTestFlexContainer(UIViewFlexContainer(direction, incremental)).apply {
       value.backgroundColor = backgroundColor.toUIColor()
+
+      // Install a default SizeListener that doesn't do anything. Otherwise the test subject
+      // benefits from fallback behavior that it might not get in other containers.
+      sizeListener = object : SizeListener {
+        override fun invalidateSize() {
+        }
+      }
     }
   }
 

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSnapshotter.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSnapshotter.kt
@@ -27,7 +27,6 @@ class UIViewSnapshotter(
 ) : Snapshotter {
 
   override fun snapshot(name: String?) {
-    layoutSubject()
     callback.verifySnapshot(subject, name)
   }
 

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ad709c45e78d2044dad6630674e8c03335cfc03ce37a2da4900c2fb89c62d96
+size 58919

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13f250f383464dcb3b0971f0f46bd94f028b52e17f6f211565b542c810c1c559
+size 12431

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4d0510f386560f1fba2b802bae733be6d77eb3d9a5dd1e8a23e5b7e4b606cb1
+size 59748

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df2aa26b2ed0f636db3cc496fb8808a9d8ce130f7bff61cd5bc9c535b7c3d404
+size 12609

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3668a85bcc4d5bd5f4e13da7f05afaf7e7429d37ba9c120699e75d9acf51fd34
+size 59331

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d5ad6bf3da5eed1df8d15bdfb02d103f95fcc86b7c85a82b5fca9700556fb30
+size 12344

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a1cb0a65b7f781a3e9c7c6f63772d077fa6b97e6f9e35e9cc35d84619a72d97
+size 59995

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c07f1441bc84c5bb8ba641083040aeedc87740a6ef7d6ac157fbd1edf6ee3c8
+size 12465

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v1.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5451b48979e96cb17d628745cc189f0747f8682f13c668c2c88ff4fe9ec0cea
+size 141836

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c6776c1446efaaf445ec36fb55bbcd9e08c5d4d1bae86602cdfe6ec4746b4f7
+size 77390

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8de5fc5a71c640ca6f955bc1bc1d1aa6262a1865ed24bc0d830455b02ada384a
+size 58756

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[LTR]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b809ac4aaa1ffa351fe1ed3f1a3a726be4b7d951c865d7fdd370233f7316cfe
+size 12275

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8bb6f814a212791a7c4f9d4315bb3e226203939ba6932b137a17fecc1361f49
+size 58399

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testRecursiveLayoutHandlesResizes[RTL]_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c50dae574db67eafce56f47fe4ef412caa0a076a1b44979139c5fa4bd6c1422b
+size 12246


### PR DESCRIPTION
We had a bug in incremental layouts (off by default) where we weren't marking a flex container as needing layout when it needed layout.
