### PR TITLE
Fix Overflow.Scroll to fill its enclosing container

### DIFF
--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testFillAndOverflowScroll.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e07e3df829767bf2734cee7bd7cd3d10e7a1a7bcf952276c1325c82fc4618e32
+size 6878

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testFillAndOverflowScroll.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e07e3df829767bf2734cee7bd7cd3d10e7a1a7bcf952276c1325c82fc4618e32
+size 6878

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -942,6 +942,40 @@ abstract class AbstractFlexContainerTest<T : Any> {
     scrollWrapper.content = column.value
     snapshotter(scrollWrapper.value).snapshot(scrolling = true)
   }
+
+  /**
+   * We had a bug where content would shrink to its minimum required size with [Overflow.Scroll],
+   * even if the enclosing container didn't require that.
+   */
+  @Test fun testFillAndOverflowScroll() {
+    val column = flexContainer(FlexDirection.Column)
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Fill)
+        overflow(Overflow.Scroll)
+        crossAxisAlignment(CrossAxisAlignment.Center)
+      }
+
+    column.add(widgetFactory.text("top"))
+
+    column.add(
+      flexContainer(FlexDirection.Column)
+        .apply {
+          modifier = FlexImpl(1.0)
+          width(Constraint.Fill)
+          height(Constraint.Fill)
+          crossAxisAlignment(CrossAxisAlignment.Center)
+          mainAxisAlignment(MainAxisAlignment.Center)
+          add(widgetFactory.text("middle"))
+          onEndChanges()
+        },
+    )
+
+    column.add(widgetFactory.text("bottom"))
+    column.onEndChanges()
+
+    snapshotter(column.value).snapshot()
+  }
 }
 
 interface TestFlexContainer<T : Any> :

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testFillAndOverflowScroll.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testFillAndOverflowScroll.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34d96241e6620deed420cbeaa02272fb3080a195dfceb4bf019216f3aaf93c5b
+size 78728

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testFillAndOverflowScroll.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:843612aab17f733efa16c82dadb57aa1b48cee23e1677f32576c90609ba78ab1
+size 6865

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testFillAndOverflowScroll.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:843612aab17f733efa16c82dadb57aa1b48cee23e1677f32576c90609ba78ab1
+size 6865

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testFillAndOverflowScroll.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
+size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testFillAndOverflowScroll.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
+size 3836

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testFillAndOverflowScroll.1.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testFillAndOverflowScroll.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3528ee6f3346a1a8af41a3fb128d702580b45c38e40869b764d748fc1e724a1a
+size 72278

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testFillAndOverflowScroll.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88cd2e640940c20184c61f5d1e14cb0c9658a8142c2a5530761f77a053751f6e
+size 6906

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testFillAndOverflowScroll.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testFillAndOverflowScroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88cd2e640940c20184c61f5d1e14cb0c9658a8142c2a5530761f77a053751f6e
+size 6906


### PR DESCRIPTION
This was broken for YogaUIView, which collapsed the contents of scrollable content to the minimum required.
