### PR TITLE
Remove old default expression annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ New:
 
 Changed:
 - Drop support for non-incremental layouts in `Row` and `Column`.
+- Support for `@Default` annotation has now been removed, as detailed in the 0.15.0 release.
 
 Fixed:
 - Fix a layout bug where children of fixed-with `Row` containers were assigned the wrong width.

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-clean/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-clean/src/main/kotlin/example/counter/schema.kt
@@ -16,7 +16,6 @@
 package example.counter
 
 import app.cash.redwood.schema.Children
-import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
@@ -38,12 +37,12 @@ data class CounterBox(
 @Widget(2)
 data class CounterText(
   @Property(1) val text: String?,
-  @Property(2) @Default("\"black\"") val color: String,
+  @Property(2) val color: String = "black",
 )
 
 @Widget(3)
 data class CounterButton(
   @Property(1) val text: String?,
-  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(2) val enabled: Boolean = true,
   @Property(3) val onClick: () -> Unit,
 )

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-dirty/src/main/kotlin/example/counter/schema.kt
@@ -16,7 +16,6 @@
 package example.counter
 
 import app.cash.redwood.schema.Children
-import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
@@ -38,12 +37,12 @@ data class CounterBox(
 @Widget(2)
 data class CounterText(
   @Property(1) val text: String?,
-  @Property(2) @Default("\"black\"") val color: String,
+  @Property(2) val color: String = "black",
 )
 
 @Widget(3)
 data class CounterButton(
   @Property(1) val text: String?,
-  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(2) val enabled: Boolean = true,
   @Property(3) val onClick: () -> Unit,
 )

--- a/redwood-gradle-plugin/src/test/fixture/schema-api-missing/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-api-missing/src/main/kotlin/example/counter/schema.kt
@@ -16,7 +16,6 @@
 package example.counter
 
 import app.cash.redwood.schema.Children
-import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
@@ -38,12 +37,12 @@ data class CounterBox(
 @Widget(2)
 data class CounterText(
   @Property(1) val text: String?,
-  @Property(2) @Default("\"black\"") val color: String,
+  @Property(2) val color: String = "black",
 )
 
 @Widget(3)
 data class CounterButton(
   @Property(1) val text: String?,
-  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(2) val enabled: Boolean = true,
   @Property(3) val onClick: () -> Unit,
 )

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/schema/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-accessor/schema/src/main/kotlin/example/counter/schema.kt
@@ -16,7 +16,6 @@
 package example.counter
 
 import app.cash.redwood.schema.Children
-import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
@@ -38,12 +37,12 @@ data class CounterBox(
 @Widget(2)
 data class CounterText(
   @Property(1) val text: String?,
-  @Property(2) @Default("\"black\"") val color: String,
+  @Property(2) val color: String = "black",
 )
 
 @Widget(3)
 data class CounterButton(
   @Property(1) val text: String?,
-  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(2) val enabled: Boolean = true,
   @Property(3) val onClick: () -> Unit,
 )

--- a/redwood-gradle-plugin/src/test/fixture/schema-project-reference/schema/src/main/kotlin/example/counter/schema.kt
+++ b/redwood-gradle-plugin/src/test/fixture/schema-project-reference/schema/src/main/kotlin/example/counter/schema.kt
@@ -16,7 +16,6 @@
 package example.counter
 
 import app.cash.redwood.schema.Children
-import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
 import app.cash.redwood.schema.Widget
@@ -38,12 +37,12 @@ data class CounterBox(
 @Widget(2)
 data class CounterText(
   @Property(1) val text: String?,
-  @Property(2) @Default("\"black\"") val color: String,
+  @Property(2) val color: String = "black",
 )
 
 @Widget(3)
 data class CounterButton(
   @Property(1) val text: String?,
-  @Property(2) @Default("true") val enabled: Boolean,
+  @Property(2) val enabled: Boolean = true,
   @Property(3) val onClick: () -> Unit,
 )

--- a/redwood-schema/api/redwood-schema.api
+++ b/redwood-schema/api/redwood-schema.api
@@ -2,10 +2,6 @@ public abstract interface annotation class app/cash/redwood/schema/Children : ja
 	public abstract fun tag ()I
 }
 
-public abstract interface annotation class app/cash/redwood/schema/Default : java/lang/annotation/Annotation {
-	public abstract fun expression ()Ljava/lang/String;
-}
-
 public abstract interface annotation class app/cash/redwood/schema/Modifier : java/lang/annotation/Annotation {
 	public abstract fun scopes ()[Ljava/lang/Class;
 	public abstract fun tag ()I

--- a/redwood-schema/src/main/kotlin/app/cash/redwood/schema/annotations.kt
+++ b/redwood-schema/src/main/kotlin/app/cash/redwood/schema/annotations.kt
@@ -184,23 +184,6 @@ public annotation class Children(
 )
 
 /**
- * Annotates a [Property] with an associated default expression. The [expression] is not
- * type-checked and will be used verbatim in the generated code.
- *
- * ```
- * @Widget(1)
- * data class Button(
- *   @Property(1) val text: String,
- *   @Property(2) @Default("true") val enabled: Boolean,
- * )
- * ```
- */
-@Retention(RUNTIME)
-@Target(PROPERTY)
-@Deprecated("Migrate to normal default parameter expressions")
-public annotation class Default(val expression: String)
-
-/**
  * Annotates a data class which represents a modifier for a [Widget].
  *
  * Each modifier in a [Schema] must have a unique [tag] among all [Modifier] annotations in the

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
@@ -413,7 +413,7 @@ private fun FirContext.parseWidget(
 
       val propertyAnnotation = findPropertyAnnotation(property.annotations)
       val childrenAnnotation = findChildrenAnnotation(property.annotations)
-      val defaultExpression = findDefaultExpression(memberType, parameter, property)
+      val defaultExpression = findDefaultExpression(parameter)
       val deprecation = findDeprecationAnnotation(property.annotations)
         ?.toDeprecation { "$memberType.$name" }
       val documentation = parameter.source?.findAndParseKDoc()
@@ -582,7 +582,7 @@ private fun FirContext.parseModifier(
       val parameterType = parameter.resolvedReturnType.toFqType()
       val property = firClass.declarations.filterIsInstance<FirProperty>().single { it.name == parameter.name }
 
-      val defaultExpression = findDefaultExpression(memberType, parameter, property)
+      val defaultExpression = findDefaultExpression(parameter)
       val deprecation = findDeprecationAnnotation(property.annotations)
         ?.toDeprecation { "$memberType.$name" }
       val documentation = parameter.source?.findAndParseKDoc()
@@ -776,28 +776,13 @@ private data class ChildrenAnnotation(
 )
 
 private fun FirContext.findDefaultExpression(
-  memberType: FqType,
   parameter: FirValueParameterSymbol,
-  property: FirProperty,
 ): String? {
-  val annotation = property.annotations.find { it.fqName(firSession) == FqNames.Default }
-    ?.let { annotation ->
-      annotation.argumentMapping
-        .mapping[Name.identifier("expression")] as? FirLiteralExpression
-        ?: throw AssertionError(annotation.source?.text)
-    }
-    ?.value as String?
-
-  val expression = parameter.defaultValueSource?.let { defaultValue ->
+  return parameter.defaultValueSource?.let { defaultValue ->
     defaultValue.treeStructure
       .toString(defaultValue.lighterASTNode)
       .toString()
   }
-
-  check(annotation == null || expression == null) {
-    "Only @Default or a default expression may be present–not both: $memberType.${parameter.name}"
-  }
-  return expression ?: annotation
 }
 
 private fun FirContext.findModifierAnnotation(
@@ -921,7 +906,6 @@ private fun ClassId.toFqType() = FqType(
 
 private object FqNames {
   val Children = FqName("app.cash.redwood.schema.Children")
-  val Default = FqName("app.cash.redwood.schema.Default")
   val Deprecated = FqName("kotlin.Deprecated")
   val Modifier = FqName("app.cash.redwood.schema.Modifier")
   val Property = FqName("app.cash.redwood.schema.Property")

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -18,7 +18,6 @@ package app.cash.redwood.tooling.schema
 import app.cash.redwood.layout.RedwoodLayout
 import app.cash.redwood.layout.Row
 import app.cash.redwood.schema.Children
-import app.cash.redwood.schema.Default
 import app.cash.redwood.schema.Modifier
 import app.cash.redwood.schema.Property
 import app.cash.redwood.schema.Schema
@@ -828,51 +827,6 @@ class SchemaParserTest {
 
     val modifier = schema.modifiers.single()
     assertThat(modifier.properties.single().defaultExpression).isEqualTo("5")
-  }
-
-  @Schema([DefaultExpressionAnnotationWidget::class, DefaultExpressionAnnotationModifier::class])
-  interface DefaultExpressionAnnotationSchema
-
-  @Suppress("DEPRECATION") // Testing deprecated annotation.
-  @Widget(1)
-  data class DefaultExpressionAnnotationWidget(
-    @Property(1) @Default("5") val a: Int,
-    @Children(1) @Default("{}") val b: () -> Unit,
-  )
-
-  @Modifier(1)
-  @Suppress("DEPRECATION") // Testing deprecated annotation.
-  data class DefaultExpressionAnnotationModifier(
-    @Default("5") val a: Int,
-  )
-
-  @Test fun defaultExpressionAnnotations() {
-    val schema = parseTestSchema(DefaultExpressionAnnotationSchema::class).schema
-
-    val widget = schema.widgets.single()
-    val property = widget.traits.filterIsInstance<PropertyTrait>().single()
-    val children = widget.traits.filterIsInstance<ChildrenTrait>().single()
-    assertThat(property.defaultExpression).isEqualTo("5")
-    assertThat(children.defaultExpression).isEqualTo("{}")
-
-    val modifier = schema.modifiers.single()
-    assertThat(modifier.properties.single().defaultExpression).isEqualTo("5")
-  }
-
-  @Schema([DefaultExpressionBothWidget::class])
-  interface DefaultExpressionBothSchema
-
-  @Widget(1)
-  @Suppress("DEPRECATION") // Testing deprecated annotation.
-  data class DefaultExpressionBothWidget(
-    @Property(1) @Default("5") val a: Int = 5,
-  )
-
-  @Test fun defaultExpressionBothThrows() {
-    assertFailure {
-      parseTestSchema(DefaultExpressionBothSchema::class)
-    }.isInstanceOf<IllegalStateException>()
-      .hasMessage("Only @Default or a default expression may be present–not both: app.cash.redwood.tooling.schema.SchemaParserTest.DefaultExpressionBothWidget.a")
   }
 
   @Schema([SomeWidget::class, SomeModifier::class])


### PR DESCRIPTION
Regular default expressions have worked since the last release.

Closes #2225

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
