### PR TITLE
Honor margins internally in UIViewBox

### DIFF
--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testMargins.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testMargins.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c967e7f741dc37bd9fc262e91117c4cc3a11035b366ac52b9affd7c28177e80
-size 69973
+oid sha256:199218033bc3435075e976bb7602a62c6a8a8674d61b057bbc4276fac4c20517
+size 69770


### PR DESCRIPTION
Previously the margins were external, which required the enclosing layout to honor them. That was not supported when the enclosing layout was a Box, Row, or Column.

