### PR TITLE
Do not track API for generated code

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -524,6 +524,8 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
         klib.strictValidation = isCiEnvironment
 
         nonPublicMarkers += listOf(
+          // Codegen-specific API only supports the exact same version as which did the generation.
+          "app.cash.redwood.RedwoodCodegenApi",
           // The yoga module is an implementation detail of our layouts.
           "app.cash.redwood.yoga.RedwoodYogaApi",
         )

--- a/redwood-compose/api/android/redwood-compose.api
+++ b/redwood-compose/api/android/redwood-compose.api
@@ -1,8 +1,3 @@
-public final class app/cash/redwood/compose/ActualsKt {
-	public static final fun redwoodApplier (Landroidx/compose/runtime/Composer;)Lapp/cash/redwood/compose/RedwoodApplier;
-	public static final fun widgetSystem (Lapp/cash/redwood/compose/RedwoodApplier;)Lapp/cash/redwood/widget/WidgetFactoryOwner;
-}
-
 public final class app/cash/redwood/compose/AndroidUiDispatcher : kotlinx/coroutines/CoroutineDispatcher {
 	public static final field $stable I
 	public static final field Companion Lapp/cash/redwood/compose/AndroidUiDispatcher$Companion;
@@ -31,32 +26,12 @@ public final class app/cash/redwood/compose/BackHandlerKt {
 	public static final fun getLocalOnBackPressedDispatcher ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
-public abstract interface class app/cash/redwood/compose/Node {
-}
-
-public abstract interface class app/cash/redwood/compose/RedwoodApplier {
-	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
-	public abstract fun recordChanged (Lapp/cash/redwood/widget/Widget;)V
-}
-
-public final class app/cash/redwood/compose/RedwoodComposeContent {
-	public static final field $stable I
-	public static final field Companion Lapp/cash/redwood/compose/RedwoodComposeContent$Companion;
-	public fun <init> ()V
-	public final fun Children (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-}
-
-public final class app/cash/redwood/compose/RedwoodComposeContent$Companion {
-	public final fun getInstance ()Lapp/cash/redwood/compose/RedwoodComposeContent;
-}
-
 public abstract interface class app/cash/redwood/compose/RedwoodComposition {
 	public abstract fun cancel ()V
 	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class app/cash/redwood/compose/RedwoodCompositionKt {
-	public static final fun RedwoodComposeNode (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
 	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
 	public static synthetic fun RedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/compose/RedwoodComposition;
@@ -66,22 +41,6 @@ public final class app/cash/redwood/compose/RedwoodCompositionKt {
 public final class app/cash/redwood/compose/UiConfigurationKt {
 	public static final fun getCurrent (Lapp/cash/redwood/ui/UiConfiguration$Companion;Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/UiConfiguration;
 	public static final fun getLocalUiConfiguration ()Landroidx/compose/runtime/ProvidableCompositionLocal;
-}
-
-public final class app/cash/redwood/compose/WidgetNode : app/cash/redwood/compose/Node {
-	public static final field $stable I
-	public static final field Companion Lapp/cash/redwood/compose/WidgetNode$Companion;
-	public fun <init> (Lapp/cash/redwood/compose/RedwoodApplier;Lapp/cash/redwood/widget/Widget;)V
-	public final fun getContainer ()Lapp/cash/redwood/widget/Widget$Children;
-	public final fun getIndex ()I
-	public final fun getWidget ()Lapp/cash/redwood/widget/Widget;
-	public final fun recordChanged ()V
-	public final fun setContainer (Lapp/cash/redwood/widget/Widget$Children;)V
-	public final fun setIndex (I)V
-}
-
-public final class app/cash/redwood/compose/WidgetNode$Companion {
-	public final fun getSetModifiers ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class app/cash/redwood/compose/WidgetVersionKt {

--- a/redwood-compose/api/jvm/redwood-compose.api
+++ b/redwood-compose/api/jvm/redwood-compose.api
@@ -1,31 +1,7 @@
-public final class app/cash/redwood/compose/ActualsKt {
-	public static final fun redwoodApplier (Landroidx/compose/runtime/Composer;)Lapp/cash/redwood/compose/RedwoodApplier;
-	public static final fun widgetSystem (Lapp/cash/redwood/compose/RedwoodApplier;)Lapp/cash/redwood/widget/WidgetFactoryOwner;
-}
-
 public final class app/cash/redwood/compose/BackHandlerKt {
 	public static final fun BackHandler (ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 	public static final fun getCurrent (Lapp/cash/redwood/ui/OnBackPressedDispatcher$Companion;Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/OnBackPressedDispatcher;
 	public static final fun getLocalOnBackPressedDispatcher ()Landroidx/compose/runtime/ProvidableCompositionLocal;
-}
-
-public abstract interface class app/cash/redwood/compose/Node {
-}
-
-public abstract interface class app/cash/redwood/compose/RedwoodApplier {
-	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
-	public abstract fun recordChanged (Lapp/cash/redwood/widget/Widget;)V
-}
-
-public final class app/cash/redwood/compose/RedwoodComposeContent {
-	public static final field $stable I
-	public static final field Companion Lapp/cash/redwood/compose/RedwoodComposeContent$Companion;
-	public fun <init> ()V
-	public final fun Children (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-}
-
-public final class app/cash/redwood/compose/RedwoodComposeContent$Companion {
-	public final fun getInstance ()Lapp/cash/redwood/compose/RedwoodComposeContent;
 }
 
 public abstract interface class app/cash/redwood/compose/RedwoodComposition {
@@ -34,7 +10,6 @@ public abstract interface class app/cash/redwood/compose/RedwoodComposition {
 }
 
 public final class app/cash/redwood/compose/RedwoodCompositionKt {
-	public static final fun RedwoodComposeNode (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
 	public static final fun RedwoodComposition (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;)Lapp/cash/redwood/compose/RedwoodComposition;
 	public static synthetic fun RedwoodComposition$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/widget/RedwoodView;Lapp/cash/redwood/widget/WidgetSystem;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/compose/RedwoodComposition;
@@ -44,22 +19,6 @@ public final class app/cash/redwood/compose/RedwoodCompositionKt {
 public final class app/cash/redwood/compose/UiConfigurationKt {
 	public static final fun getCurrent (Lapp/cash/redwood/ui/UiConfiguration$Companion;Landroidx/compose/runtime/Composer;I)Lapp/cash/redwood/ui/UiConfiguration;
 	public static final fun getLocalUiConfiguration ()Landroidx/compose/runtime/ProvidableCompositionLocal;
-}
-
-public final class app/cash/redwood/compose/WidgetNode : app/cash/redwood/compose/Node {
-	public static final field $stable I
-	public static final field Companion Lapp/cash/redwood/compose/WidgetNode$Companion;
-	public fun <init> (Lapp/cash/redwood/compose/RedwoodApplier;Lapp/cash/redwood/widget/Widget;)V
-	public final fun getContainer ()Lapp/cash/redwood/widget/Widget$Children;
-	public final fun getIndex ()I
-	public final fun getWidget ()Lapp/cash/redwood/widget/Widget;
-	public final fun recordChanged ()V
-	public final fun setContainer (Lapp/cash/redwood/widget/Widget$Children;)V
-	public final fun setIndex (I)V
-}
-
-public final class app/cash/redwood/compose/WidgetNode$Companion {
-	public final fun getSetModifiers ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class app/cash/redwood/compose/WidgetVersionKt {

--- a/redwood-compose/api/redwood-compose.klib.api
+++ b/redwood-compose/api/redwood-compose.klib.api
@@ -7,50 +7,9 @@
 // - Show declarations: true
 
 // Library unique name: <app.cash.redwood:redwood-compose>
-abstract interface <#A: kotlin/Any> app.cash.redwood.compose/RedwoodApplier { // app.cash.redwood.compose/RedwoodApplier|null[0]
-    abstract val widgetSystem // app.cash.redwood.compose/RedwoodApplier.widgetSystem|{}widgetSystem[0]
-        abstract fun <get-widgetSystem>(): app.cash.redwood.widget/WidgetSystem<#A> // app.cash.redwood.compose/RedwoodApplier.widgetSystem.<get-widgetSystem>|<get-widgetSystem>(){}[0]
-
-    abstract fun recordChanged(app.cash.redwood.widget/Widget<#A>) // app.cash.redwood.compose/RedwoodApplier.recordChanged|recordChanged(app.cash.redwood.widget.Widget<1:0>){}[0]
-}
-
 abstract interface app.cash.redwood.compose/RedwoodComposition { // app.cash.redwood.compose/RedwoodComposition|null[0]
     abstract fun cancel() // app.cash.redwood.compose/RedwoodComposition.cancel|cancel(){}[0]
     abstract fun setContent(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>) // app.cash.redwood.compose/RedwoodComposition.setContent|setContent(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
-}
-
-sealed interface <#A: kotlin/Any> app.cash.redwood.compose/Node // app.cash.redwood.compose/Node|null[0]
-
-final class <#A: out app.cash.redwood.widget/Widget<#B>, #B: kotlin/Any> app.cash.redwood.compose/WidgetNode : app.cash.redwood.compose/Node<#B> { // app.cash.redwood.compose/WidgetNode|null[0]
-    constructor <init>(app.cash.redwood.compose/RedwoodApplier<#B>, #A) // app.cash.redwood.compose/WidgetNode.<init>|<init>(app.cash.redwood.compose.RedwoodApplier<1:1>;1:0){}[0]
-
-    final val widget // app.cash.redwood.compose/WidgetNode.widget|{}widget[0]
-        final fun <get-widget>(): #A // app.cash.redwood.compose/WidgetNode.widget.<get-widget>|<get-widget>(){}[0]
-
-    final var container // app.cash.redwood.compose/WidgetNode.container|{}container[0]
-        final fun <get-container>(): app.cash.redwood.widget/Widget.Children<#B>? // app.cash.redwood.compose/WidgetNode.container.<get-container>|<get-container>(){}[0]
-        final fun <set-container>(app.cash.redwood.widget/Widget.Children<#B>?) // app.cash.redwood.compose/WidgetNode.container.<set-container>|<set-container>(app.cash.redwood.widget.Widget.Children<1:1>?){}[0]
-    final var index // app.cash.redwood.compose/WidgetNode.index|{}index[0]
-        final fun <get-index>(): kotlin/Int // app.cash.redwood.compose/WidgetNode.index.<get-index>|<get-index>(){}[0]
-        final fun <set-index>(kotlin/Int) // app.cash.redwood.compose/WidgetNode.index.<set-index>|<set-index>(kotlin.Int){}[0]
-
-    final fun recordChanged() // app.cash.redwood.compose/WidgetNode.recordChanged|recordChanged(){}[0]
-
-    final object Companion { // app.cash.redwood.compose/WidgetNode.Companion|null[0]
-        final val SetModifiers // app.cash.redwood.compose/WidgetNode.Companion.SetModifiers|{}SetModifiers[0]
-            final fun <get-SetModifiers>(): kotlin/Function2<app.cash.redwood.compose/WidgetNode<app.cash.redwood.widget/Widget<kotlin/Any>, kotlin/Any>, app.cash.redwood/Modifier, kotlin/Unit> // app.cash.redwood.compose/WidgetNode.Companion.SetModifiers.<get-SetModifiers>|<get-SetModifiers>(){}[0]
-    }
-}
-
-final class <#A: out app.cash.redwood.widget/Widget<*>> app.cash.redwood.compose/RedwoodComposeContent { // app.cash.redwood.compose/RedwoodComposeContent|null[0]
-    constructor <init>() // app.cash.redwood.compose/RedwoodComposeContent.<init>|<init>(){}[0]
-
-    final fun Children(kotlin/Function1<#A, app.cash.redwood.widget/Widget.Children<*>>, kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int) // app.cash.redwood.compose/RedwoodComposeContent.Children|Children(kotlin.Function1<1:0,app.cash.redwood.widget.Widget.Children<*>>;kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
-
-    final object Companion { // app.cash.redwood.compose/RedwoodComposeContent.Companion|null[0]
-        final val Instance // app.cash.redwood.compose/RedwoodComposeContent.Companion.Instance|{}Instance[0]
-            final fun <get-Instance>(): app.cash.redwood.compose/RedwoodComposeContent<kotlin/Nothing> // app.cash.redwood.compose/RedwoodComposeContent.Companion.Instance.<get-Instance>|<get-Instance>(){}[0]
-    }
 }
 
 final val app.cash.redwood.compose/LocalOnBackPressedDispatcher // app.cash.redwood.compose/LocalOnBackPressedDispatcher|{}LocalOnBackPressedDispatcher[0]
@@ -77,9 +36,6 @@ final fun app.cash.redwood.compose/app_cash_redwood_compose_ChildrenNode$stablep
 final fun app.cash.redwood.compose/app_cash_redwood_compose_NodeApplier$stableprop_getter(): kotlin/Int // app.cash.redwood.compose/app_cash_redwood_compose_NodeApplier$stableprop_getter|app_cash_redwood_compose_NodeApplier$stableprop_getter(){}[0]
 final fun app.cash.redwood.compose/app_cash_redwood_compose_RedwoodComposeContent$stableprop_getter(): kotlin/Int // app.cash.redwood.compose/app_cash_redwood_compose_RedwoodComposeContent$stableprop_getter|app_cash_redwood_compose_RedwoodComposeContent$stableprop_getter(){}[0]
 final fun app.cash.redwood.compose/app_cash_redwood_compose_WidgetNode$stableprop_getter(): kotlin/Int // app.cash.redwood.compose/app_cash_redwood_compose_WidgetNode$stableprop_getter|app_cash_redwood_compose_WidgetNode$stableprop_getter(){}[0]
-final inline fun <#A: app.cash.redwood.widget/WidgetFactoryOwner<#B>, #B: kotlin/Any> (app.cash.redwood.compose/RedwoodApplier<#B>).app.cash.redwood.compose/widgetSystem(): #A // app.cash.redwood.compose/widgetSystem|widgetSystem@app.cash.redwood.compose.RedwoodApplier<0:1>(){0§<app.cash.redwood.widget.WidgetFactoryOwner<0:1>>;1§<kotlin.Any>}[0]
-final inline fun <#A: app.cash.redwood.widget/WidgetFactoryOwner<#C>, #B: app.cash.redwood.widget/Widget<#C>, #C: kotlin/Any> app.cash.redwood.compose/RedwoodComposeNode(crossinline kotlin/Function1<#A, #B>, kotlin/Function1<androidx.compose.runtime/Updater<app.cash.redwood.compose/WidgetNode<#B, #C>>, kotlin/Unit>, kotlin/Function3<app.cash.redwood.compose/RedwoodComposeContent<#B>, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int) // app.cash.redwood.compose/RedwoodComposeNode|RedwoodComposeNode(kotlin.Function1<0:0,0:1>;kotlin.Function1<androidx.compose.runtime.Updater<app.cash.redwood.compose.WidgetNode<0:1,0:2>>,kotlin.Unit>;kotlin.Function3<app.cash.redwood.compose.RedwoodComposeContent<0:1>,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){0§<app.cash.redwood.widget.WidgetFactoryOwner<0:2>>;1§<app.cash.redwood.widget.Widget<0:2>>;2§<kotlin.Any>}[0]
-final inline fun <#A: kotlin/Any> (androidx.compose.runtime/Composer).app.cash.redwood.compose/redwoodApplier(): app.cash.redwood.compose/RedwoodApplier<#A> // app.cash.redwood.compose/redwoodApplier|redwoodApplier@androidx.compose.runtime.Composer(){0§<kotlin.Any>}[0]
 
 // Targets: [ios]
 final object app.cash.redwood.compose/DisplayLinkClock : androidx.compose.runtime/MonotonicFrameClock { // app.cash.redwood.compose/DisplayLinkClock|null[0]

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/RedwoodComposition.kt
@@ -242,6 +242,7 @@ public class RedwoodComposeContent<out W : Widget<*>> {
     )
   }
 
+  @RedwoodCodegenApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val Instance: RedwoodComposeContent<Nothing> = RedwoodComposeContent()
   }

--- a/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
+++ b/redwood-compose/src/commonMain/kotlin/app/cash/redwood/compose/WidgetApplier.kt
@@ -151,6 +151,7 @@ public class WidgetNode<out W : Widget<V>, V : Any>(
   /** The index of [widget] within its parent [container] when attached. */
   public var index: Int = -1
 
+  @RedwoodCodegenApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public companion object {
     public val SetModifiers: WidgetNode<Widget<Any>, Any>.(Modifier) -> Unit = {
       recordChanged()

--- a/redwood-layout-widget/api/redwood-layout-widget.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.api
@@ -34,15 +34,6 @@ public abstract interface class app/cash/redwood/layout/widget/RedwoodLayoutWidg
 	public abstract fun Spacer ()Lapp/cash/redwood/layout/widget/Spacer;
 }
 
-public abstract interface class app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner : app/cash/redwood/widget/WidgetFactoryOwner {
-	public static final field Companion Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner$Companion;
-	public abstract fun getRedwoodLayout ()Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;
-}
-
-public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner$Companion {
-	public final fun apply (Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
-}
-
 public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem : app/cash/redwood/layout/widget/RedwoodLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
 	public static final field Companion Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem$Companion;
 	public fun <init> (Lapp/cash/redwood/layout/widget/RedwoodLayoutWidgetFactory;)V

--- a/redwood-layout-widget/api/redwood-layout-widget.klib.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.klib.api
@@ -46,15 +46,6 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/RedwoodLayout
     abstract fun Spacer(): app.cash.redwood.layout.widget/Spacer<#A> // app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactory.Spacer|Spacer(){}[0]
 }
 
-abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactoryOwner : app.cash.redwood.widget/WidgetFactoryOwner<#A> { // app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactoryOwner|null[0]
-    abstract val RedwoodLayout // app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactoryOwner.RedwoodLayout|{}RedwoodLayout[0]
-        abstract fun <get-RedwoodLayout>(): app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactory<#A> // app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactoryOwner.RedwoodLayout.<get-RedwoodLayout>|<get-RedwoodLayout>(){}[0]
-
-    final object Companion { // app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactoryOwner.Companion|null[0]
-        final fun <#A2: kotlin/Any> apply(app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactory<#A2>, #A2, app.cash.redwood/Modifier.UnscopedElement) // app.cash.redwood.layout.widget/RedwoodLayoutWidgetFactoryOwner.Companion.apply|apply(app.cash.redwood.layout.widget.RedwoodLayoutWidgetFactory<0:0>;0:0;app.cash.redwood.Modifier.UnscopedElement){0§<kotlin.Any>}[0]
-    }
-}
-
 abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/Row : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.layout.widget/Row|null[0]
     abstract val children // app.cash.redwood.layout.widget/Row.children|{}children[0]
         abstract fun <get-children>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.layout.widget/Row.children.<get-children>|<get-children>(){}[0]

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -56,15 +56,6 @@ public abstract interface class app/cash/redwood/lazylayout/widget/RedwoodLazyLa
 	public abstract fun RefreshableLazyList ()Lapp/cash/redwood/lazylayout/widget/RefreshableLazyList;
 }
 
-public abstract interface class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner : app/cash/redwood/widget/WidgetFactoryOwner {
-	public static final field Companion Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner$Companion;
-	public abstract fun getRedwoodLazyLayout ()Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;
-}
-
-public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner$Companion {
-	public final fun apply (Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
-}
-
 public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSystem : app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactoryOwner, app/cash/redwood/widget/WidgetSystem {
 	public static final field Companion Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSystem$Companion;
 	public fun <init> (Lapp/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetFactory;)V

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -28,15 +28,6 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.lazylayout.widget/RedwoodLa
     abstract fun RefreshableLazyList(): app.cash.redwood.lazylayout.widget/RefreshableLazyList<#A> // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactory.RefreshableLazyList|RefreshableLazyList(){}[0]
 }
 
-abstract interface <#A: kotlin/Any> app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactoryOwner : app.cash.redwood.widget/WidgetFactoryOwner<#A> { // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactoryOwner|null[0]
-    abstract val RedwoodLazyLayout // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactoryOwner.RedwoodLazyLayout|{}RedwoodLazyLayout[0]
-        abstract fun <get-RedwoodLazyLayout>(): app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactory<#A> // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactoryOwner.RedwoodLazyLayout.<get-RedwoodLazyLayout>|<get-RedwoodLazyLayout>(){}[0]
-
-    final object Companion { // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactoryOwner.Companion|null[0]
-        final fun <#A2: kotlin/Any> apply(app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactory<#A2>, #A2, app.cash.redwood/Modifier.UnscopedElement) // app.cash.redwood.lazylayout.widget/RedwoodLazyLayoutWidgetFactoryOwner.Companion.apply|apply(app.cash.redwood.lazylayout.widget.RedwoodLazyLayoutWidgetFactory<0:0>;0:0;app.cash.redwood.Modifier.UnscopedElement){0§<kotlin.Any>}[0]
-    }
-}
-
 abstract interface <#A: kotlin/Any> app.cash.redwood.lazylayout.widget/RefreshableLazyList : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.lazylayout.widget/RefreshableLazyList|null[0]
     abstract val items // app.cash.redwood.lazylayout.widget/RefreshableLazyList.items|{}items[0]
         abstract fun <get-items>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.lazylayout.widget/RefreshableLazyList.items.<get-items>|<get-items>(){}[0]

--- a/redwood-protocol-guest/api/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.api
@@ -24,23 +24,10 @@ public final class app/cash/redwood/protocol/guest/DefaultGuestProtocolAdapter :
 public abstract class app/cash/redwood/protocol/guest/GuestProtocolAdapter : app/cash/redwood/protocol/EventSink {
 	public static final field $stable I
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public abstract fun appendAdd-ARs5Qwk (IIILapp/cash/redwood/protocol/guest/ProtocolWidget;)V
-	public abstract fun appendCreate-kyz2zXs (II)V
-	public abstract fun appendModifierChange-z3jyS0k (ILapp/cash/redwood/Modifier;)V
-	public abstract fun appendMove-HpxY78w (IIIII)V
-	public abstract fun appendPropertyChange-DxQz5cw (IILkotlinx/serialization/KSerializer;Ljava/lang/Object;)V
-	public abstract fun appendPropertyChange-M7EZMwg (III)V
-	public abstract fun appendPropertyChange-e3iP1vo (IIZ)V
-	public abstract fun appendRemove-HpxY78w (IIIILjava/util/List;)V
 	public abstract fun emitChanges ()V
-	public final fun getChildrenVisitor ()Lapp/cash/redwood/protocol/guest/ProtocolWidget$ChildrenVisitor;
-	public abstract fun getJson ()Lkotlinx/serialization/json/Json;
 	public abstract fun getRoot ()Lapp/cash/redwood/widget/Widget$Children;
-	public final fun getSynthesizeSubtreeRemoval ()Z
 	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;
 	public abstract fun initChangesSink (Lapp/cash/redwood/protocol/ChangesSink;)V
-	public abstract fun nextId-0HhLjSo ()I
-	public abstract fun removeWidget-ou3jOuA (I)V
 }
 
 public abstract interface class app/cash/redwood/protocol/guest/ProtocolMismatchHandler {
@@ -58,35 +45,9 @@ public final class app/cash/redwood/protocol/guest/ProtocolRedwoodCompositionKt 
 	public static synthetic fun ProtocolRedwoodComposition-C-DY9sE$default (Lkotlinx/coroutines/CoroutineScope;Lapp/cash/redwood/protocol/guest/GuestProtocolAdapter;ILapp/cash/redwood/ui/OnBackPressedDispatcher;Landroidx/compose/runtime/saveable/SaveableStateRegistry;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lapp/cash/redwood/compose/RedwoodComposition;
 }
 
-public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget : app/cash/redwood/widget/Widget {
-	public abstract fun depthFirstWalk (Lapp/cash/redwood/protocol/guest/ProtocolWidget$ChildrenVisitor;)V
-	public abstract fun getId-0HhLjSo ()I
-	public abstract fun getTag-BlhN7y0 ()I
-	public synthetic fun getValue ()Ljava/lang/Object;
-	public fun getValue ()Lkotlin/Unit;
-	public abstract fun sendEvent (Lapp/cash/redwood/protocol/Event;)V
-}
-
-public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidget$ChildrenVisitor {
-	public abstract fun visit-KUkifdM (Lapp/cash/redwood/protocol/guest/ProtocolWidget;ILapp/cash/redwood/protocol/guest/ProtocolWidgetChildren;)V
-}
-
-public final class app/cash/redwood/protocol/guest/ProtocolWidgetChildren : app/cash/redwood/widget/Widget$Children {
-	public static final field $stable I
-	public synthetic fun <init> (IILapp/cash/redwood/protocol/guest/GuestProtocolAdapter;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun depthFirstWalk (Lapp/cash/redwood/protocol/guest/ProtocolWidget;Lapp/cash/redwood/protocol/guest/ProtocolWidget$ChildrenVisitor;)V
-	public fun detach ()V
-	public fun getWidgets ()Ljava/util/List;
-	public fun insert (ILapp/cash/redwood/widget/Widget;)V
-	public fun move (III)V
-	public fun onModifierUpdated (ILapp/cash/redwood/widget/Widget;)V
-	public fun remove (II)V
-}
-
 public abstract interface class app/cash/redwood/protocol/guest/ProtocolWidgetSystemFactory {
 	public abstract fun create (Lapp/cash/redwood/protocol/guest/GuestProtocolAdapter;Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;)Lapp/cash/redwood/widget/WidgetSystem;
 	public static synthetic fun create$default (Lapp/cash/redwood/protocol/guest/ProtocolWidgetSystemFactory;Lapp/cash/redwood/protocol/guest/GuestProtocolAdapter;Lapp/cash/redwood/protocol/guest/ProtocolMismatchHandler;ILjava/lang/Object;)Lapp/cash/redwood/widget/WidgetSystem;
-	public abstract fun modifierTagAndSerializationStrategy (Lapp/cash/redwood/Modifier$Element;)Lkotlin/Pair;
 }
 
 public final class app/cash/redwood/protocol/guest/VersionKt {

--- a/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
@@ -16,53 +16,20 @@ abstract interface app.cash.redwood.protocol.guest/ProtocolMismatchHandler { // 
     }
 }
 
-abstract interface app.cash.redwood.protocol.guest/ProtocolWidget : app.cash.redwood.widget/Widget<kotlin/Unit> { // app.cash.redwood.protocol.guest/ProtocolWidget|null[0]
-    abstract val id // app.cash.redwood.protocol.guest/ProtocolWidget.id|{}id[0]
-        abstract fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.guest/ProtocolWidget.id.<get-id>|<get-id>(){}[0]
-    abstract val tag // app.cash.redwood.protocol.guest/ProtocolWidget.tag|{}tag[0]
-        abstract fun <get-tag>(): app.cash.redwood.protocol/WidgetTag // app.cash.redwood.protocol.guest/ProtocolWidget.tag.<get-tag>|<get-tag>(){}[0]
-    open val value // app.cash.redwood.protocol.guest/ProtocolWidget.value|{}value[0]
-        open fun <get-value>() // app.cash.redwood.protocol.guest/ProtocolWidget.value.<get-value>|<get-value>(){}[0]
-
-    abstract fun depthFirstWalk(app.cash.redwood.protocol.guest/ProtocolWidget.ChildrenVisitor) // app.cash.redwood.protocol.guest/ProtocolWidget.depthFirstWalk|depthFirstWalk(app.cash.redwood.protocol.guest.ProtocolWidget.ChildrenVisitor){}[0]
-    abstract fun sendEvent(app.cash.redwood.protocol/Event) // app.cash.redwood.protocol.guest/ProtocolWidget.sendEvent|sendEvent(app.cash.redwood.protocol.Event){}[0]
-
-    abstract fun interface ChildrenVisitor { // app.cash.redwood.protocol.guest/ProtocolWidget.ChildrenVisitor|null[0]
-        abstract fun visit(app.cash.redwood.protocol.guest/ProtocolWidget, app.cash.redwood.protocol/ChildrenTag, app.cash.redwood.protocol.guest/ProtocolWidgetChildren) // app.cash.redwood.protocol.guest/ProtocolWidget.ChildrenVisitor.visit|visit(app.cash.redwood.protocol.guest.ProtocolWidget;app.cash.redwood.protocol.ChildrenTag;app.cash.redwood.protocol.guest.ProtocolWidgetChildren){}[0]
-    }
-}
-
 abstract interface app.cash.redwood.protocol.guest/ProtocolWidgetSystemFactory { // app.cash.redwood.protocol.guest/ProtocolWidgetSystemFactory|null[0]
-    abstract fun <#A1: app.cash.redwood/Modifier.Element> modifierTagAndSerializationStrategy(#A1): kotlin/Pair<app.cash.redwood.protocol/ModifierTag, kotlinx.serialization/SerializationStrategy<#A1>?> // app.cash.redwood.protocol.guest/ProtocolWidgetSystemFactory.modifierTagAndSerializationStrategy|modifierTagAndSerializationStrategy(0:0){0§<app.cash.redwood.Modifier.Element>}[0]
     abstract fun create(app.cash.redwood.protocol.guest/GuestProtocolAdapter, app.cash.redwood.protocol.guest/ProtocolMismatchHandler = ...): app.cash.redwood.widget/WidgetSystem<kotlin/Unit> // app.cash.redwood.protocol.guest/ProtocolWidgetSystemFactory.create|create(app.cash.redwood.protocol.guest.GuestProtocolAdapter;app.cash.redwood.protocol.guest.ProtocolMismatchHandler){}[0]
 }
 
 abstract class app.cash.redwood.protocol.guest/GuestProtocolAdapter : app.cash.redwood.protocol/EventSink { // app.cash.redwood.protocol.guest/GuestProtocolAdapter|null[0]
     constructor <init>(app.cash.redwood.protocol/RedwoodVersion) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.<init>|<init>(app.cash.redwood.protocol.RedwoodVersion){}[0]
 
-    abstract val json // app.cash.redwood.protocol.guest/GuestProtocolAdapter.json|{}json[0]
-        abstract fun <get-json>(): kotlinx.serialization.json/Json // app.cash.redwood.protocol.guest/GuestProtocolAdapter.json.<get-json>|<get-json>(){}[0]
     abstract val root // app.cash.redwood.protocol.guest/GuestProtocolAdapter.root|{}root[0]
         abstract fun <get-root>(): app.cash.redwood.widget/Widget.Children<kotlin/Unit> // app.cash.redwood.protocol.guest/GuestProtocolAdapter.root.<get-root>|<get-root>(){}[0]
     abstract val widgetSystem // app.cash.redwood.protocol.guest/GuestProtocolAdapter.widgetSystem|{}widgetSystem[0]
         abstract fun <get-widgetSystem>(): app.cash.redwood.widget/WidgetSystem<kotlin/Unit> // app.cash.redwood.protocol.guest/GuestProtocolAdapter.widgetSystem.<get-widgetSystem>|<get-widgetSystem>(){}[0]
-    final val childrenVisitor // app.cash.redwood.protocol.guest/GuestProtocolAdapter.childrenVisitor|{}childrenVisitor[0]
-        final fun <get-childrenVisitor>(): app.cash.redwood.protocol.guest/ProtocolWidget.ChildrenVisitor // app.cash.redwood.protocol.guest/GuestProtocolAdapter.childrenVisitor.<get-childrenVisitor>|<get-childrenVisitor>(){}[0]
-    final val synthesizeSubtreeRemoval // app.cash.redwood.protocol.guest/GuestProtocolAdapter.synthesizeSubtreeRemoval|{}synthesizeSubtreeRemoval[0]
-        final fun <get-synthesizeSubtreeRemoval>(): kotlin/Boolean // app.cash.redwood.protocol.guest/GuestProtocolAdapter.synthesizeSubtreeRemoval.<get-synthesizeSubtreeRemoval>|<get-synthesizeSubtreeRemoval>(){}[0]
 
-    abstract fun <#A1: kotlin/Any?> appendPropertyChange(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/PropertyTag, kotlinx.serialization/KSerializer<#A1>, #A1) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendPropertyChange|appendPropertyChange(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.PropertyTag;kotlinx.serialization.KSerializer<0:0>;0:0){0§<kotlin.Any?>}[0]
-    abstract fun appendAdd(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, app.cash.redwood.protocol.guest/ProtocolWidget) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendAdd|appendAdd(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;app.cash.redwood.protocol.guest.ProtocolWidget){}[0]
-    abstract fun appendCreate(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/WidgetTag) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendCreate|appendCreate(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.WidgetTag){}[0]
-    abstract fun appendModifierChange(app.cash.redwood.protocol/Id, app.cash.redwood/Modifier) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendModifierChange|appendModifierChange(app.cash.redwood.protocol.Id;app.cash.redwood.Modifier){}[0]
-    abstract fun appendMove(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, kotlin/Int, kotlin/Int) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendMove|appendMove(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
-    abstract fun appendPropertyChange(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/PropertyTag, kotlin/Boolean) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendPropertyChange|appendPropertyChange(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.PropertyTag;kotlin.Boolean){}[0]
-    abstract fun appendPropertyChange(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/PropertyTag, kotlin/UInt) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendPropertyChange|appendPropertyChange(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.PropertyTag;kotlin.UInt){}[0]
-    abstract fun appendRemove(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, kotlin/Int, kotlin.collections/List<app.cash.redwood.protocol/Id>) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.appendRemove|appendRemove(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;kotlin.Int;kotlin.collections.List<app.cash.redwood.protocol.Id>){}[0]
     abstract fun emitChanges() // app.cash.redwood.protocol.guest/GuestProtocolAdapter.emitChanges|emitChanges(){}[0]
     abstract fun initChangesSink(app.cash.redwood.protocol/ChangesSink) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.initChangesSink|initChangesSink(app.cash.redwood.protocol.ChangesSink){}[0]
-    abstract fun nextId(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.guest/GuestProtocolAdapter.nextId|nextId(){}[0]
-    abstract fun removeWidget(app.cash.redwood.protocol/Id) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.removeWidget|removeWidget(app.cash.redwood.protocol.Id){}[0]
 }
 
 final class app.cash.redwood.protocol.guest/DefaultGuestProtocolAdapter : app.cash.redwood.protocol.guest/GuestProtocolAdapter { // app.cash.redwood.protocol.guest/DefaultGuestProtocolAdapter|null[0]
@@ -89,20 +56,6 @@ final class app.cash.redwood.protocol.guest/DefaultGuestProtocolAdapter : app.ca
     final fun removeWidget(app.cash.redwood.protocol/Id) // app.cash.redwood.protocol.guest/DefaultGuestProtocolAdapter.removeWidget|removeWidget(app.cash.redwood.protocol.Id){}[0]
     final fun sendEvent(app.cash.redwood.protocol/Event) // app.cash.redwood.protocol.guest/DefaultGuestProtocolAdapter.sendEvent|sendEvent(app.cash.redwood.protocol.Event){}[0]
     final fun takeChanges(): kotlin.collections/List<app.cash.redwood.protocol/Change> // app.cash.redwood.protocol.guest/DefaultGuestProtocolAdapter.takeChanges|takeChanges(){}[0]
-}
-
-final class app.cash.redwood.protocol.guest/ProtocolWidgetChildren : app.cash.redwood.widget/Widget.Children<kotlin/Unit> { // app.cash.redwood.protocol.guest/ProtocolWidgetChildren|null[0]
-    constructor <init>(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, app.cash.redwood.protocol.guest/GuestProtocolAdapter) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.<init>|<init>(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;app.cash.redwood.protocol.guest.GuestProtocolAdapter){}[0]
-
-    final val widgets // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.widgets|{}widgets[0]
-        final fun <get-widgets>(): kotlin.collections/List<app.cash.redwood.protocol.guest/ProtocolWidget> // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.widgets.<get-widgets>|<get-widgets>(){}[0]
-
-    final fun depthFirstWalk(app.cash.redwood.protocol.guest/ProtocolWidget, app.cash.redwood.protocol.guest/ProtocolWidget.ChildrenVisitor) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.depthFirstWalk|depthFirstWalk(app.cash.redwood.protocol.guest.ProtocolWidget;app.cash.redwood.protocol.guest.ProtocolWidget.ChildrenVisitor){}[0]
-    final fun detach() // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.detach|detach(){}[0]
-    final fun insert(kotlin/Int, app.cash.redwood.widget/Widget<kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.insert|insert(kotlin.Int;app.cash.redwood.widget.Widget<kotlin.Unit>){}[0]
-    final fun move(kotlin/Int, kotlin/Int, kotlin/Int) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.move|move(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
-    final fun onModifierUpdated(kotlin/Int, app.cash.redwood.widget/Widget<kotlin/Unit>) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.onModifierUpdated|onModifierUpdated(kotlin.Int;app.cash.redwood.widget.Widget<kotlin.Unit>){}[0]
-    final fun remove(kotlin/Int, kotlin/Int) // app.cash.redwood.protocol.guest/ProtocolWidgetChildren.remove|remove(kotlin.Int;kotlin.Int){}[0]
 }
 
 final val app.cash.redwood.protocol.guest/app_cash_redwood_protocol_guest_DefaultGuestProtocolAdapter$stableprop // app.cash.redwood.protocol.guest/app_cash_redwood_protocol_guest_DefaultGuestProtocolAdapter$stableprop|#static{}app_cash_redwood_protocol_guest_DefaultGuestProtocolAdapter$stableprop[0]

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidget.kt
@@ -65,6 +65,7 @@ public interface ProtocolWidget : Widget<Unit> {
    */
   public fun depthFirstWalk(visitor: ChildrenVisitor)
 
+  @RedwoodCodegenApi // https://github.com/Kotlin/binary-compatibility-validator/issues/91
   public fun interface ChildrenVisitor {
     public fun visit(
       parent: ProtocolWidget,

--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -1,23 +1,7 @@
-public abstract interface class app/cash/redwood/protocol/host/GeneratedHostProtocol : app/cash/redwood/protocol/host/ProtocolFactory {
-	public abstract fun createModifier (Lapp/cash/redwood/protocol/ModifierElement;)Lapp/cash/redwood/Modifier;
-	public abstract fun widget-WCEpcRY (I)Lapp/cash/redwood/protocol/host/WidgetHostProtocol;
-}
-
 public final class app/cash/redwood/protocol/host/HostProtocolAdapter : app/cash/redwood/protocol/ChangesSink {
 	public synthetic fun <init> (Ljava/lang/String;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/protocol/host/ProtocolFactory;Lapp/cash/redwood/protocol/host/UiEventSink;Lapp/cash/redwood/leaks/LeakDetector;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun close ()V
 	public fun sendChanges (Ljava/util/List;)V
-}
-
-public abstract interface class app/cash/redwood/protocol/host/IdVisitor {
-	public abstract fun visit-ou3jOuA (I)V
-}
-
-public final class app/cash/redwood/protocol/host/ProtocolChildren {
-	public fun <init> (Lapp/cash/redwood/widget/Widget$Children;)V
-	public final fun detach ()V
-	public final fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
-	public final fun visitIds (Lapp/cash/redwood/protocol/host/IdVisitor;)V
 }
 
 public abstract interface class app/cash/redwood/protocol/host/ProtocolFactory {
@@ -36,21 +20,6 @@ public abstract interface class app/cash/redwood/protocol/host/ProtocolMismatchH
 public final class app/cash/redwood/protocol/host/ProtocolMismatchHandler$Companion {
 }
 
-public abstract class app/cash/redwood/protocol/host/ProtocolNode {
-	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public abstract fun apply (Lapp/cash/redwood/protocol/PropertyChange;Lapp/cash/redwood/protocol/host/UiEventSink;)V
-	public abstract fun children-dBpC-2Y (I)Lapp/cash/redwood/protocol/host/ProtocolChildren;
-	public abstract fun detach ()V
-	public final fun getId-0HhLjSo ()I
-	public abstract fun getWidget ()Lapp/cash/redwood/widget/Widget;
-	public abstract fun getWidgetName ()Ljava/lang/String;
-	public abstract fun getWidgetTag-BlhN7y0 ()I
-	public final fun setId-ou3jOuA (I)V
-	public final fun toString ()Ljava/lang/String;
-	public final fun updateModifier (Lapp/cash/redwood/Modifier;)V
-	public fun visitIds (Lapp/cash/redwood/protocol/host/IdVisitor;)V
-}
-
 public final class app/cash/redwood/protocol/host/UiEvent {
 	public synthetic fun <init> (II[Ljava/lang/Object;[Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getArgs ()[Ljava/lang/Object;
@@ -66,10 +35,5 @@ public abstract interface class app/cash/redwood/protocol/host/UiEventSink {
 
 public final class app/cash/redwood/protocol/host/VersionKt {
 	public static final fun getHostRedwoodVersion ()Ljava/lang/String;
-}
-
-public abstract interface class app/cash/redwood/protocol/host/WidgetHostProtocol {
-	public abstract fun createNode-ou3jOuA (I)Lapp/cash/redwood/protocol/host/ProtocolNode;
-	public abstract fun getChildrenTags ()[I
 }
 

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -6,24 +6,8 @@
 // - Show declarations: true
 
 // Library unique name: <app.cash.redwood:redwood-protocol-host>
-abstract fun interface app.cash.redwood.protocol.host/IdVisitor { // app.cash.redwood.protocol.host/IdVisitor|null[0]
-    abstract fun visit(app.cash.redwood.protocol/Id) // app.cash.redwood.protocol.host/IdVisitor.visit|visit(app.cash.redwood.protocol.Id){}[0]
-}
-
 abstract fun interface app.cash.redwood.protocol.host/UiEventSink { // app.cash.redwood.protocol.host/UiEventSink|null[0]
     abstract fun sendEvent(app.cash.redwood.protocol.host/UiEvent) // app.cash.redwood.protocol.host/UiEventSink.sendEvent|sendEvent(app.cash.redwood.protocol.host.UiEvent){}[0]
-}
-
-abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/GeneratedHostProtocol : app.cash.redwood.protocol.host/ProtocolFactory<#A> { // app.cash.redwood.protocol.host/GeneratedHostProtocol|null[0]
-    abstract fun createModifier(app.cash.redwood.protocol/ModifierElement): app.cash.redwood/Modifier // app.cash.redwood.protocol.host/GeneratedHostProtocol.createModifier|createModifier(app.cash.redwood.protocol.ModifierElement){}[0]
-    abstract fun widget(app.cash.redwood.protocol/WidgetTag): app.cash.redwood.protocol.host/WidgetHostProtocol<#A>? // app.cash.redwood.protocol.host/GeneratedHostProtocol.widget|widget(app.cash.redwood.protocol.WidgetTag){}[0]
-}
-
-abstract interface <#A: kotlin/Any> app.cash.redwood.protocol.host/WidgetHostProtocol { // app.cash.redwood.protocol.host/WidgetHostProtocol|null[0]
-    abstract val childrenTags // app.cash.redwood.protocol.host/WidgetHostProtocol.childrenTags|{}childrenTags[0]
-        abstract fun <get-childrenTags>(): kotlin/IntArray? // app.cash.redwood.protocol.host/WidgetHostProtocol.childrenTags.<get-childrenTags>|<get-childrenTags>(){}[0]
-
-    abstract fun createNode(app.cash.redwood.protocol/Id): app.cash.redwood.protocol.host/ProtocolNode<#A> // app.cash.redwood.protocol.host/WidgetHostProtocol.createNode|createNode(app.cash.redwood.protocol.Id){}[0]
 }
 
 abstract interface app.cash.redwood.protocol.host/ProtocolMismatchHandler { // app.cash.redwood.protocol.host/ProtocolMismatchHandler|null[0]
@@ -43,43 +27,11 @@ sealed interface <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolFactory
         abstract fun <get-widgetSystem>(): app.cash.redwood.widget/WidgetSystem<#A> // app.cash.redwood.protocol.host/ProtocolFactory.widgetSystem.<get-widgetSystem>|<get-widgetSystem>(){}[0]
 }
 
-abstract class <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolNode { // app.cash.redwood.protocol.host/ProtocolNode|null[0]
-    constructor <init>(app.cash.redwood.protocol/Id) // app.cash.redwood.protocol.host/ProtocolNode.<init>|<init>(app.cash.redwood.protocol.Id){}[0]
-
-    abstract val widget // app.cash.redwood.protocol.host/ProtocolNode.widget|{}widget[0]
-        abstract fun <get-widget>(): app.cash.redwood.widget/Widget<#A> // app.cash.redwood.protocol.host/ProtocolNode.widget.<get-widget>|<get-widget>(){}[0]
-    abstract val widgetName // app.cash.redwood.protocol.host/ProtocolNode.widgetName|{}widgetName[0]
-        abstract fun <get-widgetName>(): kotlin/String // app.cash.redwood.protocol.host/ProtocolNode.widgetName.<get-widgetName>|<get-widgetName>(){}[0]
-    abstract val widgetTag // app.cash.redwood.protocol.host/ProtocolNode.widgetTag|{}widgetTag[0]
-        abstract fun <get-widgetTag>(): app.cash.redwood.protocol/WidgetTag // app.cash.redwood.protocol.host/ProtocolNode.widgetTag.<get-widgetTag>|<get-widgetTag>(){}[0]
-
-    final var id // app.cash.redwood.protocol.host/ProtocolNode.id|{}id[0]
-        final fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.host/ProtocolNode.id.<get-id>|<get-id>(){}[0]
-        final fun <set-id>(app.cash.redwood.protocol/Id) // app.cash.redwood.protocol.host/ProtocolNode.id.<set-id>|<set-id>(app.cash.redwood.protocol.Id){}[0]
-
-    abstract fun apply(app.cash.redwood.protocol/PropertyChange, app.cash.redwood.protocol.host/UiEventSink) // app.cash.redwood.protocol.host/ProtocolNode.apply|apply(app.cash.redwood.protocol.PropertyChange;app.cash.redwood.protocol.host.UiEventSink){}[0]
-    abstract fun children(app.cash.redwood.protocol/ChildrenTag): app.cash.redwood.protocol.host/ProtocolChildren<#A>? // app.cash.redwood.protocol.host/ProtocolNode.children|children(app.cash.redwood.protocol.ChildrenTag){}[0]
-    abstract fun detach() // app.cash.redwood.protocol.host/ProtocolNode.detach|detach(){}[0]
-    final fun toString(): kotlin/String // app.cash.redwood.protocol.host/ProtocolNode.toString|toString(){}[0]
-    final fun updateModifier(app.cash.redwood/Modifier) // app.cash.redwood.protocol.host/ProtocolNode.updateModifier|updateModifier(app.cash.redwood.Modifier){}[0]
-    open fun visitIds(app.cash.redwood.protocol.host/IdVisitor) // app.cash.redwood.protocol.host/ProtocolNode.visitIds|visitIds(app.cash.redwood.protocol.host.IdVisitor){}[0]
-}
-
 final class <#A: kotlin/Any> app.cash.redwood.protocol.host/HostProtocolAdapter : app.cash.redwood.protocol/ChangesSink { // app.cash.redwood.protocol.host/HostProtocolAdapter|null[0]
     constructor <init>(app.cash.redwood.protocol/RedwoodVersion, app.cash.redwood.widget/Widget.Children<#A>, app.cash.redwood.protocol.host/ProtocolFactory<#A>, app.cash.redwood.protocol.host/UiEventSink, app.cash.redwood.leaks/LeakDetector) // app.cash.redwood.protocol.host/HostProtocolAdapter.<init>|<init>(app.cash.redwood.protocol.RedwoodVersion;app.cash.redwood.widget.Widget.Children<1:0>;app.cash.redwood.protocol.host.ProtocolFactory<1:0>;app.cash.redwood.protocol.host.UiEventSink;app.cash.redwood.leaks.LeakDetector){}[0]
 
     final fun close() // app.cash.redwood.protocol.host/HostProtocolAdapter.close|close(){}[0]
     final fun sendChanges(kotlin.collections/List<app.cash.redwood.protocol/Change>) // app.cash.redwood.protocol.host/HostProtocolAdapter.sendChanges|sendChanges(kotlin.collections.List<app.cash.redwood.protocol.Change>){}[0]
-}
-
-final class <#A: kotlin/Any> app.cash.redwood.protocol.host/ProtocolChildren { // app.cash.redwood.protocol.host/ProtocolChildren|null[0]
-    constructor <init>(app.cash.redwood.widget/Widget.Children<#A>) // app.cash.redwood.protocol.host/ProtocolChildren.<init>|<init>(app.cash.redwood.widget.Widget.Children<1:0>){}[0]
-
-    final val children // app.cash.redwood.protocol.host/ProtocolChildren.children|{}children[0]
-        final fun <get-children>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.protocol.host/ProtocolChildren.children.<get-children>|<get-children>(){}[0]
-
-    final fun detach() // app.cash.redwood.protocol.host/ProtocolChildren.detach|detach(){}[0]
-    final fun visitIds(app.cash.redwood.protocol.host/IdVisitor) // app.cash.redwood.protocol.host/ProtocolChildren.visitIds|visitIds(app.cash.redwood.protocol.host.IdVisitor){}[0]
 }
 
 final class app.cash.redwood.protocol.host/UiEvent { // app.cash.redwood.protocol.host/UiEvent|null[0]

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/testingGeneration.kt
@@ -122,7 +122,6 @@ internal fun generateTester(schemaSet: SchemaSet): FileSpec {
 }
 
 /*
-@RedwoodCodegenApi
 public class EmojiSearchTestingWidgetFactory : EmojiSearchWidgetFactory<WidgetValue> {
   public override fun Text(): Text<WidgetValue> = MutableText()
   public override fun Button(): Button<WidgetValue> = MutableButton()
@@ -135,7 +134,6 @@ internal fun generateMutableWidgetFactory(schema: Schema): FileSpec {
     addType(
       TypeSpec.classBuilder(mutableWidgetFactoryType)
         .addSuperinterface(schema.getWidgetFactoryType().parameterizedBy(RedwoodTesting.WidgetValue))
-        .addAnnotation(Redwood.RedwoodCodegenApi)
         .apply {
           for (widget in schema.widgets) {
             addFunction(

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
@@ -170,6 +170,8 @@ internal fun generateWidgetSystem(schemaSet: SchemaSet): FileSpec {
         .addProperty(schema.type.flatName, schema.getWidgetFactoryType().parameterizedBy(typeVariableW))
         .addType(
           TypeSpec.companionObjectBuilder()
+            // Needed because https://github.com/Kotlin/binary-compatibility-validator/issues/91
+            .addAnnotation(Redwood.RedwoodCodegenApi)
             .addFunction(
               FunSpec.builder("apply")
                 .addTypeVariable(typeVariableW)

--- a/redwood-widget/api/android/redwood-widget.api
+++ b/redwood-widget/api/android/redwood-widget.api
@@ -100,9 +100,6 @@ public abstract interface class app/cash/redwood/widget/Widget$Children {
 	public abstract fun remove (II)V
 }
 
-public abstract interface class app/cash/redwood/widget/WidgetFactoryOwner {
-}
-
 public abstract interface class app/cash/redwood/widget/WidgetSystem {
 	public abstract fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 }

--- a/redwood-widget/api/jvm/redwood-widget.api
+++ b/redwood-widget/api/jvm/redwood-widget.api
@@ -78,9 +78,6 @@ public abstract interface class app/cash/redwood/widget/Widget$Children {
 	public abstract fun remove (II)V
 }
 
-public abstract interface class app/cash/redwood/widget/WidgetFactoryOwner {
-}
-
 public abstract interface class app/cash/redwood/widget/WidgetSystem {
 	public abstract fun apply (Ljava/lang/Object;Lapp/cash/redwood/Modifier$UnscopedElement;)V
 }

--- a/redwood-widget/api/redwood-widget.klib.api
+++ b/redwood-widget/api/redwood-widget.klib.api
@@ -40,8 +40,6 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.widget/Widget { // app.cash
     }
 }
 
-abstract interface <#A: kotlin/Any> app.cash.redwood.widget/WidgetFactoryOwner // app.cash.redwood.widget/WidgetFactoryOwner|null[0]
-
 abstract interface <#A: kotlin/Any> app.cash.redwood.widget/WidgetSystem { // app.cash.redwood.widget/WidgetSystem|null[0]
     abstract fun apply(#A, app.cash.redwood/Modifier.UnscopedElement) // app.cash.redwood.widget/WidgetSystem.apply|apply(1:0;app.cash.redwood.Modifier.UnscopedElement){}[0]
 }


### PR DESCRIPTION
We require the runtime libraries to use the exact same version as the code generator.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
