### PR TITLE
Clear up dual schema nomenclature in codegen

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolCodegen.kt
@@ -38,10 +38,10 @@ internal fun ProtocolSchemaSet.generateFileSpecs(type: ProtocolCodegenType): Lis
       Guest -> {
         add(generateProtocolWidgetSystemFactory(this@generateFileSpecs))
         for (dependency in all) {
-          add(generateProtocolWidgetFactory(dependency, host = schema))
-          generateProtocolModifierSerializers(dependency, host = schema)?.let { add(it) }
+          add(generateProtocolWidgetFactory(schema, dependency))
+          generateProtocolModifierSerializers(schema, dependency)?.let { add(it) }
           for (widget in dependency.widgets) {
-            add(generateProtocolWidget(dependency, widget, host = schema))
+            add(generateProtocolWidget(schema, dependency, widget))
           }
         }
       }
@@ -49,9 +49,9 @@ internal fun ProtocolSchemaSet.generateFileSpecs(type: ProtocolCodegenType): Lis
       Host -> {
         add(generateProtocolFactory(this@generateFileSpecs))
         for (dependency in all) {
-          generateProtocolModifierImpls(dependency, host = schema)?.let { add(it) }
+          generateProtocolModifierImpls(schema, dependency)?.let { add(it) }
           for (widget in dependency.widgets) {
-            add(generateProtocolNode(dependency, widget, host = schema))
+            add(generateProtocolNode(schema, dependency, widget))
           }
         }
       }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/sharedHelpers.kt
@@ -72,11 +72,11 @@ internal fun Schema.modifierPackage() = type.names[0] + ".modifier"
 internal fun Schema.testingPackage() = type.names[0] + ".testing"
 internal fun Schema.widgetPackage() = type.names[0] + ".widget"
 
-internal fun Schema.guestProtocolPackage(host: Schema? = null) = protocolPackage("guest", host)
-internal fun Schema.hostProtocolPackage(host: Schema? = null) = protocolPackage("host", host)
-private fun Schema.protocolPackage(name: String, host: Schema?): String {
-  val base = (host ?: this).type.names[0] + ".protocol." + name
-  return if (host != null) "$base.${type.flatName.lowercase()}" else base
+internal fun Schema.guestProtocolPackage(otherSchema: Schema? = null) = protocolPackage("guest", otherSchema)
+internal fun Schema.hostProtocolPackage(otherSchema: Schema? = null) = protocolPackage("host", otherSchema)
+private fun Schema.protocolPackage(name: String, otherSchema: Schema?): String {
+  val base = type.names[0] + ".protocol." + name
+  return if (otherSchema != null) "$base.${otherSchema.type.flatName.lowercase()}" else base
 }
 
 internal fun Schema.widgetType(widget: Widget): ClassName {

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ProtocolGuestGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/ProtocolGuestGenerationTest.kt
@@ -40,7 +40,7 @@ class ProtocolGuestGenerationTest {
   @Test fun `id property does not collide`() {
     val schema = parseTestSchema(IdPropertyNameCollisionSchema::class).schema
 
-    val fileSpec = generateProtocolWidget(schema, schema.widgets.single())
+    val fileSpec = generateProtocolWidget(schema, schema, schema.widgets.single())
     assertThat(fileSpec.toString()).contains(
       """
       |  override fun id(id: String) {


### PR DESCRIPTION
We now have "generating" instead of "host", since "host" is already used in host/guest differentiation.

The "other" schema (i.e., non-generating) is called "other" or perhaps something more specific (like "modifierSchema" when used as the source of a modifier).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
