### PR TITLE
Remove subtree removal synthesis for old hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/redwood/compare/0.16.0...HEAD
 
+Breaking:
+- Treehouse hosts running Redwood 0.11.0 or older are not longer actively supported. They will continue to work, but they will experience indefinite memory leaks of native widgets.
+
 New:
 - Nothing yet!
 

--- a/redwood-protocol-guest/api/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.api
@@ -23,7 +23,7 @@ public final class app/cash/redwood/protocol/guest/DefaultGuestProtocolAdapter :
 
 public abstract class app/cash/redwood/protocol/guest/GuestProtocolAdapter : app/cash/redwood/protocol/EventSink {
 	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
 	public abstract fun emitChanges ()V
 	public abstract fun getRoot ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;

--- a/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
@@ -21,7 +21,7 @@ abstract interface app.cash.redwood.protocol.guest/ProtocolWidgetSystemFactory {
 }
 
 abstract class app.cash.redwood.protocol.guest/GuestProtocolAdapter : app.cash.redwood.protocol/EventSink { // app.cash.redwood.protocol.guest/GuestProtocolAdapter|null[0]
-    constructor <init>(app.cash.redwood.protocol/RedwoodVersion) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.<init>|<init>(app.cash.redwood.protocol.RedwoodVersion){}[0]
+    constructor <init>() // app.cash.redwood.protocol.guest/GuestProtocolAdapter.<init>|<init>(){}[0]
 
     abstract val root // app.cash.redwood.protocol.guest/GuestProtocolAdapter.root|{}root[0]
         abstract fun <get-root>(): app.cash.redwood.widget/Widget.Children<kotlin/Unit> // app.cash.redwood.protocol.guest/GuestProtocolAdapter.root.<get-root>|<get-root>(){}[0]

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/DefaultGuestProtocolAdapter.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/DefaultGuestProtocolAdapter.kt
@@ -41,10 +41,12 @@ import kotlinx.serialization.json.JsonPrimitive
 @OptIn(RedwoodCodegenApi::class)
 public class DefaultGuestProtocolAdapter(
   public override val json: Json = Json.Default,
+  // Just keep this parameter because we may need it in the future to vary the protocol.
+  @Suppress("unused")
   hostVersion: RedwoodVersion,
   private val widgetSystemFactory: ProtocolWidgetSystemFactory,
   private val mismatchHandler: ProtocolMismatchHandler = ProtocolMismatchHandler.Throwing,
-) : GuestProtocolAdapter(hostVersion) {
+) : GuestProtocolAdapter() {
   private var nextValue = Id.Root.value + 1
   private val widgets = mutableMapOf<Int, ProtocolWidget>()
   private val changes = mutableListOf<Change>()

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/ProtocolWidgetChildren.kt
@@ -37,26 +37,12 @@ public class ProtocolWidgetChildren(
   }
 
   override fun remove(index: Int, count: Int) {
-    val removedIds = if (guestAdapter.synthesizeSubtreeRemoval) {
-      // This boxes Id values. Don't bother optimizing since it only serves very old hosts.
-      buildList(count) {
-        for (i in index until index + count) {
-          val widget = _widgets[i]
-          this += widget.id
-          guestAdapter.removeWidget(widget.id)
-
-          widget.depthFirstWalk(guestAdapter.childrenRemover)
-        }
-      }
-    } else {
-      for (i in index until index + count) {
-        val widget = _widgets[i]
-        guestAdapter.removeWidget(widget.id)
-        widget.depthFirstWalk(guestAdapter.childrenRemover)
-      }
-      emptyList()
+    for (i in index until index + count) {
+      val widget = _widgets[i]
+      guestAdapter.removeWidget(widget.id)
+      widget.depthFirstWalk(guestAdapter.childrenRemover)
     }
-    guestAdapter.appendRemove(id, tag, index, count, removedIds)
+    guestAdapter.appendRemove(id, tag, index, count, emptyList())
 
     _widgets.remove(index, count)
   }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolGuestGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolGuestGeneration.kt
@@ -438,14 +438,7 @@ internal fun generateProtocolWidget(
             .apply {
               for (trait in widget.traits) {
                 if (trait is ProtocolChildren) {
-                  if (workAroundLazyListPlaceholderRemoveCrash(widget, trait)) {
-                    addComment("Work around the LazyList.placeholder remove crash.")
-                    beginControlFlow("if (!guestAdapter.synthesizeSubtreeRemoval)")
-                    addStatement("%N.depthFirstWalk(this, visitor)", trait.name)
-                    endControlFlow()
-                  } else {
-                    addStatement("%N.depthFirstWalk(this, visitor)", trait.name)
-                  }
+                  addStatement("%N.depthFirstWalk(this, visitor)", trait.name)
                 }
               }
             }
@@ -455,25 +448,6 @@ internal fun generateProtocolWidget(
     )
   }
 }
-
-private val placeholderParentTypeNames = listOf(
-  listOf("app.cash.redwood.lazylayout", "LazyList"),
-  listOf("app.cash.redwood.lazylayout", "RefreshableLazyList"),
-)
-
-/**
- * Returns true if this is the `LazyList.placeholder` trait, which had a severe bug in host code
- * by assuming `Widget.Children.remove()` is never be called. (This started crashing when we fixed
- * host-side memory leaks by removing guest-side children.)
- *
- * We work around this by not attempting to fix the host-side memory leak. This turns out to not
- * be a problem in practice anyway, because we never remove placeholders until we remove the
- * entire LazyList.
- */
-private fun workAroundLazyListPlaceholderRemoveCrash(
-  widget: ProtocolWidget,
-  trait: ProtocolWidget.ProtocolTrait,
-): Boolean = widget.type.names in placeholderParentTypeNames && trait.name == "placeholder"
 
 /*
 internal val GrowTagAndSerializer: Pair<ModifierTag, SerializationStrategy<Grow>?> =

--- a/redwood-treehouse-guest/src/jsMain/kotlin/app/cash/redwood/treehouse/ProtocolBridgeJs.kt
+++ b/redwood-treehouse-guest/src/jsMain/kotlin/app/cash/redwood/treehouse/ProtocolBridgeJs.kt
@@ -43,15 +43,14 @@ internal actual fun GuestProtocolAdapter(
   hostVersion: RedwoodVersion,
   widgetSystemFactory: ProtocolWidgetSystemFactory,
   mismatchHandler: ProtocolMismatchHandler,
-): GuestProtocolAdapter = FastGuestProtocolAdapter(json, hostVersion, widgetSystemFactory, mismatchHandler)
+): GuestProtocolAdapter = FastGuestProtocolAdapter(json, widgetSystemFactory, mismatchHandler)
 
 @OptIn(ExperimentalSerializationApi::class, RedwoodCodegenApi::class)
 internal class FastGuestProtocolAdapter(
   override val json: Json = Json.Default,
-  hostVersion: RedwoodVersion,
   private val widgetSystemFactory: ProtocolWidgetSystemFactory,
   private val mismatchHandler: ProtocolMismatchHandler = ProtocolMismatchHandler.Throwing,
-) : GuestProtocolAdapter(hostVersion) {
+) : GuestProtocolAdapter() {
   private var nextValue = Id.Root.value + 1
   private val widgets = JsMap<Int, ProtocolWidget>()
   private val changes = JsArray<Change>()

--- a/redwood-treehouse-guest/src/jsTest/kotlin/app/cash/redwood/treehouse/FastGuestProtocolAdapterTest.kt
+++ b/redwood-treehouse-guest/src/jsTest/kotlin/app/cash/redwood/treehouse/FastGuestProtocolAdapterTest.kt
@@ -137,8 +137,6 @@ class FastGuestProtocolAdapterTest {
     block: (Widget.Children<Unit>, TestSchemaWidgetSystem<Unit>) -> Unit,
   ): List<Change> {
     val guest = FastGuestProtocolAdapter(
-      // Use latest guest version as the host version to avoid any compatibility behavior.
-      hostVersion = guestRedwoodVersion,
       widgetSystemFactory = TestSchemaProtocolWidgetSystemFactory,
       json = json,
       mismatchHandler = ProtocolMismatchHandler.Throwing,


### PR DESCRIPTION
This is inhibiting the ability to easily support Compose capabilities like `movableContentOf`.

Refs #1900.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
