### PR TITLE
Clamp scroll callback offset to content size maximum

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -139,9 +139,12 @@ internal class YogaUIView(
   override fun scrollViewDidScroll(scrollView: UIScrollView) {
     val onScroll = onScroll
     if (onScroll != null) {
+      val max = scrollView.contentSize.useContents {
+        if (isColumn()) height else width
+      }
       val offset = scrollView.contentOffset.useContents {
         if (isColumn()) y else x
-      }.coerceAtLeast(0.0)
+      }.coerceIn(minimumValue = 0.0, maximumValue = max)
       onScroll(Px(offset))
     }
   }


### PR DESCRIPTION
A quick followup to #2328 

On iOS the scroll can overshoot the bottom of the content which will report offsets larger than the actual size of the scroll content. Since we currently don't pass any information about the actual content size, there's no way for calling code to tell if a user has actually scrolled to the bottom or not. Clamping this value matches the behaviour to what we'd see on Android, or other platforms.

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
