### PR TITLE
Remove widgets individually in the protocol

### DIFF
--- a/redwood-protocol-guest/api/redwood-protocol-guest.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.api
@@ -23,7 +23,7 @@ public final class app/cash/redwood/protocol/guest/DefaultGuestProtocolAdapter :
 
 public abstract class app/cash/redwood/protocol/guest/GuestProtocolAdapter : app/cash/redwood/protocol/EventSink {
 	public static final field $stable I
-	public fun <init> ()V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public abstract fun emitChanges ()V
 	public abstract fun getRoot ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun getWidgetSystem ()Lapp/cash/redwood/widget/WidgetSystem;

--- a/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
+++ b/redwood-protocol-guest/api/redwood-protocol-guest.klib.api
@@ -21,7 +21,7 @@ abstract interface app.cash.redwood.protocol.guest/ProtocolWidgetSystemFactory {
 }
 
 abstract class app.cash.redwood.protocol.guest/GuestProtocolAdapter : app.cash.redwood.protocol/EventSink { // app.cash.redwood.protocol.guest/GuestProtocolAdapter|null[0]
-    constructor <init>() // app.cash.redwood.protocol.guest/GuestProtocolAdapter.<init>|<init>(){}[0]
+    constructor <init>(app.cash.redwood.protocol/RedwoodVersion) // app.cash.redwood.protocol.guest/GuestProtocolAdapter.<init>|<init>(app.cash.redwood.protocol.RedwoodVersion){}[0]
 
     abstract val root // app.cash.redwood.protocol.guest/GuestProtocolAdapter.root|{}root[0]
         abstract fun <get-root>(): app.cash.redwood.widget/Widget.Children<kotlin/Unit> // app.cash.redwood.protocol.guest/GuestProtocolAdapter.root.<get-root>|<get-root>(){}[0]

--- a/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/GuestProtocolAdapter.kt
+++ b/redwood-protocol-guest/src/commonMain/kotlin/app/cash/redwood/protocol/guest/GuestProtocolAdapter.kt
@@ -22,6 +22,7 @@ import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.PropertyTag
+import app.cash.redwood.protocol.RedwoodVersion
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.Widget
 import app.cash.redwood.widget.WidgetSystem
@@ -36,9 +37,21 @@ import kotlinx.serialization.json.Json
  *
  * This interface is for generated code use only.
  */
-public abstract class GuestProtocolAdapter : EventSink {
+public abstract class GuestProtocolAdapter(
+  hostVersion: RedwoodVersion,
+) : EventSink {
   @RedwoodCodegenApi
   public abstract val json: Json
+
+  /**
+   * Whether the host supports the detach parameter on
+   * [app.cash.redwood.protocol.ChildrenChange.Remove]. This also implies that the `count`
+   * parameter does not need to be sent.
+   *
+   * TODO Remove when minimum-supported host version is 1.17 or higher.
+   */
+  @RedwoodCodegenApi
+  protected val hostSupportsRemoveDetachAndNoCount: Boolean = hostVersion >= RedwoodVersion("0.17.0-SNAPSHOT")
 
   /**
    * The provider of factories of widgets which record property changes and whose children changes

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -105,16 +105,18 @@ public class HostProtocolAdapter<W : Any>(
               children.move(change.fromIndex, change.toIndex, change.count)
             }
 
-            is Remove -> {
-              if (!change.detach) {
-                for (childIndex in change.index until change.index + change.count) {
-                  val child = children.nodes[childIndex]
-                  child.visitIds(removeNodeById)
-                  poolOrDetach(child)
+            is Remove ->
+              @Suppress("DEPRECATION") // For compatibility with old guests.
+              {
+                if (!change.detach) {
+                  for (childIndex in change.index until change.index + change.count) {
+                    val child = children.nodes[childIndex]
+                    child.visitIds(removeNodeById)
+                    poolOrDetach(child)
+                  }
                 }
+                children.remove(change.index, change.count)
               }
-              children.remove(change.index, change.count)
-            }
           }
 
           val widget = node.widget

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapterTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapterTest.kt
@@ -149,7 +149,7 @@ class HostProtocolAdapterTest {
           id = Id.Root,
           tag = ChildrenTag.Root,
           index = 0,
-          count = 1,
+          detach = false,
         ),
       ),
     )
@@ -253,7 +253,7 @@ class HostProtocolAdapterTest {
     // Remove root TestRow.
     host.sendChanges(
       listOf(
-        Remove(Id.Root, ChildrenTag.Root, 0, 1),
+        Remove(Id.Root, ChildrenTag.Root, 0, false),
       ),
     )
 
@@ -308,9 +308,9 @@ class HostProtocolAdapterTest {
     host.sendChanges(
       listOf(
         // Detach inner TestRow.
-        Remove(Id(1), ChildrenTag(1), 0, 1, detach = true),
+        Remove(Id(1), ChildrenTag(1), 0, detach = true),
         // Remove outer TestRow.
-        Remove(Id.Root, ChildrenTag.Root, 0, 1),
+        Remove(Id.Root, ChildrenTag.Root, 0, detach = false),
         // New outer TestRow.
         Create(Id(4), WidgetTag(1)),
         ModifierChange(Id(4)),

--- a/redwood-protocol/api/redwood-protocol.api
+++ b/redwood-protocol/api/redwood-protocol.api
@@ -102,8 +102,8 @@ public synthetic class app/cash/redwood/protocol/ChildrenChange$Remove$$serializ
 }
 
 public final class app/cash/redwood/protocol/ChildrenChange$Remove$Companion {
-	public final fun invoke-HpxY78w (IIIIZ)Lapp/cash/redwood/protocol/ChildrenChange$Remove;
-	public static synthetic fun invoke-HpxY78w$default (Lapp/cash/redwood/protocol/ChildrenChange$Remove$Companion;IIIIZILjava/lang/Object;)Lapp/cash/redwood/protocol/ChildrenChange$Remove;
+	public final fun invoke-ARs5Qwk (IIII)Lapp/cash/redwood/protocol/ChildrenChange$Remove;
+	public final fun invoke-ARs5Qwk (IIIZ)Lapp/cash/redwood/protocol/ChildrenChange$Remove;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/redwood-protocol/api/redwood-protocol.klib.api
+++ b/redwood-protocol/api/redwood-protocol.klib.api
@@ -114,7 +114,8 @@ sealed interface app.cash.redwood.protocol/ChildrenChange : app.cash.redwood.pro
         }
 
         final object Companion { // app.cash.redwood.protocol/ChildrenChange.Remove.Companion|null[0]
-            final fun invoke(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, kotlin/Int, kotlin/Boolean = ...): app.cash.redwood.protocol/ChildrenChange.Remove // app.cash.redwood.protocol/ChildrenChange.Remove.Companion.invoke|invoke(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;kotlin.Int;kotlin.Boolean){}[0]
+            final fun invoke(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, kotlin/Boolean): app.cash.redwood.protocol/ChildrenChange.Remove // app.cash.redwood.protocol/ChildrenChange.Remove.Companion.invoke|invoke(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;kotlin.Boolean){}[0]
+            final fun invoke(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/ChildrenTag, kotlin/Int, kotlin/Int): app.cash.redwood.protocol/ChildrenChange.Remove // app.cash.redwood.protocol/ChildrenChange.Remove.Companion.invoke|invoke(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.ChildrenTag;kotlin.Int;kotlin.Int){}[0]
             final fun serializer(): kotlinx.serialization/KSerializer<app.cash.redwood.protocol/ChildrenChange.Remove> // app.cash.redwood.protocol/ChildrenChange.Remove.Companion.serializer|serializer(){}[0]
         }
     }

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/protocol.kt
@@ -247,11 +247,14 @@ public sealed interface ChildrenChange : Change {
     @SerialName("tag")
     private val _tag: Int,
     public val index: Int,
-    public val count: Int,
+    @Deprecated("Always 1 after 0.17.0. Will be >1 with earlier guests.")
+    public val count: Int = 1,
     /**
      * When true, the associated nodes should only be detached from the tree with the expectation
      * that a future [Add] will re-attach them. Otherwise, nodes should be detached and fully
      * removed for garbage collection.
+     *
+     * Note: This property is only populated for hosts running 0.17.0 or newer.
      */
     public val detach: Boolean = false,
   ) : ChildrenChange {
@@ -263,9 +266,16 @@ public sealed interface ChildrenChange : Change {
         id: Id,
         tag: ChildrenTag,
         index: Int,
+        detach: Boolean,
+      ): Remove = Remove(id.value, tag.value, index, 1, detach)
+
+      @Deprecated("Count is only supported on hosts older than 0.17.0.")
+      public operator fun invoke(
+        id: Id,
+        tag: ChildrenTag,
+        index: Int,
         count: Int,
-        detach: Boolean = false,
-      ): Remove = Remove(id.value, tag.value, index, count, detach)
+      ): Remove = Remove(id.value, tag.value, index, count, false)
     }
   }
 }

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
@@ -57,7 +57,9 @@ class ProtocolTest {
       Create(Id(1), WidgetTag(2)),
       ChildrenChange.Add(Id(1), ChildrenTag(2), Id(3), 4),
       ChildrenChange.Move(Id(1), ChildrenTag(2), 3, 4, 5),
-      ChildrenChange.Remove(Id(4), ChildrenTag(3), 2, 1),
+      @Suppress("DEPRECATION") // Testing for compatibility.
+      ChildrenChange.Remove(Id(4), ChildrenTag(3), 2, 10),
+      ChildrenChange.Remove(Id(5), ChildrenTag(3), 2, detach = true),
       ModifierChange(
         Id(1),
         listOf(
@@ -90,7 +92,8 @@ class ProtocolTest {
       """["create",{"id":1,"tag":2}],""" +
       """["add",{"id":1,"tag":2,"childId":3,"index":4}],""" +
       """["move",{"id":1,"tag":2,"fromIndex":3,"toIndex":4,"count":5}],""" +
-      """["remove",{"id":4,"tag":3,"index":2,"count":1}],""" +
+      """["remove",{"id":4,"tag":3,"index":2,"count":10}],""" +
+      """["remove",{"id":5,"tag":3,"index":2,"detach":true}],""" +
       """["modifier",{"id":1,"elements":[[1,{}],[2,3],[3,[]],[4],[5]]}],""" +
       """["property",{"id":1,"widget":2,"tag":2,"value":"hello"}],""" +
       """["property",{"id":1,"widget":2,"tag":2}]""" +

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/SnapshotChangeListTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/SnapshotChangeListTest.kt
@@ -62,7 +62,7 @@ class SnapshotChangeListTest {
           Move(Id.Root, ChildrenTag.Root, 1, 2, 3),
           PropertyChange(Id(1), WidgetTag(1), PropertyTag(1), JsonPrimitive("Hello")),
           Add(Id.Root, ChildrenTag.Root, Id(1), 0),
-          Remove(Id.Root, ChildrenTag.Root, 1, 2),
+          Remove(Id.Root, ChildrenTag.Root, 1, false),
         ),
       )
     }.hasMessage(
@@ -71,7 +71,7 @@ class SnapshotChangeListTest {
       |
       |Found:
       | - Move(_id=0, _tag=1, fromIndex=1, toIndex=2, count=3)
-      | - Remove(_id=0, _tag=1, index=1, count=2, detach=false)
+      | - Remove(_id=0, _tag=1, index=1, count=1, detach=false)
       """.trimMargin(),
     )
   }

--- a/redwood-treehouse-guest/src/jsTest/kotlin/app/cash/redwood/treehouse/FastGuestProtocolAdapterTest.kt
+++ b/redwood-treehouse-guest/src/jsTest/kotlin/app/cash/redwood/treehouse/FastGuestProtocolAdapterTest.kt
@@ -137,6 +137,8 @@ class FastGuestProtocolAdapterTest {
     block: (Widget.Children<Unit>, TestSchemaWidgetSystem<Unit>) -> Unit,
   ): List<Change> {
     val guest = FastGuestProtocolAdapter(
+      // Use latest guest version as the host version to avoid any compatibility behavior.
+      hostVersion = guestRedwoodVersion,
       widgetSystemFactory = TestSchemaProtocolWidgetSystemFactory,
       json = json,
       mismatchHandler = ProtocolMismatchHandler.Throwing,


### PR DESCRIPTION
This is required to efficiently implement `movableContentOf` in a future change.

See #1902 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
