### PR TITLE
Mark `RedwoodComposeNode` as `@ExplicitGroupsComposable`

### DIFF
--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.ComposeNode
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.ExplicitGroupsComposable
 import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.Updater
@@ -187,6 +188,7 @@ public interface RedwoodApplier<W : Any> {
  */
 @Composable
 @RedwoodCodegenApi
+@ExplicitGroupsComposable
 public inline fun <O : WidgetFactoryOwner<V>, W : Widget<V>, V : Any> RedwoodComposeNode(
   crossinline factory: (O) -> W,
   update: @DisallowComposableCalls Updater<WidgetNode<W, V>>.() -> Unit,


### PR DESCRIPTION
This eliminates compiler-generated group management which is not needed for this low-level function.

Example diff:

```diff
 // Inline function 'app.cash.redwood.compose.RedwoodComposeNode' call
 var $composer_1 = $composer_0;
-$composer_1.startReplaceableGroup_ip860b_k$(-1884366384);
 $composer_1.startNode_htvs8k_k$();
 if ($composer_1.get_inserting_25mlsw_k$()) {
   var tmp = ensureNotNull($composer_1.get_applier_bupu8u_k$());
   var applier = isInterface(tmp, RedwoodApplier) ? tmp : THROW_CCE();
   var tmp_0 = $composer_1;
   tmp_0.createNode_ahrd54_k$(function () {
     // Inline function 'com.example.redwood.testapp.compose.Button.<anonymous>' call
     var tmp = applier.get_widgetSystem_mxid3w_k$();
     var tmp$ret$0 = (isInterface(tmp, WidgetFactoryOwner) ? tmp : THROW_CCE()).get_TestSchema_txdklg_k$().Button_x3fioi_k$();
     return new WidgetNode(applier, tmp$ret$0);
   });
 } else {
   $composer_1.useNode_io5s9l_k$();
 }
 // Inline function 'com.example.redwood.testapp.compose.Button.<anonymous>' call
 var $this$RedwoodComposeNode = _Updater___init__impl__rbfxm8($composer_1);
 Updater__set_impl_v7kwss($this$RedwoodComposeNode, text, Button$lambda);
 Updater__set_impl_v7kwss($this$RedwoodComposeNode, onClick, Button$lambda_0);
 var tmp_1 = color_0._v;
 Updater__set_impl_v7kwss($this$RedwoodComposeNode, tmp_1, Button$lambda_1);
 Updater__set_impl_v7kwss($this$RedwoodComposeNode, modifier_0._v, Companion_getInstance_0().get_SetModifiers_1a2o4j_k$());
 // Inline function 'com.example.redwood.testapp.compose.Button.<anonymous>' call
 Companion_getInstance_1().get_Instance_ljxvgi_k$();
 var $composer_2 = $composer_1;
 $composer_1.endNode_3m0yfn_k$();
-$composer_1.endReplaceableGroup_ern0ak_k$();
 if (isTraceInProgress()) {
   traceEventEnd();
 }
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
