### PR TITLE
Create a widget protocol descriptor type

### DIFF
--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -1,7 +1,6 @@
-public abstract interface class app/cash/redwood/protocol/host/GeneratedProtocolFactory : app/cash/redwood/protocol/host/ProtocolFactory {
+public abstract interface class app/cash/redwood/protocol/host/GeneratedHostProtocol : app/cash/redwood/protocol/host/ProtocolFactory {
 	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
-	public abstract fun createNode-kyz2zXs (II)Lapp/cash/redwood/protocol/host/ProtocolNode;
-	public abstract fun widgetChildren-WCEpcRY (I)[I
+	public abstract fun widget-WCEpcRY (I)Lapp/cash/redwood/protocol/host/WidgetHostProtocol;
 }
 
 public final class app/cash/redwood/protocol/host/HostProtocolAdapter : app/cash/redwood/protocol/ChangesSink {
@@ -66,5 +65,10 @@ public abstract interface class app/cash/redwood/protocol/host/UiEventSink {
 
 public final class app/cash/redwood/protocol/host/VersionKt {
 	public static final fun getHostRedwoodVersion ()Ljava/lang/String;
+}
+
+public abstract interface class app/cash/redwood/protocol/host/WidgetHostProtocol {
+	public abstract fun createNode-ou3jOuA (I)Lapp/cash/redwood/protocol/host/ProtocolNode;
+	public abstract fun getChildrenTags ()[I
 }
 

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -14,10 +14,16 @@ abstract fun interface app.cash.redwood.protocol.host/UiEventSink { // app.cash.
     abstract fun sendEvent(app.cash.redwood.protocol.host/UiEvent) // app.cash.redwood.protocol.host/UiEventSink.sendEvent|sendEvent(app.cash.redwood.protocol.host.UiEvent){}[0]
 }
 
-abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/GeneratedProtocolFactory : app.cash.redwood.protocol.host/ProtocolFactory<#A> { // app.cash.redwood.protocol.host/GeneratedProtocolFactory|null[0]
-    abstract fun createModifier(app.cash.redwood.protocol/ModifierElement): app.cash.redwood/Modifier // app.cash.redwood.protocol.host/GeneratedProtocolFactory.createModifier|createModifier(app.cash.redwood.protocol.ModifierElement){}[0]
-    abstract fun createNode(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/WidgetTag): app.cash.redwood.protocol.host/ProtocolNode<#A>? // app.cash.redwood.protocol.host/GeneratedProtocolFactory.createNode|createNode(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.WidgetTag){}[0]
-    abstract fun widgetChildren(app.cash.redwood.protocol/WidgetTag): kotlin/IntArray? // app.cash.redwood.protocol.host/GeneratedProtocolFactory.widgetChildren|widgetChildren(app.cash.redwood.protocol.WidgetTag){}[0]
+abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/GeneratedHostProtocol : app.cash.redwood.protocol.host/ProtocolFactory<#A> { // app.cash.redwood.protocol.host/GeneratedHostProtocol|null[0]
+    abstract fun createModifier(app.cash.redwood.protocol/ModifierElement): app.cash.redwood/Modifier // app.cash.redwood.protocol.host/GeneratedHostProtocol.createModifier|createModifier(app.cash.redwood.protocol.ModifierElement){}[0]
+    abstract fun widget(app.cash.redwood.protocol/WidgetTag): app.cash.redwood.protocol.host/WidgetHostProtocol<#A>? // app.cash.redwood.protocol.host/GeneratedHostProtocol.widget|widget(app.cash.redwood.protocol.WidgetTag){}[0]
+}
+
+abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/WidgetHostProtocol { // app.cash.redwood.protocol.host/WidgetHostProtocol|null[0]
+    abstract val childrenTags // app.cash.redwood.protocol.host/WidgetHostProtocol.childrenTags|{}childrenTags[0]
+        abstract fun <get-childrenTags>(): kotlin/IntArray? // app.cash.redwood.protocol.host/WidgetHostProtocol.childrenTags.<get-childrenTags>|<get-childrenTags>(){}[0]
+
+    abstract fun createNode(app.cash.redwood.protocol/Id): app.cash.redwood.protocol.host/ProtocolNode<#A> // app.cash.redwood.protocol.host/WidgetHostProtocol.createNode|createNode(app.cash.redwood.protocol.Id){}[0]
 }
 
 abstract interface app.cash.redwood.protocol.host/ProtocolMismatchHandler { // app.cash.redwood.protocol.host/ProtocolMismatchHandler|null[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -57,7 +57,7 @@ public class HostProtocolAdapter<W : Any>(
   private val leakDetector: LeakDetector,
 ) : ChangesSink {
   private val factory = when (factory) {
-    is GeneratedProtocolFactory -> factory
+    is GeneratedHostProtocol -> factory
   }
 
   private val nodes =
@@ -83,7 +83,8 @@ public class HostProtocolAdapter<W : Any>(
       val id = change.id
       when (change) {
         is Create -> {
-          val node = factory.createNode(id, change.tag) ?: continue
+          val widgetProtocol = factory.widget(change.tag) ?: continue
+          val node = widgetProtocol.createNode(id)
           val old = nodes.put(change.id.value, node)
           require(old == null) {
             "Insert attempted to replace existing widget with ID ${change.id.value}"

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/NodeReuse.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/NodeReuse.kt
@@ -31,7 +31,7 @@ import app.cash.redwood.protocol.host.HostProtocolAdapter.ReuseNode
  */
 @OptIn(RedwoodCodegenApi::class)
 internal fun shapesEqual(
-  factory: GeneratedProtocolFactory<*>,
+  factory: GeneratedHostProtocol<*>,
   a: ReuseNode<*>,
   b: ProtocolNode<*>,
 ): Boolean {
@@ -39,7 +39,8 @@ internal fun shapesEqual(
   if (a.widgetTag == UnknownWidgetTag) return false // No 'Create' for this.
   if (b.widgetTag != a.widgetTag) return false // Widget types don't match.
 
-  val widgetChildren = factory.widgetChildren(a.widgetTag)
+  val widgetChildren = factory.widget(a.widgetTag)
+    ?.childrenTags
     ?: return true // Widget has no children.
 
   return widgetChildren.all { childrenTag ->
@@ -59,7 +60,7 @@ internal fun shapesEqual(
  */
 @OptIn(RedwoodCodegenApi::class)
 private fun childrenEqual(
-  factory: GeneratedProtocolFactory<*>,
+  factory: GeneratedHostProtocol<*>,
   aChildren: List<ReuseNode<*>>,
   bChildren: List<ProtocolNode<*>>,
   childrenTag: ChildrenTag,
@@ -81,7 +82,7 @@ private fun childrenEqual(
 /** Returns a hash of this node, or 0L if this node isn't eligible for reuse. */
 @OptIn(RedwoodCodegenApi::class)
 internal fun shapeHash(
-  factory: GeneratedProtocolFactory<*>,
+  factory: GeneratedHostProtocol<*>,
   node: ReuseNode<*>,
 ): Long {
   if (!node.eligibleForReuse) return 0L // This node is ineligible.
@@ -89,7 +90,7 @@ internal fun shapeHash(
 
   var result = node.widgetTag.value.toLong()
 
-  factory.widgetChildren(node.widgetTag)?.forEach { childrenTag ->
+  factory.widget(node.widgetTag)?.childrenTags?.forEach { childrenTag ->
     result = (result * 37L) + childrenTag
     var childCount = 0
     for (child in node.children) {
@@ -106,11 +107,11 @@ internal fun shapeHash(
 /** Returns the same hash as [shapeHash], but on an already-built [ProtocolNode]. */
 @OptIn(RedwoodCodegenApi::class)
 internal fun shapeHash(
-  factory: GeneratedProtocolFactory<*>,
+  factory: GeneratedHostProtocol<*>,
   node: ProtocolNode<*>,
 ): Long {
   var result = node.widgetTag.value.toLong()
-  factory.widgetChildren(node.widgetTag)?.forEach { childrenTag ->
+  factory.widget(node.widgetTag)?.childrenTags?.forEach { childrenTag ->
     result = (result * 37L) + childrenTag
     val children = node.children(ChildrenTag(childrenTag))
       ?: return@forEach // This acts like a 'continue'.

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolFactory.kt
@@ -35,20 +35,20 @@ public sealed interface ProtocolFactory<W : Any> {
 }
 
 /**
- * [ProtocolFactory] but containing codegen APIs.
+ * [ProtocolFactory] but containing codegen APIs for a schema.
  *
  * @suppress
  */
 @RedwoodCodegenApi
-public interface GeneratedProtocolFactory<W : Any> : ProtocolFactory<W> {
+public interface GeneratedHostProtocol<W : Any> : ProtocolFactory<W> {
   /**
-   * Create a new protocol node with [id] of the specified [tag].
+   * Look up host protocol information for a widget with the given [tag].
    *
    * Invalid [tag] values can either produce an exception or result in `null` being returned.
    * If `null` is returned, the caller should make every effort to ignore this node and
    * continue executing.
    */
-  public fun createNode(id: Id, tag: WidgetTag): ProtocolNode<W>?
+  public fun widget(tag: WidgetTag): WidgetHostProtocol<W>?
 
   /**
    * Create a new modifier from the specified [element].
@@ -57,12 +57,22 @@ public interface GeneratedProtocolFactory<W : Any> : ProtocolFactory<W> {
    * or result in the unit [`Modifier`][Modifier.Companion] being returned.
    */
   public fun createModifier(element: ModifierElement): Modifier
+}
+
+/**
+ * Protocol APIs for a widget definition.
+ *
+ * @suppress
+ */
+@RedwoodCodegenApi
+public interface WidgetHostProtocol<W : Any> {
+  /** Create an instance of this widget wrapped as a [ProtocolNode] with the given [id]. */
+  public fun createNode(id: Id): ProtocolNode<W>
 
   /**
-   * Look up known children tags for the given widget [tag]. These are stored as a bare [IntArray]
-   * for efficiency, but are otherwise an array of [ChildrenTag] instances.
-   *
-   * @return `null` when widget has no children
+   * Look up known children tags for this widget. These are stored as a bare [IntArray]
+   * for efficiency, but are otherwise an array of [ChildrenTag] instances. A value of
+   * `null` indicates no children.
    */
-  public fun widgetChildren(tag: WidgetTag): IntArray?
+  public val childrenTags: IntArray?
 }

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ProtocolFactoryTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ProtocolFactoryTest.kt
@@ -60,7 +60,7 @@ class ProtocolFactoryTest {
     )
 
     val t = assertFailsWith<IllegalArgumentException> {
-      factory.createNode(Id(1), WidgetTag(345432))
+      factory.widget(WidgetTag(345432))
     }
     assertThat(t).hasMessage("Unknown widget tag 345432")
   }
@@ -76,8 +76,7 @@ class ProtocolFactoryTest {
       mismatchHandler = handler,
     )
 
-    assertThat(factory.createNode(Id(1), WidgetTag(345432))).isNull()
-
+    assertThat(factory.widget(WidgetTag(345432))).isNull()
     assertThat(handler.events.single()).isEqualTo("Unknown widget 345432")
   }
 
@@ -216,7 +215,7 @@ class ProtocolFactoryTest {
         RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
       ),
     )
-    val button = factory.createNode(Id(1), WidgetTag(4))!!
+    val button = factory.widget(WidgetTag(4))!!.createNode(Id(1))
 
     val t = assertFailsWith<IllegalArgumentException> {
       button.children(ChildrenTag(345432))
@@ -235,7 +234,7 @@ class ProtocolFactoryTest {
       mismatchHandler = handler,
     )
 
-    val button = factory.createNode(Id(1), WidgetTag(4))!!
+    val button = factory.widget(WidgetTag(4))!!.createNode(Id(1))
     assertThat(button.children(ChildrenTag(345432))).isNull()
 
     assertThat(handler.events.single()).isEqualTo("Unknown children 345432 for 4")
@@ -255,7 +254,7 @@ class ProtocolFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.createNode(Id(1), WidgetTag(5))!!
+    val textInput = factory.widget(WidgetTag(5))!!.createNode(Id(1))
 
     val throwingEventSink = UiEventSink { error(it) }
     textInput.apply(PropertyChange(Id(1), PropertyTag(2), JsonPrimitive("PT10S")), throwingEventSink)
@@ -271,7 +270,7 @@ class ProtocolFactoryTest {
         RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
       ),
     )
-    val button = factory.createNode(Id(1), WidgetTag(4))!!
+    val button = factory.widget(WidgetTag(4))!!.createNode(Id(1))
 
     val change = PropertyChange(Id(1), PropertyTag(345432))
     val eventSink = UiEventSink { throw UnsupportedOperationException() }
@@ -291,7 +290,7 @@ class ProtocolFactoryTest {
       ),
       mismatchHandler = handler,
     )
-    val button = factory.createNode(Id(1), WidgetTag(4))!!
+    val button = factory.widget(WidgetTag(4))!!.createNode(Id(1))
 
     button.apply(PropertyChange(Id(1), PropertyTag(345432))) { throw UnsupportedOperationException() }
 
@@ -312,7 +311,7 @@ class ProtocolFactoryTest {
       ),
       json = json,
     )
-    val textInput = factory.createNode(Id(1), WidgetTag(5))!!
+    val textInput = factory.widget(WidgetTag(5))!!.createNode(Id(1))
 
     val eventSink = RecordingUiEventSink()
     textInput.apply(PropertyChange(Id(1), PropertyTag(4), JsonPrimitive(true)), eventSink)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -54,9 +54,10 @@ internal object ProtocolHost {
     ClassName("app.cash.redwood.protocol.host", "ProtocolMismatchHandler")
   val ProtocolNode = ClassName("app.cash.redwood.protocol.host", "ProtocolNode")
   val ProtocolChildren = ClassName("app.cash.redwood.protocol.host", "ProtocolChildren")
-  val GeneratedProtocolFactory = ClassName("app.cash.redwood.protocol.host", "GeneratedProtocolFactory")
+  val GeneratedProtocolHost = ClassName("app.cash.redwood.protocol.host", "GeneratedHostProtocol")
   val UiEvent = ClassName("app.cash.redwood.protocol.host", "UiEvent")
   val UiEventSink = ClassName("app.cash.redwood.protocol.host", "UiEventSink")
+  val WidgetHostProtocol = ClassName("app.cash.redwood.protocol.host", "WidgetHostProtocol")
 }
 
 internal object Redwood {

--- a/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
+++ b/redwood-tooling-codegen/src/test/kotlin/app/cash/redwood/tooling/codegen/WidgetProtocolGenerationTest.kt
@@ -15,50 +15,14 @@
  */
 package app.cash.redwood.tooling.codegen
 
-import app.cash.redwood.schema.Property
-import app.cash.redwood.schema.Schema
-import app.cash.redwood.schema.Widget
 import app.cash.redwood.tooling.schema.ProtocolSchemaSet
-import app.cash.redwood.tooling.schema.parseTestSchema
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
-import assertk.assertions.containsMatch
 import com.example.redwood.testapp.TestSchema
-import kotlin.text.RegexOption.MULTILINE
 import org.junit.Test
 
 class WidgetProtocolGenerationTest {
-  @Schema(
-    [
-      Node12::class,
-      Node1::class,
-      Node3::class,
-      Node2::class,
-    ],
-  )
-  interface SortedByTagSchema
-
-  @Widget(1)
-  data class Node1(@Property(1) val text: String)
-
-  @Widget(2)
-  data class Node2(@Property(1) val text: String)
-
-  @Widget(3)
-  data class Node3(@Property(1) val text: String)
-
-  @Widget(12)
-  data class Node12(@Property(1) val text: String)
-
-  @Test fun `names are sorted by their node tags`() {
-    val schema = parseTestSchema(SortedByTagSchema::class)
-
-    val fileSpec = generateProtocolFactory(schema)
-    assertThat(fileSpec.toString())
-      .containsMatch(Regex("1 ->[^2]+2 ->[^3]+3 ->[^1]+12 ->", MULTILINE))
-  }
-
   @Test fun `dependency layout modifier are included in serialization`() {
     val schema = ProtocolSchemaSet.load(TestSchema::class)
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeHostProtocol.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeHostProtocol.kt
@@ -20,14 +20,22 @@ import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.ModifierElement
 import app.cash.redwood.protocol.WidgetTag
-import app.cash.redwood.protocol.host.GeneratedProtocolFactory
+import app.cash.redwood.protocol.host.GeneratedHostProtocol
 import app.cash.redwood.protocol.host.ProtocolNode
+import app.cash.redwood.protocol.host.WidgetHostProtocol
 import app.cash.redwood.widget.WidgetSystem
 
 @OptIn(RedwoodCodegenApi::class)
-internal class FakeProtocolNodeFactory : GeneratedProtocolFactory<FakeWidget> {
+internal class FakeHostProtocol : GeneratedHostProtocol<FakeWidget> {
   override val widgetSystem: WidgetSystem<FakeWidget> = FakeWidgetSystem()
-  override fun createNode(id: Id, tag: WidgetTag): ProtocolNode<FakeWidget> = FakeProtocolNode(id, tag)
+  override fun widget(tag: WidgetTag): WidgetHostProtocol<FakeWidget>? = FakeWidgetHostProtocol(tag)
   override fun createModifier(element: ModifierElement): Modifier = Modifier
-  override fun widgetChildren(tag: WidgetTag): IntArray? = null
+}
+
+@OptIn(RedwoodCodegenApi::class)
+private class FakeWidgetHostProtocol(
+  private val tag: WidgetTag,
+) : WidgetHostProtocol<FakeWidget> {
+  override fun createNode(id: Id): ProtocolNode<FakeWidget> = FakeProtocolNode(id, tag)
+  override val childrenTags: IntArray? get() = null
 }

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseWidgetSystem.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeTreehouseWidgetSystem.kt
@@ -22,5 +22,5 @@ internal class FakeTreehouseWidgetSystem : TreehouseView.WidgetSystem<FakeWidget
   override fun widgetFactory(
     json: Json,
     protocolMismatchHandler: ProtocolMismatchHandler,
-  ) = FakeProtocolNodeFactory()
+  ) = FakeHostProtocol()
 }


### PR DESCRIPTION
This has knowledge of the child IDs for this widget as well as the ability to create instances of it.

In the future this will also hold more information such as property IDs so that we can deserialize them on the Zipline thread.

Part of #2145.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
