### PR TITLE
Implement test-only background color support for Compose UI spacer

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -72,8 +72,9 @@ class ComposeUiFlexContainerTest(
     }
 
   override fun spacer(backgroundColor: Int): Spacer<@Composable () -> Unit> {
-    // TODO: honor backgroundColor.
-    return ComposeUiSpacer()
+    return ComposeUiSpacer().apply {
+      testOnlyModifier = Modifier.background(Color(backgroundColor))
+    }
   }
 
   override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)

--- a/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacer.kt
+++ b/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacer.kt
@@ -30,9 +30,12 @@ import app.cash.redwood.ui.dp
 internal class ComposeUiSpacer : Spacer<@Composable () -> Unit> {
   private var width by mutableStateOf(0.dp)
   private var height by mutableStateOf(0.dp)
+  var testOnlyModifier: Modifier? = null
 
   override val value = @Composable {
-    Spacer(Modifier.defaultMinSize(width.toDp(), height.toDp()))
+    var modifier = Modifier.defaultMinSize(width.toDp(), height.toDp())
+    testOnlyModifier?.let { modifier = modifier.then(it) }
+    Spacer(modifier)
   }
 
   override var modifier: RedwoodModifier = RedwoodModifier

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -70,8 +70,11 @@ class ComposeUiLazyListTest(
   }
 
   override fun spacer(backgroundColor: Int): Spacer<@Composable () -> Unit> {
-    // TODO: honor backgroundColor.
-    return ComposeUiRedwoodLayoutWidgetFactory().Spacer()
+    return ComposeUiRedwoodLayoutWidgetFactory().Spacer().apply {
+      @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+      (this as ComposeUiSpacer).testOnlyModifier =
+        Modifier.background(Color(backgroundColor))
+    }
   }
 
   override fun snapshotter(widget: @Composable () -> Unit) = ComposeSnapshotter(paparazzi, widget)


### PR DESCRIPTION
Closes #2365. Closes #2366.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
