### PR TITLE
Accept a ZiplineHttpClient creating a TreehouseAppFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 New:
 - Redwood publishes what's happening in bound content through the new `Content.State` type.
+- Accept a `ZiplineHttpClient` in `TreehouseAppFactory` on Android.
 
 Changed:
 - Drop support for non-incremental layouts in `Row` and `Column`.

--- a/redwood-treehouse-host/api/android/redwood-treehouse-host.api
+++ b/redwood-treehouse-host/api/android/redwood-treehouse-host.api
@@ -130,7 +130,9 @@ public abstract class app/cash/redwood/treehouse/TreehouseApp$Spec {
 }
 
 public final class app/cash/redwood/treehouse/TreehouseAppFactoryAndroidKt {
+	public static final fun TreehouseAppFactory (Landroid/content/Context;Lapp/cash/zipline/loader/ZiplineHttpClient;Lapp/cash/zipline/loader/ManifestVerifier;Lokio/FileSystem;Lokio/Path;Ljava/lang/String;JLapp/cash/zipline/loader/LoaderEventListener;ILapp/cash/redwood/treehouse/StateStore;Lapp/cash/redwood/leaks/LeakDetector;)Lapp/cash/redwood/treehouse/TreehouseApp$Factory;
 	public static final fun TreehouseAppFactory (Landroid/content/Context;Lokhttp3/OkHttpClient;Lapp/cash/zipline/loader/ManifestVerifier;Lokio/FileSystem;Lokio/Path;Ljava/lang/String;JLapp/cash/zipline/loader/LoaderEventListener;ILapp/cash/redwood/treehouse/StateStore;Lapp/cash/redwood/leaks/LeakDetector;)Lapp/cash/redwood/treehouse/TreehouseApp$Factory;
+	public static synthetic fun TreehouseAppFactory$default (Landroid/content/Context;Lapp/cash/zipline/loader/ZiplineHttpClient;Lapp/cash/zipline/loader/ManifestVerifier;Lokio/FileSystem;Lokio/Path;Ljava/lang/String;JLapp/cash/zipline/loader/LoaderEventListener;ILapp/cash/redwood/treehouse/StateStore;Lapp/cash/redwood/leaks/LeakDetector;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/TreehouseApp$Factory;
 	public static synthetic fun TreehouseAppFactory$default (Landroid/content/Context;Lokhttp3/OkHttpClient;Lapp/cash/zipline/loader/ManifestVerifier;Lokio/FileSystem;Lokio/Path;Ljava/lang/String;JLapp/cash/zipline/loader/LoaderEventListener;ILapp/cash/redwood/treehouse/StateStore;Lapp/cash/redwood/leaks/LeakDetector;ILjava/lang/Object;)Lapp/cash/redwood/treehouse/TreehouseApp$Factory;
 }
 

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/treehouseAppFactoryAndroid.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import app.cash.redwood.leaks.LeakDetector
 import app.cash.zipline.loader.LoaderEventListener
 import app.cash.zipline.loader.ManifestVerifier
+import app.cash.zipline.loader.ZiplineHttpClient
 import app.cash.zipline.loader.asZiplineHttpClient
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
@@ -38,9 +39,36 @@ public fun TreehouseAppFactory(
   concurrentDownloads: Int = 8,
   stateStore: StateStore = MemoryStateStore(),
   leakDetector: LeakDetector = LeakDetector.none(),
+): TreehouseApp.Factory = TreehouseAppFactory(
+  context = context,
+  httpClient = httpClient.asZiplineHttpClient(),
+  manifestVerifier = manifestVerifier,
+  embeddedFileSystem = embeddedFileSystem,
+  embeddedDir = embeddedDir,
+  cacheName = cacheName,
+  cacheMaxSizeInBytes = cacheMaxSizeInBytes,
+  loaderEventListener = loaderEventListener,
+  concurrentDownloads = concurrentDownloads,
+  stateStore = stateStore,
+  leakDetector = leakDetector,
+)
+
+@Suppress("FunctionName")
+public fun TreehouseAppFactory(
+  context: Context,
+  httpClient: ZiplineHttpClient,
+  manifestVerifier: ManifestVerifier,
+  embeddedFileSystem: FileSystem? = null,
+  embeddedDir: Path? = null,
+  cacheName: String = "zipline",
+  cacheMaxSizeInBytes: Long = 50L * 1024L * 1024L,
+  loaderEventListener: LoaderEventListener = LoaderEventListener.None,
+  concurrentDownloads: Int = 8,
+  stateStore: StateStore = MemoryStateStore(),
+  leakDetector: LeakDetector = LeakDetector.none(),
 ): TreehouseApp.Factory = RealTreehouseApp.Factory(
   platform = AndroidTreehousePlatform(context),
-  httpClient = httpClient.asZiplineHttpClient(),
+  httpClient = httpClient,
   frameClockFactory = AndroidChoreographerFrameClock.Factory(),
   manifestVerifier = manifestVerifier,
   embeddedFileSystem = embeddedFileSystem,


### PR DESCRIPTION
The current OkHttpClient is what we ultimately want to provide, but that forces us to create the OkHttpClient eagerly and we'd rather do that lazily.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
