### PR TITLE
Remove most of `Id`'s boxing

### DIFF
--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -10,11 +10,15 @@ public final class app/cash/redwood/protocol/host/HostProtocolAdapter : app/cash
 	public fun sendChanges (Ljava/util/List;)V
 }
 
+public abstract interface class app/cash/redwood/protocol/host/IdVisitor {
+	public abstract fun visit-ou3jOuA (I)V
+}
+
 public final class app/cash/redwood/protocol/host/ProtocolChildren {
 	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;)V
 	public final fun detach ()V
 	public final fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
-	public final fun visitIds (Lkotlin/jvm/functions/Function1;)V
+	public final fun visitIds (Lapp/cash/redwood/protocol/host/IdVisitor;)V
 }
 
 public abstract interface class app/cash/redwood/protocol/host/ProtocolFactory {
@@ -44,7 +48,7 @@ public abstract class app/cash/redwood/protocol/host/ProtocolNode {
 	public final fun setId-ou3jOuA (I)V
 	public abstract fun toString ()Ljava/lang/String;
 	public final fun updateModifier (Lapp/cash/redwood/Modifier;)V
-	public fun visitIds (Lkotlin/jvm/functions/Function1;)V
+	public fun visitIds (Lapp/cash/redwood/protocol/host/IdVisitor;)V
 }
 
 public final class app/cash/redwood/protocol/host/UiEvent {

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <app.cash.redwood:redwood-protocol-host>
+abstract fun interface app.cash.redwood.protocol.host/IdVisitor { // app.cash.redwood.protocol.host/IdVisitor|null[0]
+    abstract fun visit(app.cash.redwood.protocol/Id) // app.cash.redwood.protocol.host/IdVisitor.visit|visit(app.cash.redwood.protocol.Id){}[0]
+}
+
 abstract fun interface app.cash.redwood.protocol.host/UiEventSink { // app.cash.redwood.protocol.host/UiEventSink|null[0]
     abstract fun sendEvent(app.cash.redwood.protocol.host/UiEvent) // app.cash.redwood.protocol.host/UiEventSink.sendEvent|sendEvent(app.cash.redwood.protocol.host.UiEvent){}[0]
 }
@@ -50,7 +54,7 @@ abstract class <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolNode { //
     abstract fun detach() // app.cash.redwood.protocol.host/ProtocolNode.detach|detach(){}[0]
     abstract fun toString(): kotlin/String // app.cash.redwood.protocol.host/ProtocolNode.toString|toString(){}[0]
     final fun updateModifier(app.cash.redwood/Modifier) // app.cash.redwood.protocol.host/ProtocolNode.updateModifier|updateModifier(app.cash.redwood.Modifier){}[0]
-    open fun visitIds(kotlin/Function1<app.cash.redwood.protocol/Id, kotlin/Unit>) // app.cash.redwood.protocol.host/ProtocolNode.visitIds|visitIds(kotlin.Function1<app.cash.redwood.protocol.Id,kotlin.Unit>){}[0]
+    open fun visitIds(app.cash.redwood.protocol.host/IdVisitor) // app.cash.redwood.protocol.host/ProtocolNode.visitIds|visitIds(app.cash.redwood.protocol.host.IdVisitor){}[0]
 }
 
 final class <#A: kotlin/Any> app.cash.redwood.protocol.host/HostProtocolAdapter : app.cash.redwood.protocol/ChangesSink { // app.cash.redwood.protocol.host/HostProtocolAdapter|null[0]
@@ -67,7 +71,7 @@ final class <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolChildren { /
         final fun <get-children>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.protocol.host/ProtocolChildren.children.<get-children>|<get-children>(){}[0]
 
     final fun detach() // app.cash.redwood.protocol.host/ProtocolChildren.detach|detach(){}[0]
-    final fun visitIds(kotlin/Function1<app.cash.redwood.protocol/Id, kotlin/Unit>) // app.cash.redwood.protocol.host/ProtocolChildren.visitIds|visitIds(kotlin.Function1<app.cash.redwood.protocol.Id,kotlin.Unit>){}[0]
+    final fun visitIds(app.cash.redwood.protocol.host/IdVisitor) // app.cash.redwood.protocol.host/ProtocolChildren.visitIds|visitIds(app.cash.redwood.protocol.host.IdVisitor){}[0]
 }
 
 final class app.cash.redwood.protocol.host/UiEvent { // app.cash.redwood.protocol.host/UiEvent|null[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
@@ -66,8 +66,8 @@ public abstract class ProtocolNode<W : Any>(
   public abstract fun children(tag: ChildrenTag): ProtocolChildren<W>?
 
   /** Recursively visit IDs in this widget's tree, starting with this widget's [id]. */
-  public open fun visitIds(block: (Id) -> Unit) {
-    block(id)
+  public open fun visitIds(visitor: IdVisitor) {
+    visitor.visit(id)
   }
 
   /**
@@ -79,6 +79,12 @@ public abstract class ProtocolNode<W : Any>(
 
   /** Human-readable name of this node along with [id] and [widgetTag]. */
   public abstract override fun toString(): String
+}
+
+/** @suppress */
+@RedwoodCodegenApi
+public fun interface IdVisitor {
+  public fun visit(id: Id)
 }
 
 /**
@@ -136,10 +142,10 @@ public class ProtocolChildren<W : Any>(
     children.move(from, to, count)
   }
 
-  public fun visitIds(block: (Id) -> Unit) {
+  public fun visitIds(visitor: IdVisitor) {
     nodes.let { nodes ->
       for (i in nodes.indices) {
-        nodes[i].visitIds(block)
+        nodes[i].visitIds(visitor)
       }
     }
   }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -35,7 +35,6 @@ import com.squareup.kotlinpoet.INT_ARRAY
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -43,7 +42,6 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.buildCodeBlock
 import com.squareup.kotlinpoet.joinToCode
 
@@ -502,12 +500,12 @@ internal fun generateProtocolNode(
             addFunction(
               FunSpec.builder("visitIds")
                 .addModifiers(OVERRIDE)
-                .addParameter("block", LambdaTypeName.get(null, Id, returnType = UNIT))
-                .addStatement("block(id)")
+                .addParameter("visitor", ProtocolHost.IdVisitor)
+                .addStatement("visitor.visit(id)")
                 .apply {
                   for (trait in widget.traits) {
                     if (trait is ProtocolChildren) {
-                      addStatement("%N.visitIds(block)", trait.name)
+                      addStatement("%N.visitIds(visitor)", trait.name)
                     }
                   }
                 }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -48,6 +48,7 @@ internal object ProtocolGuest {
 }
 
 internal object ProtocolHost {
+  val IdVisitor = ClassName("app.cash.redwood.protocol.host", "IdVisitor")
   val ProtocolMismatchHandler =
     ClassName("app.cash.redwood.protocol.host", "ProtocolMismatchHandler")
   val ProtocolNode = ClassName("app.cash.redwood.protocol.host", "ProtocolNode")

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeProtocolNode.kt
@@ -48,10 +48,6 @@ internal class FakeProtocolNode(
     error("unexpected call")
   }
 
-  override fun visitIds(block: (Id) -> Unit) {
-    block(id)
-  }
-
   override fun detach() {
   }
 


### PR DESCRIPTION
Use specialization collections which can store raw `Int`s and a dedicated functional interface that does not use the value class in a generic context (which forces boxing).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
