### PR TITLE
Enable incremental layouts by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changed:
 Fixed:
 - Breaking the last remaining retain cycle in `UIViewLazyList`.
 - Don't leak the `DisplayLink` when a `TreehouseApp` is stopped on iOS.
-- Correctly handle dynamic size changes for child widgets of `Box`.
+- Correctly handle dynamic size changes for child widgets of `Box`, `Column`, and `Row`.
 - Correctly implement margins for `Box` on iOS.
 
 

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -45,7 +45,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * currently opt-in, but will soon be the only supported mode.
    */
   open val incremental: Boolean
-    get() = false
+    get() = true
 
   abstract val widgetFactory: TestWidgetFactory<T>
 

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3baca195937d9eb18bc3621ac848e92b6a1f3cef7582a7f6932f02267d543b96
-size 78387
+oid sha256:637d06130ef8bc5ed439dc97b52f27ee9458b536eb16a19575c2f60c5c01a2fb
+size 79741

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewRedwoodLayoutWidgetFactory.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewRedwoodLayoutWidgetFactory.kt
@@ -26,7 +26,7 @@ import app.cash.redwood.yoga.FlexDirection
 
 public class ViewRedwoodLayoutWidgetFactory(
   private val context: Context,
-  private val incremental: Boolean = false,
+  private val incremental: Boolean = true,
 ) : RedwoodLayoutWidgetFactory<View> {
   override fun Box(): Box<View> = ViewBox(context)
 


### PR DESCRIPTION
Next step is to remove the option.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
