### PR TITLE
Remove old `ZiplineTreehouseUi.start` overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 Breaking:
 - Treehouse hosts running Redwood 0.11.0 or older are not longer actively supported. They will continue to work, but they will experience indefinite memory leaks of native widgets.
+- Old, deprecated overloads of `ZiplineTreehouseUi.start` have been removed. The new overloads have been available since Redwood 0.8.0 for over a year.
 
 New:
 - `UIConfiguration.viewInsets` tracks the safe area of the specific `RedwoodView` being targeted. This is currently implemented for views on Android and UIViews on iOS.

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -27,7 +27,6 @@ import app.cash.redwood.ui.OnBackPressedCallback
 import app.cash.redwood.ui.OnBackPressedDispatcher
 import app.cash.redwood.ui.UiConfiguration
 import app.cash.redwood.widget.Widget
-import app.cash.zipline.ZiplineApiMismatchException
 import app.cash.zipline.ZiplineScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -500,16 +499,7 @@ private class ViewContentCodeBinding<A : AppService>(
       stateSnapshot = viewOrNull?.stateSnapshotId?.let {
         stateStore.get(it.value.orEmpty())
       }
-      try {
-        treehouseUi.start(this@ViewContentCodeBinding)
-      } catch (e: ZiplineApiMismatchException) {
-        // Fall back to calling the function that doesn't have a back pressed dispatcher.
-        treehouseUi.start(
-          changesSink = this@ViewContentCodeBinding,
-          uiConfigurations = uiConfigurationFlow,
-          stateSnapshot = stateSnapshot,
-        )
-      }
+      treehouseUi.start(this@ViewContentCodeBinding)
     }
   }
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeZiplineTreehouseUi.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeZiplineTreehouseUi.kt
@@ -23,9 +23,7 @@ import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.PropertyChange
 import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
-import app.cash.redwood.ui.UiConfiguration
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.JsonPrimitive
 
 /**
@@ -88,25 +86,6 @@ class FakeZiplineTreehouseUi(
     extraServicesToClose += result
 
     return result
-  }
-
-  @Suppress("OVERRIDE_DEPRECATION")
-  override fun start(
-    changesSink: ChangesSinkService,
-    onBackPressedDispatcher: OnBackPressedDispatcherService,
-    uiConfigurations: StateFlow<UiConfiguration>,
-    stateSnapshot: StateSnapshot?,
-  ) {
-    error("unexpected call")
-  }
-
-  @Suppress("OVERRIDE_DEPRECATION")
-  override fun start(
-    changesSink: ChangesSinkService,
-    uiConfigurations: StateFlow<UiConfiguration>,
-    stateSnapshot: StateSnapshot?,
-  ) {
-    error("unexpected call")
   }
 
   override fun close() {

--- a/redwood-treehouse/api/android/redwood-treehouse.api
+++ b/redwood-treehouse/api/android/redwood-treehouse.api
@@ -215,8 +215,6 @@ public final class app/cash/redwood/treehouse/StateSnapshotKt {
 public abstract interface class app/cash/redwood/treehouse/ZiplineTreehouseUi : app/cash/redwood/protocol/EventSink, app/cash/zipline/ZiplineService {
 	public static final field Companion Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Companion;
 	public fun snapshotState ()Lapp/cash/redwood/treehouse/StateSnapshot;
-	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
-	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
 	public abstract fun start (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;)V
 }
 

--- a/redwood-treehouse/api/jvm/redwood-treehouse.api
+++ b/redwood-treehouse/api/jvm/redwood-treehouse.api
@@ -215,8 +215,6 @@ public final class app/cash/redwood/treehouse/StateSnapshotKt {
 public abstract interface class app/cash/redwood/treehouse/ZiplineTreehouseUi : app/cash/redwood/protocol/EventSink, app/cash/zipline/ZiplineService {
 	public static final field Companion Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Companion;
 	public fun snapshotState ()Lapp/cash/redwood/treehouse/StateSnapshot;
-	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lapp/cash/redwood/treehouse/OnBackPressedDispatcherService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
-	public abstract fun start (Lapp/cash/redwood/treehouse/ChangesSinkService;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/redwood/treehouse/StateSnapshot;)V
 	public abstract fun start (Lapp/cash/redwood/treehouse/ZiplineTreehouseUi$Host;)V
 }
 

--- a/redwood-treehouse/api/redwood-treehouse.klib.api
+++ b/redwood-treehouse/api/redwood-treehouse.klib.api
@@ -59,8 +59,6 @@ abstract interface app.cash.redwood.treehouse/OnBackPressedDispatcherService : a
 }
 
 abstract interface app.cash.redwood.treehouse/ZiplineTreehouseUi : app.cash.redwood.protocol/EventSink, app.cash.zipline/ZiplineService { // app.cash.redwood.treehouse/ZiplineTreehouseUi|null[0]
-    abstract fun start(app.cash.redwood.treehouse/ChangesSinkService, app.cash.redwood.treehouse/OnBackPressedDispatcherService, kotlinx.coroutines.flow/StateFlow<app.cash.redwood.ui/UiConfiguration>, app.cash.redwood.treehouse/StateSnapshot?) // app.cash.redwood.treehouse/ZiplineTreehouseUi.start|start(app.cash.redwood.treehouse.ChangesSinkService;app.cash.redwood.treehouse.OnBackPressedDispatcherService;kotlinx.coroutines.flow.StateFlow<app.cash.redwood.ui.UiConfiguration>;app.cash.redwood.treehouse.StateSnapshot?){}[0]
-    abstract fun start(app.cash.redwood.treehouse/ChangesSinkService, kotlinx.coroutines.flow/StateFlow<app.cash.redwood.ui/UiConfiguration>, app.cash.redwood.treehouse/StateSnapshot?) // app.cash.redwood.treehouse/ZiplineTreehouseUi.start|start(app.cash.redwood.treehouse.ChangesSinkService;kotlinx.coroutines.flow.StateFlow<app.cash.redwood.ui.UiConfiguration>;app.cash.redwood.treehouse.StateSnapshot?){}[0]
     abstract fun start(app.cash.redwood.treehouse/ZiplineTreehouseUi.Host) // app.cash.redwood.treehouse/ZiplineTreehouseUi.start|start(app.cash.redwood.treehouse.ZiplineTreehouseUi.Host){}[0]
     open fun snapshotState(): app.cash.redwood.treehouse/StateSnapshot? // app.cash.redwood.treehouse/ZiplineTreehouseUi.snapshotState|snapshotState(){}[0]
 

--- a/redwood-treehouse/api/zipline-api.toml
+++ b/redwood-treehouse/api/zipline-api.toml
@@ -101,12 +101,6 @@ functions = [
   # fun snapshotState(): app.cash.redwood.treehouse.StateSnapshot
   "mPBGCHFl",
 
-  # fun start(app.cash.redwood.treehouse.ChangesSinkService, app.cash.redwood.treehouse.OnBackPressedDispatcherService, kotlinx.coroutines.flow.StateFlow<app.cash.redwood.ui.UiConfiguration>, app.cash.redwood.treehouse.StateSnapshot): kotlin.Unit
-  "UkTy28z8",
-
-  # fun start(app.cash.redwood.treehouse.ChangesSinkService, kotlinx.coroutines.flow.StateFlow<app.cash.redwood.ui.UiConfiguration>, app.cash.redwood.treehouse.StateSnapshot): kotlin.Unit
-  "FiVQXMQW",
-
   # fun start(app.cash.redwood.treehouse.ZiplineTreehouseUi.Host): kotlin.Unit
   "h9yZr91W",
 ]

--- a/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineTreehouseUi.kt
+++ b/redwood-treehouse/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineTreehouseUi.kt
@@ -32,24 +32,6 @@ public interface ZiplineTreehouseUi :
   EventSink {
   public fun start(host: Host)
 
-  @Deprecated("Use `start` method that takes in a Host")
-  public fun start(
-    changesSink: ChangesSinkService,
-    onBackPressedDispatcher: OnBackPressedDispatcherService,
-    uiConfigurations: StateFlow<UiConfiguration>,
-    stateSnapshot: StateSnapshot?,
-  )
-
-  @Deprecated(
-    "Use `start` method that takes in an `OnBackPressedDispatcherService` instead.",
-    ReplaceWith("start(changesSink, TODO(), uiConfigurations, stateSnapshot)"),
-  )
-  public fun start(
-    changesSink: ChangesSinkService,
-    uiConfigurations: StateFlow<UiConfiguration>,
-    stateSnapshot: StateSnapshot?,
-  )
-
   public fun snapshotState(): StateSnapshot? = null
 
   /** Access to the host that presents this UI. */


### PR DESCRIPTION
These have been deprecated for more than one year. Technically it's a little sooner than the 16-months promised by #1539, but with things like #2470 we might as well clean these up, too.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
