### PR TITLE
Add fallback for property change widget tag

### DIFF
--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
@@ -98,7 +98,7 @@ public class PropertyChange private constructor(
   @SerialName("id")
   private val _id: Int,
   @SerialName("widget")
-  private val _widgetTag: Int,
+  private val _widgetTag: Int = -1,
   @SerialName("tag")
   private val _tag: Int,
   public val value: JsonElement = JsonNull,

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
@@ -128,6 +128,12 @@ class ProtocolTest {
     assertThat(three).hasMessage("ModifierElement array may only have 1 or 2 values. Found: 3")
   }
 
+  @Test fun propertyChangeMissingWidgetTag() {
+    val expected = PropertyChange(Id(1), WidgetTag(-1), PropertyTag(2), JsonPrimitive("hello"))
+    val json = """["property",{"id":1,"tag":2,"value":"hello"}]"""
+    assertThat(format.decodeFromString(Change.serializer(), json)).isEqualTo(expected)
+  }
+
   private fun <T> assertJsonRoundtrip(serializer: KSerializer<T>, model: T, json: String) {
     assertThat(format.encodeToString(serializer, model)).isEqualTo(json)
     assertThat(format.decodeFromString(serializer, json)).isEqualTo(model)


### PR DESCRIPTION
We don't require this on the host-side yet, so allow deserialization of models from old guests for now.

Follow-up from #2355 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
