### PR TITLE
Remove child helpers from `TestFlexContainer` interface

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -28,7 +28,6 @@ import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.snapshot.testing.ComposeSnapshotter
 import app.cash.redwood.snapshot.testing.ComposeUiTestWidgetFactory
 import app.cash.redwood.ui.Px
-import app.cash.redwood.widget.Widget
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import app.cash.redwood.yoga.FlexDirection
 import com.android.resources.LayoutDirection
@@ -72,8 +71,6 @@ class ComposeUiFlexContainerTest(
     private val delegate: ComposeUiFlexContainer,
   ) : TestFlexContainer<@Composable () -> Unit>,
     YogaFlexContainer<@Composable () -> Unit> by delegate {
-    private var childCount = 0
-
     override val children: ComposeWidgetChildren = delegate.children
 
     constructor(direction: FlexDirection, backgroundColor: Int) : this(
@@ -90,20 +87,6 @@ class ComposeUiFlexContainerTest(
       runBlocking {
         delegate.scrollState?.scrollTo(offset.value.toInt())
       }
-    }
-
-    override fun add(widget: Widget<@Composable () -> Unit>) {
-      addAt(childCount, widget)
-    }
-
-    override fun addAt(index: Int, widget: Widget<@Composable () -> Unit>) {
-      delegate.children.insert(index, widget)
-      childCount++
-    }
-
-    override fun removeAt(index: Int) {
-      delegate.children.remove(index = index, count = 1)
-      childCount--
     }
 
     override fun onEndChanges() {

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -63,6 +63,18 @@ abstract class AbstractFlexContainerTest<T : Any> {
     onScroll(null)
   }
 
+  protected fun <T : Any> TestFlexContainer<T>.add(widget: Widget<T>) {
+    addAt(children.widgets.size, widget)
+  }
+
+  protected fun <T : Any> TestFlexContainer<T>.addAt(index: Int, widget: Widget<T>) {
+    children.insert(index, widget)
+  }
+
+  protected fun <T : Any> TestFlexContainer<T>.removeAt(index: Int) {
+    children.remove(index, 1)
+  }
+
   /** Returns a non-lazy flex container row, even if the test is for a LazyList. */
   abstract fun row(): Row<T>
 
@@ -959,9 +971,6 @@ interface TestFlexContainer<T : Any> :
   fun overflow(overflow: Overflow)
   fun onScroll(onScroll: ((Px) -> Unit)?)
   fun scroll(offset: Px)
-  fun add(widget: Widget<T>)
-  fun addAt(index: Int, widget: Widget<T>)
-  fun removeAt(index: Int)
 }
 
 private val movies = listOf(

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
@@ -83,8 +83,6 @@ class UIViewFlexContainerTest(
     ResizableWidget<UIView>,
     YogaFlexContainer<UIView> by delegate,
     ChangeListener by delegate {
-    private var childCount = 0
-
     override var sizeListener: SizeListener? by delegate::sizeListener
 
     override val children: Widget.Children<UIView> = delegate.children
@@ -99,20 +97,6 @@ class UIViewFlexContainerTest(
 
     override fun scroll(offset: Px) {
       (delegate.value as UIScrollView).setContentOffset(cValue { y = offset.value }, false)
-    }
-
-    override fun add(widget: Widget<UIView>) {
-      addAt(childCount, widget)
-    }
-
-    override fun addAt(index: Int, widget: Widget<UIView>) {
-      delegate.children.insert(index, widget)
-      childCount++
-    }
-
-    override fun removeAt(index: Int) {
-      delegate.children.remove(index = index, count = 1)
-      childCount--
     }
   }
 

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -27,7 +27,6 @@ import app.cash.redwood.snapshot.testing.ViewTestWidgetFactory
 import app.cash.redwood.ui.Px
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.ViewGroupChildren
-import app.cash.redwood.widget.Widget
 import app.cash.redwood.yoga.FlexDirection
 import com.android.resources.LayoutDirection
 import org.junit.Rule
@@ -76,7 +75,6 @@ class ViewFlexContainerTest(
   ) : TestFlexContainer<View>,
     YogaFlexContainer<View> by delegate,
     ChangeListener by delegate {
-    private var childCount = 0
     private var onScroll: ((Px) -> Unit)? = null
 
     override val children: ViewGroupChildren = delegate.children
@@ -87,20 +85,6 @@ class ViewFlexContainerTest(
 
     override fun scroll(offset: Px) {
       onScroll?.invoke(offset)
-    }
-
-    override fun add(widget: Widget<View>) {
-      addAt(childCount, widget)
-    }
-
-    override fun addAt(index: Int, widget: Widget<View>) {
-      delegate.children.insert(index, widget)
-      childCount++
-    }
-
-    override fun removeAt(index: Int) {
-      delegate.children.remove(index = index, count = 1)
-      childCount--
     }
   }
 }

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -34,7 +34,6 @@ import app.cash.redwood.lazylayout.widget.LazyList
 import app.cash.redwood.snapshot.testing.ComposeSnapshotter
 import app.cash.redwood.snapshot.testing.ComposeUiTestWidgetFactory
 import app.cash.redwood.ui.Px
-import app.cash.redwood.widget.Widget
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import app.cash.redwood.yoga.FlexDirection
 import com.android.resources.LayoutDirection
@@ -85,7 +84,6 @@ class ComposeUiLazyListTest(
     // Work around https://youtrack.jetbrains.com/issue/KT-68850
     override val value: @Composable () -> Unit get() = delegate.value
 
-    private var childCount = 0
     private var onScroll: ((Px) -> Unit)? = null
 
     constructor(direction: FlexDirection, backgroundColor: Int) : this(
@@ -109,20 +107,6 @@ class ComposeUiLazyListTest(
     }
 
     override fun overflow(overflow: Overflow) {
-    }
-
-    override fun add(widget: Widget<@Composable () -> Unit>) {
-      addAt(childCount, widget)
-    }
-
-    override fun addAt(index: Int, widget: Widget<@Composable () -> Unit>) {
-      delegate.items.insert(index, widget)
-      childCount++
-    }
-
-    override fun removeAt(index: Int) {
-      delegate.items.remove(index = index, count = 1)
-      childCount--
     }
 
     override fun onEndChanges() {

--- a/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
@@ -62,7 +62,6 @@ class UIViewLazyListAsFlexContainerTest(
     private val delegate: LazyList<UIView>,
   ) : TestFlexContainer<UIView>,
     LazyList<UIView> by delegate {
-    private var childCount = 0
     private var onScroll: ((Px) -> Unit)? = null
 
     constructor(delegate: LazyList<UIView>, direction: FlexDirection, backgroundColor: Int) : this(
@@ -86,20 +85,6 @@ class UIViewLazyListAsFlexContainerTest(
     }
 
     override fun overflow(overflow: Overflow) {
-    }
-
-    override fun add(widget: Widget<UIView>) {
-      addAt(childCount, widget)
-    }
-
-    override fun addAt(index: Int, widget: Widget<UIView>) {
-      delegate.items.insert(index, widget)
-      childCount++
-    }
-
-    override fun removeAt(index: Int) {
-      delegate.items.remove(index = index, count = 1)
-      childCount--
     }
 
     override fun onEndChanges() {

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
@@ -83,7 +83,6 @@ class ViewLazyListAsFlexContainerTest(
   ) : TestFlexContainer<View>,
     LazyList<View> by delegate,
     ChangeListener by delegate {
-    private var childCount = 0
     private var onScroll: ((Px) -> Unit)? = null
 
     constructor(context: Context, direction: FlexDirection, backgroundColor: Int) : this(
@@ -107,20 +106,6 @@ class ViewLazyListAsFlexContainerTest(
     }
 
     override fun overflow(overflow: Overflow) {
-    }
-
-    override fun add(widget: Widget<View>) {
-      addAt(childCount, widget)
-    }
-
-    override fun addAt(index: Int, widget: Widget<View>) {
-      delegate.items.insert(index, widget)
-      childCount++
-    }
-
-    override fun removeAt(index: Int) {
-      delegate.items.remove(index = index, count = 1)
-      childCount--
     }
   }
 }


### PR DESCRIPTION
We can implement these generally now that the backing widget list provides the existing count for new insertion positions.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
