### PR TITLE
Handle resizes of items in LazyColumn on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixed:
 - Fix a layout bug where `Row` and `Column` layouts reported the wrong dimensions if their subviews could wrap.
 - Correctly update the layout when a Box's child's modifiers are removed.
 - Fix a layout bug where children of `Box` containers were not measured properly.
+- Fix a bug where `LazyColumn` didn't honor child widget resizes.
 
 Breaking:
 - Replace `CodeListener` with a new `DynamicContentWidgetFactory` API. Now loading and crashed views work like all other child widgets.

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42b3b4cbbdc49e1ae57480170ae7123211a7c3382124464904493c72f310e88e
+size 4027

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26eb384f334000d653501344cf7ecad9766e7c2046d8313e3d98f63aff672072
+size 3992

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42b3b4cbbdc49e1ae57480170ae7123211a7c3382124464904493c72f310e88e
+size 4027

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26eb384f334000d653501344cf7ecad9766e7c2046d8313e3d98f63aff672072
+size 3992

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testLayoutHandlesChildResizes.v1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testLayoutHandlesChildResizes.v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26600d51a113d807212a1833a733f6f8a4ce350cc761a457bed16abfbbb80096
+size 66344

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testLayoutHandlesChildResizes.v2.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testLayoutHandlesChildResizes.v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20185482127b0b55dd1cdeae1126d3ba895ab5ddaa673cc484fad759d7ebdf84
+size 66598

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12f19a1e2bc21e4c6a136e14efd749c443840cff074af5bb4c5401e082c24a8b
+size 4059

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e975caa6125173e5f4536bcb5f1cee741b645ca52ee39fbd123cfdee485f3150
+size 4015

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12f19a1e2bc21e4c6a136e14efd749c443840cff074af5bb4c5401e082c24a8b
+size 4059

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e975caa6125173e5f4536bcb5f1cee741b645ca52ee39fbd123cfdee485f3150
+size 4015

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6736ae8bb46937be3c189a7e223114aa4c263fa72bb576bc1a052fff55172b9f
+size 4554

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c479419f809c174d347ae5c655fb32180f7b5960f48cbde9e8bcd3a54cb5d4f
+size 4526

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:511453ec5fdefd584856ef97bd17ed9f470dbc9dc9c8e6f957598966823a5dbb
+size 4497

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:097606fafb740546d54780a4d87c12df1dfc2e3b6e280c1d82eee87b2a7621b8
+size 4479

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testChildWithUpdatedProperty.updated.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testChildWithUpdatedProperty.updated.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d930492c69fcc84cd8129fcfb5ded815a9c202579d6077af06ae4e6b59eca4f
-size 70697
+oid sha256:90e5f1f941bd7fe01603d151dc055d5542680485f2a8f4b0624f4ed08d8957a7
+size 70543

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testLayoutHandlesChildResizes.v1.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testLayoutHandlesChildResizes.v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26600d51a113d807212a1833a733f6f8a4ce350cc761a457bed16abfbbb80096
+size 66344

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testLayoutHandlesChildResizes.v2.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testLayoutHandlesChildResizes.v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20185482127b0b55dd1cdeae1126d3ba895ab5ddaa673cc484fad759d7ebdf84
+size 66598

--- a/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
+++ b/redwood-lazylayout-uiview/RedwoodLazylayoutUIViewTests/__Snapshots__/UIViewLazyListAsFlexContainerTestHost/testRecursiveLayoutHandlesResizes.v2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:106ecd41ecc0fef54ef4d276bd711ca9303c3b25c1d49f9f318bd898bd6f23ae
-size 74954
+oid sha256:1a32ab82587b6a2d091db032b45dbcd593cc327133e77cfbb7fd2c3d942d2e45
+size 76976

--- a/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
@@ -39,6 +39,8 @@ class UIViewLazyListAsFlexContainerTest(
 
   private val lazyLayoutWidgetFactory = UIViewRedwoodLazyLayoutWidgetFactory()
 
+  override val viewMeasurementIsImpreciseAfterAnItemSizeChanges = true
+
   override fun flexContainer(
     direction: FlexDirection,
     backgroundColor: Int,

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12f19a1e2bc21e4c6a136e14efd749c443840cff074af5bb4c5401e082c24a8b
+size 4059

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_RTL_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e975caa6125173e5f4536bcb5f1cee741b645ca52ee39fbd123cfdee485f3150
+size 4015

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutHandlesChildResizes_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12f19a1e2bc21e4c6a136e14efd749c443840cff074af5bb4c5401e082c24a8b
+size 4059

--- a/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-lazylayout-view/src/test/snapshots/images/app.cash.redwood.lazylayout.view_ViewLazyListAsFlexContainerTest_testLayoutHandlesChildResizes_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e975caa6125173e5f4536bcb5f1cee741b645ca52ee39fbd123cfdee485f3150
+size 4015

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -45,6 +45,7 @@ public abstract class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor
 public final class app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor$Binding {
 	public final fun bind (Ljava/lang/Object;)V
 	public final fun detach ()V
+	public final fun getProcessor ()Lapp/cash/redwood/lazylayout/widget/LazyListUpdateProcessor;
 	public final fun getView ()Ljava/lang/Object;
 	public final fun isBound ()Z
 	public final fun unbind ()V

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -75,6 +75,8 @@ abstract class <#A: kotlin/Any, #B: kotlin/Any> app.cash.redwood.lazylayout.widg
     final class <#A1: kotlin/Any, #B1: kotlin/Any> Binding { // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding|null[0]
         final val isBound // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.isBound|{}isBound[0]
             final fun <get-isBound>(): kotlin/Boolean // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.isBound.<get-isBound>|<get-isBound>(){}[0]
+        final val processor // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.processor|{}processor[0]
+            final fun <get-processor>(): app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor<#A1, #B1> // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.processor.<get-processor>|<get-processor>(){}[0]
 
         final var view // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.view|{}view[0]
             final fun <get-view>(): #A1? // app.cash.redwood.lazylayout.widget/LazyListUpdateProcessor.Binding.view.<get-view>|<get-view>(){}[0]

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
@@ -461,7 +461,7 @@ public abstract class LazyListUpdateProcessor<V : Any, W : Any> {
    * assumes that a view that is discarded will never be bound again.
    */
   public class Binding<V : Any, W : Any> internal constructor(
-    internal val processor: LazyListUpdateProcessor<V, W>,
+    public val processor: LazyListUpdateProcessor<V, W>,
     internal var isPlaceholder: Boolean = false,
   ) {
     /** The currently-bound view. Null if this is not on-screen. */


### PR DESCRIPTION
This hooks up the recently-introduced ResizableWidget.SizeListener interface to UIViewLazyList.

Unfortunately it's introducing unexpected additional measure calls to rows unimpacted by size changes. I suspect this is a bug in UITableView.

Closes: https://github.com/cashapp/redwood/issues/1254

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
