### PR TITLE
Add a test for DisposableEffect callbacks

### DIFF
--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/FakeHostApi.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/FakeHostApi.kt
@@ -16,9 +16,20 @@
 package app.cash.redwood.treehouse
 
 import com.example.redwood.testapp.treehouse.HostApi
+import kotlinx.coroutines.channels.Channel
 
 class FakeHostApi : HostApi {
+  private val messagesChannel = Channel<String>(capacity = Int.MAX_VALUE)
+
   override suspend fun httpCall(url: String, headers: Map<String, String>): String {
     error("unexpected call")
+  }
+
+  override fun log(message: String) {
+    messagesChannel.trySend(message)
+  }
+
+  suspend fun takeMessage(): String {
+    return messagesChannel.receive()
   }
 }

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/GuestLifecycleTest.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/GuestLifecycleTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.treehouse
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.example.redwood.testapp.testing.ButtonValue
+import com.example.redwood.testapp.testing.TextInputValue
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class GuestLifecycleTest {
+  @Test
+  fun disposableEffectDisposedWhenRemovedFromComposition() = runTest {
+    val tester = TreehouseTester(this)
+    val treehouseApp = tester.loadApp()
+    val content = tester.content(treehouseApp)
+    val view = tester.view()
+
+    content.bind(view)
+
+    content.awaitContent(1)
+    val textInputValue = view.views.single() as TextInputValue
+    assertThat(textInputValue.text).isEqualTo("what would you like to see?")
+    textInputValue.onChange!!.invoke("GuestLifecycleTestShowDisposable")
+
+    tester.sendFrame()
+    assertThat(tester.hostApi.takeMessage()).isEqualTo("DisposableEffect.effect()")
+    content.awaitContent(2)
+    val nextButton = view.views.single() as ButtonValue
+    assertThat(nextButton.text).isEqualTo("Next")
+    nextButton.onClick!!.invoke()
+
+    tester.sendFrame()
+    assertThat(tester.hostApi.takeMessage()).isEqualTo("DisposableEffect.dispose()")
+    content.awaitContent(3)
+    assertThat(view.views).isEmpty()
+
+    treehouseApp.stop()
+    treehouseApp.close()
+  }
+}

--- a/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTester.kt
+++ b/redwood-treehouse-host/src/appsJvmTest/kotlin/app/cash/redwood/treehouse/TreehouseTester.kt
@@ -44,7 +44,7 @@ internal class TreehouseTester(
 ) {
   val eventLog = EventLog()
 
-  var hostApi: HostApi = FakeHostApi()
+  var hostApi = FakeHostApi()
 
   var eventListenerFactory: EventListener.Factory = FakeEventListener.Factory(eventLog)
 
@@ -98,7 +98,7 @@ internal class TreehouseTester(
     override fun create(scope: CoroutineScope, dispatchers: TreehouseDispatchers) = frameClock
   }
 
-  val treehouseAppFactory = RealTreehouseApp.Factory(
+  private val treehouseAppFactory = RealTreehouseApp.Factory(
     platform = platform,
     httpClient = httpClient,
     frameClockFactory = frameClockFactory,
@@ -129,7 +129,7 @@ internal class TreehouseTester(
       treehouseApp: TreehouseApp<TestAppPresenter>,
       zipline: Zipline,
     ) {
-      zipline.bind("HostApi", hostApi)
+      zipline.bind<HostApi>("HostApi", hostApi)
     }
 
     override fun create(zipline: Zipline): TestAppPresenter {

--- a/test-app/presenter-treehouse/src/commonMain/kotlin/com/example/redwood/testapp/treehouse/HostApi.kt
+++ b/test-app/presenter-treehouse/src/commonMain/kotlin/com/example/redwood/testapp/treehouse/HostApi.kt
@@ -22,4 +22,7 @@ import kotlin.native.ObjCName
 interface HostApi : ZiplineService {
   /** Decodes the response as a string and returns it. */
   suspend fun httpCall(url: String, headers: Map<String, String>): String
+
+  /** Records a message for any potential consumer. */
+  fun log(message: String)
 }

--- a/test-app/presenter-treehouse/src/jsMain/kotlin/com/example/redwood/testapp/treehouse/RealTestAppPresenter.kt
+++ b/test-app/presenter-treehouse/src/jsMain/kotlin/com/example/redwood/testapp/treehouse/RealTestAppPresenter.kt
@@ -37,6 +37,7 @@ class RealTestAppPresenter(
   }
 
   override fun launchForTester(): ZiplineTreehouseUi {
-    return TesterTreehouseUi().asZiplineTreehouseUi(appLifecycle)
+    val treehouseUi = TesterTreehouseUi(hostApi)
+    return treehouseUi.asZiplineTreehouseUi(appLifecycle)
   }
 }


### PR DESCRIPTION
Initially I'm adding just the test we already pass, where the effect is executed because it is removed from the composition.

https://github.com/cashapp/redwood/issues/2248

