### PR TITLE
Migrate View `Box` away from subtype

### DIFF
--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewBox.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewBox.kt
@@ -36,10 +36,22 @@ import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.ViewGroupChildren
 import app.cash.redwood.widget.Widget
 
-internal class ViewBox(
+internal class ViewBox(context: Context) : Box<View> {
+  private val delegate = BoxViewGroup(context)
+  override val value: View get() = delegate
+  override var modifier by delegate::modifier
+  override val children get() = delegate.children
+
+  override fun width(width: Constraint) = delegate.width(width)
+  override fun height(height: Constraint) = delegate.height(height)
+  override fun margin(margin: Margin) = delegate.margin(margin)
+  override fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) = delegate.horizontalAlignment(horizontalAlignment)
+  override fun verticalAlignment(verticalAlignment: CrossAxisAlignment) = delegate.verticalAlignment(verticalAlignment)
+}
+
+private class BoxViewGroup(
   context: Context,
-) : ViewGroup(context),
-  Box<View> {
+) : ViewGroup(context) {
   private val density = Density(context.resources)
   private var horizontalAlignment = CrossAxisAlignment.Start
   private var verticalAlignment = CrossAxisAlignment.Start
@@ -47,35 +59,33 @@ internal class ViewBox(
   private var heightConstraint = Constraint.Wrap
   private var margin: Margin = Margin.Zero
 
-  override var modifier: Modifier = Modifier
+  var modifier: Modifier = Modifier
 
-  override val value get() = this
-
-  override val children = ViewGroupChildren(this)
+  val children = ViewGroupChildren(this)
 
   private val measurer = Measurer()
 
-  override fun width(width: Constraint) {
+  fun width(width: Constraint) {
     this.widthConstraint = width
     requestLayout()
   }
 
-  override fun height(height: Constraint) {
+  fun height(height: Constraint) {
     this.heightConstraint = height
     requestLayout()
   }
 
-  override fun margin(margin: Margin) {
+  fun margin(margin: Margin) {
     this.margin = margin
     requestLayout()
   }
 
-  override fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) {
+  fun horizontalAlignment(horizontalAlignment: CrossAxisAlignment) {
     this.horizontalAlignment = horizontalAlignment
     requestLayout()
   }
 
-  override fun verticalAlignment(verticalAlignment: CrossAxisAlignment) {
+  fun verticalAlignment(verticalAlignment: CrossAxisAlignment) {
     this.verticalAlignment = verticalAlignment
     requestLayout()
   }

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewBoxTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewBoxTest.kt
@@ -45,7 +45,7 @@ class ViewBoxTest(
 
   override fun box(): Box<View> {
     return ViewBox(paparazzi.context).apply {
-      background = ColorDrawable(0x88000000.toInt())
+      value.background = ColorDrawable(0x88000000.toInt())
       applyDefaults()
     }
   }


### PR DESCRIPTION
When widgets switch to abstract classes, this will no longer be allowed.

Refs #2231 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
