### PR TITLE
Migrate `Spacer` implementations away from subtypes

### DIFF
--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewSpacer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewSpacer.kt
@@ -45,17 +45,17 @@ internal class UIViewSpacer : Spacer<UIView> {
   private fun invalidate() {
     value.setNeedsLayout()
   }
+}
 
-  private inner class SpacerUIView : UIView(cValue { CGRectZero }) {
-    var width = 0.0
-    var height = 0.0
+private class SpacerUIView : UIView(cValue { CGRectZero }) {
+  var width = 0.0
+  var height = 0.0
 
-    override fun intrinsicContentSize(): CValue<CGSize> {
-      return CGSizeMake(width, height)
-    }
+  override fun intrinsicContentSize(): CValue<CGSize> {
+    return CGSizeMake(width, height)
+  }
 
-    override fun sizeThatFits(size: CValue<CGSize>): CValue<CGSize> {
-      return CGSizeMake(width, height)
-    }
+  override fun sizeThatFits(size: CValue<CGSize>): CValue<CGSize> {
+    return CGSizeMake(width, height)
   }
 }

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewSpacer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewSpacer.kt
@@ -27,11 +27,10 @@ import kotlin.math.min
 
 internal class ViewSpacer(
   context: Context,
-) : View(context),
-  Spacer<View> {
+) : Spacer<View> {
   private val density = Density(context.resources)
 
-  override val value get() = this
+  override val value: View = SpacerView(context)
 
   override var modifier: Modifier = Modifier
 
@@ -44,7 +43,9 @@ internal class ViewSpacer(
     value.minimumHeight = with(density) { height.toPxInt() }
     value.requestLayout()
   }
+}
 
+private class SpacerView(context: Context) : View(context) {
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     setMeasuredDimension(
       getDefaultSizeSpace(suggestedMinimumWidth, widthMeasureSpec),

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -65,7 +65,7 @@ class ViewFlexContainerTest(
   override fun spacer(backgroundColor: Int): Spacer<View> {
     return ViewSpacer(paparazzi.context)
       .apply {
-        setBackgroundColor(backgroundColor)
+        value.setBackgroundColor(backgroundColor)
       }
   }
 


### PR DESCRIPTION
When widgets switch to abstract classes, this will no longer be allowed.

Refs #2231 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
