### PR TITLE
Fix measurement of Row and Column on iOS inside of UIStackView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changed:
 Fixed:
 - Fix a layout bug where children of fixed-with `Row` containers were assigned the wrong width.
 - Fix inconsistencies between iOS and Android for `Column` and `Row` layouts.
+- Fix a layout bug where `Row` and `Column` layouts reported the wrong dimensions if their subviews could wrap.
 - Correctly update the layout when a Box's child's modifiers are removed.
 - Fix a layout bug where children of `Box` containers were not measured properly.
 

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e997c8a79988db9bcd8e37a87173828711e3ffc1e2f29bb0e3bed2ca7cea9c04
+size 160982

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0501a3a8205508fd421603229334b74cc524b13b05a930f80c3d40b36645934f
+size 37994

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:369502c9327ca0781c62ee2537caf6afb6ae170876728848420dc12c4a83f1e0
+size 160364

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee8ce2cee7f8649aa0b7ea07ca9bf43bc520c0b9fd9ac2a57028b5126ccd8eb6
+size 37915

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -885,6 +885,63 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
     snapshotter(root.value).snapshot()
   }
+
+  @Test fun testIntrinsicContentSizeWhenSubviewsWrap() {
+    val fullWidthParent = widgetFactory.column()
+
+    flexContainer(FlexDirection.Column)
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Wrap)
+        margin(Margin(horizontal = 30.dp))
+        add(widgetFactory.text("A ".repeat(50)))
+        add(widgetFactory.text("B ".repeat(50)))
+        onEndChanges()
+      }
+      .also { fullWidthParent.add(it.value) }
+
+    flexContainer(FlexDirection.Column)
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Wrap)
+        margin(Margin(horizontal = 40.dp))
+        add(widgetFactory.text("C ".repeat(50)))
+        add(widgetFactory.text("D ".repeat(50)))
+        onEndChanges()
+      }
+      .also { fullWidthParent.add(it.value) }
+
+    flexContainer(FlexDirection.Column)
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Wrap)
+        margin(Margin(horizontal = 50.dp))
+        add(widgetFactory.text("E ".repeat(50)))
+        add(widgetFactory.text("F ".repeat(50)))
+        onEndChanges()
+      }
+      .also { fullWidthParent.add(it.value) }
+
+    val scrollWrapper = widgetFactory.scrollWrapper()
+    scrollWrapper.content = fullWidthParent.value
+    snapshotter(scrollWrapper.value).snapshot(scrolling = true)
+  }
+
+  @Test fun testIntrinsicContentSizeWhenSubviewsRequireScrolling() {
+    val column = flexContainer(FlexDirection.Column)
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Wrap)
+        margin(Margin(horizontal = 50.dp))
+        add(widgetFactory.text("AAAAA BBBB CCC DD E ".repeat(50)))
+        add(widgetFactory.text("FFFFF GGGG HHH II J ".repeat(50)))
+        onEndChanges()
+      }
+
+    val scrollWrapper = widgetFactory.scrollWrapper()
+    scrollWrapper.content = column.value
+    snapshotter(scrollWrapper.value).snapshot(scrolling = true)
+  }
 }
 
 interface TestFlexContainer<T : Any> :

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsRequireScrolling.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsRequireScrolling.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02084488d7748ef0220969e57142513fd94837b231f8f50b0a5b743cabf872fa
+size 271099

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsRequireScrolling._1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsRequireScrolling._1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:429de0a4c8ebd220655a159b294e3a76d3d9ce246a10638ee98e0e02eddc4a1f
+size 253818

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsWrap.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsWrap.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c32f78bc7d550562be65654b83509d108266714ddf87169022369f56e149e3f
+size 98569

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -38,8 +38,8 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
 
   var onScroll: ((Px) -> Unit)? = null
 
-  private var widthForIntrinsicSize = UIViewNoIntrinsicMetric
-  private var heightForIntrinsicSize = UIViewNoIntrinsicMetric
+  private var fillWidth = UIViewNoIntrinsicMetric
+  private var fillHeight = UIViewNoIntrinsicMetric
 
   init {
     // TODO: Support scroll indicators.
@@ -64,16 +64,22 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
   override fun setBounds(bounds: CValue<CGRect>) {
     val newWidth = bounds.useContents { size.width }
     val newHeight = bounds.useContents { size.height }
-    if (isColumn()) {
-      if (widthForIntrinsicSize != newWidth) {
-        invalidateIntrinsicContentSize()
-        this.widthForIntrinsicSize = newWidth
-      }
-    } else {
-      if (heightForIntrinsicSize != newHeight) {
-        invalidateIntrinsicContentSize()
-        this.heightForIntrinsicSize = newHeight
-      }
+
+    // Invalidate first because it clears fillWidth and fillHeight.
+    if (
+      (widthConstraint == Constraint.Fill && newWidth != fillWidth) ||
+      (heightConstraint == Constraint.Fill && newHeight != fillHeight)
+    ) {
+      invalidateIntrinsicContentSize()
+    }
+
+    this.fillWidth = when (widthConstraint) {
+      Constraint.Fill -> newWidth
+      else -> UIViewNoIntrinsicMetric
+    }
+    this.fillHeight = when (heightConstraint) {
+      Constraint.Fill -> newHeight
+      else -> UIViewNoIntrinsicMetric
     }
 
     super.setBounds(bounds)
@@ -81,14 +87,14 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
 
   override fun invalidateIntrinsicContentSize() {
     super.invalidateIntrinsicContentSize()
-    this.widthForIntrinsicSize = UIViewNoIntrinsicMetric
-    this.heightForIntrinsicSize = UIViewNoIntrinsicMetric
+    this.fillWidth = UIViewNoIntrinsicMetric
+    this.fillHeight = UIViewNoIntrinsicMetric
   }
 
   override fun intrinsicContentSize(): CValue<CGSize> {
     return calculateLayout(
-      width = widthForIntrinsicSize.toYogaWithWidthConstraint(),
-      height = heightForIntrinsicSize.toYogaWithWidthConstraint(),
+      width = fillWidth.toYogaWithWidthConstraint(),
+      height = fillHeight.toYogaWithWidthConstraint(),
     )
   }
 

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -16,6 +16,7 @@ import kotlinx.cinterop.CValue
 import kotlinx.cinterop.cValue
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGFloat
+import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
@@ -37,6 +38,9 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
 
   var onScroll: ((Px) -> Unit)? = null
 
+  private var widthForIntrinsicSize = UIViewNoIntrinsicMetric
+  private var heightForIntrinsicSize = UIViewNoIntrinsicMetric
+
   init {
     // TODO: Support scroll indicators.
     scrollEnabled = false
@@ -45,7 +49,48 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
     contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever
   }
 
-  override fun intrinsicContentSize(): CValue<CGSize> = calculateLayout()
+  /**
+   * The intrinsic size is broken by design if any subview's height depends on its width (or
+   * vice-versa). For example, if a subview is UILabel that wraps, we need to know how wide the
+   * label is before we can compute that label's height.
+   *
+   * We work around this by:
+   *
+   *  1. Making [intrinsicContentSize] depend on the mostly-recently applied bounds
+   *  2. Invalidating it each time the bounds change
+   *
+   * This will result in an additional layout pass when the parent view uses [intrinsicContentSize].
+   */
+  override fun setBounds(bounds: CValue<CGRect>) {
+    val newWidth = bounds.useContents { size.width }
+    val newHeight = bounds.useContents { size.height }
+    if (isColumn()) {
+      if (widthForIntrinsicSize != newWidth) {
+        invalidateIntrinsicContentSize()
+        this.widthForIntrinsicSize = newWidth
+      }
+    } else {
+      if (heightForIntrinsicSize != newHeight) {
+        invalidateIntrinsicContentSize()
+        this.heightForIntrinsicSize = newHeight
+      }
+    }
+
+    super.setBounds(bounds)
+  }
+
+  override fun invalidateIntrinsicContentSize() {
+    super.invalidateIntrinsicContentSize()
+    this.widthForIntrinsicSize = UIViewNoIntrinsicMetric
+    this.heightForIntrinsicSize = UIViewNoIntrinsicMetric
+  }
+
+  override fun intrinsicContentSize(): CValue<CGSize> {
+    return calculateLayout(
+      width = widthForIntrinsicSize.toYogaWithWidthConstraint(),
+      height = heightForIntrinsicSize.toYogaWithWidthConstraint(),
+    )
+  }
 
   override fun sizeThatFits(size: CValue<CGSize>): CValue<CGSize> {
     return size.useContents<CGSize, CValue<CGSize>> {

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7a9ebba41cc73effc51bf9886b3a2896ac7948034537a58185221dfe3a528fb
+size 159787

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec4f43c351e20ad01ec9fc52ab8404eff885ec422630a9d82b808ef1c8ac8e47
+size 107779

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a81df127cdab8bb8d86038a1541f8992f0faefde61924cd0bfe48dad4b6b296
+size 38454

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b496ece0fc67b98f3f7a7f8ae446bc307efe7e1c84c18b9ebc7d8150f1710f7
+size 160903

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f41925c68d0ffdb015b72f70350da561ba1c333627e1930f06e48cf6adadc645
+size 109146

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:add95eab5c755bd2b4d22845017f2da35abbed29be0c09d0bb92f4c535557d6f
+size 38467

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
+size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
+size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
+size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
+size 3836

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsRequireScrolling.1.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsRequireScrolling.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b6ba12ff47637286a65cce7d6f592992b28fa1418f74d40c4052a9b8dbe3a0
+size 57793

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsWrap.1.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testIntrinsicContentSizeWhenSubviewsWrap.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b6ba12ff47637286a65cce7d6f592992b28fa1418f74d40c4052a9b8dbe3a0
+size 57793

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dcdc2a17ed47018e9111dfe2abca1f2c92d0e327a4da9001a010b5d291b00a7
+size 161718

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:351b18bcb939d3c468727b739878791eb5b22b8988a2f4d98bedee4ed9e34db0
+size 120703

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3207d0b4e2178e0f9521712cc29ccec4dd0a4a4cfb5b574b973726bdc9f27ca9
+size 38507

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c98a0c7178377225a9ef7ba701527238ceac719288577f6c10259e5463476a6
+size 162750

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling__1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baf20e23b45007764c08fa03bb272fed3f8b8627dea3c38baebf6ec26cdc9fc8
+size 121854

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a36a2b773e87d7aeb1e3cc8987cc788428a9a0a1f0082cd42f674af3b09226a
+size 38523


### PR DESCRIPTION
UIStackView uses UIView.intrinsicContentSize on its subviews, but our Row and Column implementations don't have a natural implementation of this API. In particular, if any subview wraps its contents (so its height depends on its available width), there's no single intrinsicContentSize().

We work around this by following some online advice: invalidate the intrinsic size when the bounds change, and then use those bounds when computing the new intrinsic size.

This is more fragile and stateful than I'd like, but it seems like a common practice for working around UIStackView's API.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
