### PR TITLE
Invalidate UIViewFlexContainer's intrinsic size if it is not nested.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Fixed:
 - Add support for the Width modifier in `ComposeUiBox`.
 - Call `DisposableEffect` when a screen is unbound. We were only calling these when the effect was removed from the composition.
 - Support `movableContentOf` in Treehouse (and generally in the Redwood protocol). Note: this requires the host be running version 0.17.0 or newer.
-
+- Fix case where `Column` and `Row` would not update their intrinsic size on iOS if they are not a child of another `Column` or `Row`.
 
 ## [0.16.0] - 2024-11-19
 [0.16.0]: https://github.com/cashapp/redwood/releases/tag/0.16.0

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -143,16 +143,16 @@ internal class UIViewFlexContainer(
   }
 
   internal fun invalidateSize(nodeBecameDirty: Boolean = false) {
-    if (rootNode.markDirty() || nodeBecameDirty) {
+    val sizeListener = this.sizeListener
+    if (sizeListener == null) {
+      // This is a top-level flex container. Tell the enclosing view to redo its layout.
+      rootNode.markDirty()
+      value.invalidateIntrinsicContentSize()
+      value.setNeedsLayout()
+    } else if (rootNode.markDirty() || nodeBecameDirty) {
       // The node was newly-dirty. Propagate that up the tree.
-      val sizeListener = this.sizeListener
-      if (sizeListener != null) {
-        value.setNeedsLayout()
-        sizeListener.invalidateSize()
-      } else {
-        value.invalidateIntrinsicContentSize() // Tell the enclosing view that our size changed.
-        value.setNeedsLayout() // Update layout of subviews.
-      }
+      value.setNeedsLayout()
+      sizeListener.invalidateSize()
     }
   }
 }


### PR DESCRIPTION
Fix case where `Column` and `Row` would not update their intrinsic size on iOS if they are not a child of another `Column` or `Row`.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
