### PR TITLE
Do not go through serialization for removed IDs

### DIFF
--- a/redwood-treehouse-guest/src/jsMain/kotlin/app/cash/redwood/treehouse/ProtocolBridgeJs.kt
+++ b/redwood-treehouse-guest/src/jsMain/kotlin/app/cash/redwood/treehouse/ProtocolBridgeJs.kt
@@ -200,8 +200,13 @@ internal class FastGuestProtocolAdapter(
     val tag = tag
     val index = index
     val count = count
-    val removedIds = Json.encodeToDynamic(removedIds)
-    changes.push(js("""["remove",{"id":id,"tag":tag,"index":index,"count":count,"removedIds":removedIds}]"""))
+
+    val removedIdsArray = js("[]")
+    for (i in removedIds.indices) {
+      removedIdsArray.push(removedIds[i].value)
+    }
+
+    changes.push(js("""["remove",{"id":id,"tag":tag,"index":index,"count":count,"removedIds":removedIdsArray}]"""))
   }
 
   override fun emitChanges() {


### PR DESCRIPTION
In practice, this list will be empty for anything but the oldest of hosts. All the more reason to bypass it.

Before:

```js
protoOf(FastGuestProtocolAdapter).f4d = function (id, tag, index, count, removedIds) {
  var id_0 = id;
  var tag_0 = tag;
  var index_0 = index;
  var count_0 = count;
  // Inline function 'kotlinx.serialization.json.encodeToDynamic' call
  var this_0 = Default_getInstance();
  // Inline function 'kotlinx.serialization.serializer' call
  var this_1 = this_0.cm();
  // Inline function 'kotlinx.serialization.internal.cast' call
  var this_2 = serializer(this_1, createKType(getKClass(KtList), arrayOf([createInvariantKTypeProjection(createKType(getKClass(Id), arrayOf([]), false))]), false));
  var tmp$ret$1 = isInterface(this_2, KSerializer) ? this_2 : THROW_CCE();
  var removedIds_0 = encodeToDynamic(this_0, tmp$ret$1, removedIds);
  this.p56_1.push(['remove', {id: id_0, tag: tag_0, index: index_0, count: count_0, removedIds: removedIds_0}]);
};
```

After:

```js
protoOf(FastGuestProtocolAdapter).f4d = function (id, tag, index, count, removedIds) {
  var id_0 = id;
  var tag_0 = tag;
  var index_0 = index;
  var count_0 = count;
  var removedIdsArray = [];
  var inductionVariable = 0;
  var last = removedIds.n() - 1 | 0;
  if (inductionVariable <= last)
    do {
      var i = inductionVariable;
      inductionVariable = inductionVariable + 1 | 0;
      removedIdsArray.push(_Id___get_value__impl__b6l2oq(removedIds.q(i).h1l_1));
    }
     while (inductionVariable <= last);
  this.p56_1.push(['remove', {id: id_0, tag: tag_0, index: index_0, count: count_0, removedIds: removedIdsArray}]);
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
