### PR TITLE
Fix a bug with Modifier.flex() nested in a row and column

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -24,6 +24,7 @@ import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
 import app.cash.redwood.layout.widget.FlexContainer
+import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.snapshot.testing.ComposeSnapshotter
 import app.cash.redwood.snapshot.testing.ComposeUiTestWidgetFactory
 import app.cash.redwood.ui.Px
@@ -61,6 +62,11 @@ class ComposeUiFlexContainerTest(
   override fun row() = flexContainer(FlexDirection.Row)
 
   override fun column() = flexContainer(FlexDirection.Column)
+
+  override fun spacer(backgroundColor: Int): Spacer<@Composable () -> Unit> {
+    // TODO: honor backgroundColor.
+    return ComposeUiRedwoodLayoutWidgetFactory().Spacer()
+  }
 
   override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)
 

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4265096c30d46578c9f8b991878000131cf1d7ea58f67068391e77984200bf0a
+size 3906

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4265096c30d46578c9f8b991878000131cf1d7ea58f67068391e77984200bf0a
+size 3906

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:935125d0e6af227eedf349e9b908618ebfd5bd1f35893e383e69bba1ed548e29
+size 65804

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
@@ -21,6 +21,7 @@ import app.cash.redwood.layout.TestFlexContainer
 import app.cash.redwood.layout.api.Constraint
 import app.cash.redwood.layout.api.CrossAxisAlignment
 import app.cash.redwood.layout.widget.FlexContainer
+import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.snapshot.testing.UIViewSnapshotCallback
 import app.cash.redwood.snapshot.testing.UIViewSnapshotter
 import app.cash.redwood.snapshot.testing.UIViewTestWidgetFactory
@@ -67,6 +68,13 @@ class UIViewFlexContainerTest(
   override fun row() = flexContainer(FlexDirection.Row)
 
   override fun column() = flexContainer(FlexDirection.Column)
+
+  override fun spacer(backgroundColor: Int): Spacer<UIView> {
+    return UIViewRedwoodLayoutWidgetFactory().Spacer()
+      .apply {
+        value.backgroundColor = backgroundColor.toUIColor()
+      }
+  }
 
   class UIViewTestFlexContainer internal constructor(
     private val delegate: UIViewFlexContainer,

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/YogaLayout.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/YogaLayout.kt
@@ -73,11 +73,13 @@ internal class YogaLayout(context: Context) : ViewGroup(context) {
     calculateLayout(
       requestedWidth = when {
         widthMode == MeasureSpec.EXACTLY -> widthSize.toFloat()
+        widthMode == MeasureSpec.UNSPECIFIED -> Size.UNDEFINED
         widthConstraint == Constraint.Fill -> widthSize.toFloat()
         else -> Size.UNDEFINED
       },
       requestedHeight = when {
         heightMode == MeasureSpec.EXACTLY -> heightSize.toFloat()
+        heightMode == MeasureSpec.UNSPECIFIED -> Size.UNDEFINED
         heightConstraint == Constraint.Fill -> heightSize.toFloat()
         else -> Size.UNDEFINED
       },

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -21,6 +21,7 @@ import app.cash.paparazzi.Paparazzi
 import app.cash.redwood.layout.AbstractFlexContainerTest
 import app.cash.redwood.layout.TestFlexContainer
 import app.cash.redwood.layout.widget.FlexContainer
+import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.snapshot.testing.ViewSnapshotter
 import app.cash.redwood.snapshot.testing.ViewTestWidgetFactory
 import app.cash.redwood.ui.Px
@@ -62,6 +63,13 @@ class ViewFlexContainerTest(
   override fun row() = flexContainer(FlexDirection.Row)
 
   override fun column() = flexContainer(FlexDirection.Column)
+
+  override fun spacer(backgroundColor: Int): Spacer<View> {
+    return ViewSpacer(paparazzi.context)
+      .apply {
+        setBackgroundColor(backgroundColor)
+      }
+  }
 
   override fun snapshotter(widget: View) = ViewSnapshotter(paparazzi, widget)
 

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeff5cb1d11342d549ee6418a60809736bc4b321d573f55a67469bbb064d7e1c
+size 3909

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeff5cb1d11342d549ee6418a60809736bc4b321d573f55a67469bbb064d7e1c
+size 3909

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -27,6 +27,7 @@ import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.widget.Column
 import app.cash.redwood.layout.widget.Row
+import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.lazylayout.composeui.ComposeUiLazyList
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.snapshot.testing.ComposeSnapshotter
@@ -68,6 +69,11 @@ class ComposeUiLazyListTest(
 
   override fun column(): Column<@Composable () -> Unit> {
     return ComposeUiRedwoodLayoutWidgetFactory().Column()
+  }
+
+  override fun spacer(backgroundColor: Int): Spacer<@Composable () -> Unit> {
+    // TODO: honor backgroundColor.
+    return ComposeUiRedwoodLayoutWidgetFactory().Spacer()
   }
 
   override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:500df5359bd2f1aba6eb335cbba1acd26584374366ca8565d93c47f1e34a4606
+size 3844

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:500df5359bd2f1aba6eb335cbba1acd26584374366ca8565d93c47f1e34a4606
+size 3844

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e63d8061520f28e90252d1d2473c594773c707b2156541981933840f5036207
+size 65306

--- a/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
@@ -20,6 +20,7 @@ import app.cash.redwood.layout.TestFlexContainer
 import app.cash.redwood.layout.api.MainAxisAlignment
 import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.uiview.UIViewRedwoodLayoutWidgetFactory
+import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.lazylayout.toUIColor
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.snapshot.testing.UIViewSnapshotCallback
@@ -46,6 +47,13 @@ class UIViewLazyListAsFlexContainerTest(
   override fun row() = UIViewRedwoodLayoutWidgetFactory().Row()
 
   override fun column() = UIViewRedwoodLayoutWidgetFactory().Column()
+
+  override fun spacer(backgroundColor: Int): Spacer<UIView> {
+    return UIViewRedwoodLayoutWidgetFactory().Spacer()
+      .apply {
+        value.backgroundColor = backgroundColor.toUIColor()
+      }
+  }
 
   override fun snapshotter(widget: UIView) = UIViewSnapshotter.framed(callback, widget)
 

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
@@ -26,6 +26,7 @@ import app.cash.redwood.layout.api.Overflow
 import app.cash.redwood.layout.view.ViewRedwoodLayoutWidgetFactory
 import app.cash.redwood.layout.widget.Column
 import app.cash.redwood.layout.widget.Row
+import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.snapshot.testing.ViewSnapshotter
 import app.cash.redwood.snapshot.testing.ViewTestWidgetFactory
@@ -67,6 +68,13 @@ class ViewLazyListAsFlexContainerTest(
 
   override fun column(): Column<View> {
     return ViewRedwoodLayoutWidgetFactory(paparazzi.context).Column()
+  }
+
+  override fun spacer(backgroundColor: Int): Spacer<View> {
+    return ViewRedwoodLayoutWidgetFactory(paparazzi.context).Spacer()
+      .apply {
+        value.setBackgroundColor(backgroundColor)
+      }
   }
 
   override fun snapshotter(widget: View) = ViewSnapshotter(paparazzi, widget)

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[LTR].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdca08973fd5cbf55a12717a65eaa147bbfaff662cc7dca62bcae0f9d63a9859
+size 3837

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn[RTL].png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdca08973fd5cbf55a12717a65eaa147bbfaff662cc7dca62bcae0f9d63a9859
+size 3837


### PR DESCRIPTION
This is a bug in Android only caused by not explicitly handling MeasureSpec.UNSPECIFIED.


Closes: https://github.com/cashapp/redwood/issues/2018