### PR TITLE
Add `setContent` variant which returns initial snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking:
 New:
 - `UIConfiguration.viewInsets` tracks the safe area of the specific `RedwoodView` being targeted. This is currently implemented for views on Android and UIViews on iOS.
 - `ConsumeInsets {}` composable consumes insets. Most applications should call this in their root composable function.
+- Add `TestRedwoodComposition.setContentAndSnapshot` function which is a fused version of `setContent` and `awaitSnapshot`, except that it guarantees the returned snapshot is the result of the initial composition of the content without any additional frames sent.
 
 Changed:
 - Nothing yet!

--- a/redwood-testing/api/redwood-testing.api
+++ b/redwood-testing/api/redwood-testing.api
@@ -9,6 +9,7 @@ public abstract interface class app/cash/redwood/testing/TestRedwoodComposition 
 	public static synthetic fun awaitSnapshot-VtjQ1oo$default (Lapp/cash/redwood/testing/TestRedwoodComposition;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getUiConfigurations ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public abstract fun saveState ()Lapp/cash/redwood/testing/TestSavedState;
+	public abstract fun setContentAndSnapshot (Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
 
 public final class app/cash/redwood/testing/TestRedwoodCompositionKt {

--- a/redwood-testing/api/redwood-testing.klib.api
+++ b/redwood-testing/api/redwood-testing.klib.api
@@ -11,6 +11,7 @@ abstract interface <#A: kotlin/Any?> app.cash.redwood.testing/TestRedwoodComposi
         abstract fun <get-uiConfigurations>(): kotlinx.coroutines.flow/MutableStateFlow<app.cash.redwood.ui/UiConfiguration> // app.cash.redwood.testing/TestRedwoodComposition.uiConfigurations.<get-uiConfigurations>|<get-uiConfigurations>(){}[0]
 
     abstract fun saveState(): app.cash.redwood.testing/TestSavedState // app.cash.redwood.testing/TestRedwoodComposition.saveState|saveState(){}[0]
+    abstract fun setContentAndSnapshot(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>): #A // app.cash.redwood.testing/TestRedwoodComposition.setContentAndSnapshot|setContentAndSnapshot(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
     abstract suspend fun awaitSnapshot(kotlin.time/Duration = ...): #A // app.cash.redwood.testing/TestRedwoodComposition.awaitSnapshot|awaitSnapshot(kotlin.time.Duration){}[0]
 }
 

--- a/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/TestRedwoodComposition.kt
+++ b/redwood-testing/src/commonMain/kotlin/app/cash/redwood/testing/TestRedwoodComposition.kt
@@ -61,7 +61,15 @@ public fun <W : Any, S> TestRedwoodComposition(
 
 public interface TestRedwoodComposition<S> : RedwoodComposition {
   /**
+   * A fused call which does both [setContent] and [awaitSnapshot], but without sending a frame
+   * to the composition. The snapshot returned will always be the result of the synchronous
+   * recomposition of [content].
+   */
+  public fun setContentAndSnapshot(content: @Composable () -> Unit): S
+
+  /**
    * Returns a snapshot, waiting if necessary for changes to occur since the previous snapshot.
+   * Each call to this function is guaranteed to send at least once frame to the composition.
    *
    * @throws TimeoutCancellationException if no new snapshot is produced before [timeout].
    */
@@ -126,6 +134,13 @@ private class RealTestRedwoodComposition<W : Any, S>(
   override fun setContent(content: @Composable () -> Unit) {
     contentSet = true
     composition.setContent(content)
+  }
+
+  override fun setContentAndSnapshot(content: @Composable () -> Unit): S {
+    setContent(content)
+    check(hasChanges)
+    hasChanges = false
+    return createSnapshot()
   }
 
   override suspend fun awaitSnapshot(timeout: Duration): S {

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/TestRedwoodCompositionTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/TestRedwoodCompositionTest.kt
@@ -15,8 +15,10 @@
  */
 package app.cash.redwood.testing
 
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -28,12 +30,51 @@ import app.cash.redwood.widget.MutableListChildren
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.example.redwood.testapp.compose.Text
+import com.example.redwood.testapp.testing.TestSchemaTester
 import com.example.redwood.testapp.testing.TestSchemaTestingWidgetFactory
+import com.example.redwood.testapp.testing.TextValue
 import com.example.redwood.testapp.widget.TestSchemaWidgetSystem
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 
 class TestRedwoodCompositionTest {
+  @Test fun setContentAndSnapshot() = runTest {
+    TestSchemaTester {
+      var number by mutableIntStateOf(0)
+      val initial = setContentAndSnapshot {
+        Text("The number is: $number")
+        LaunchedEffect(Unit) {
+          number = 1
+        }
+      }
+
+      // Defer to allow effect to run.
+      delay(10.milliseconds)
+
+      assertThat(initial.single()).isEqualTo(TextValue(text = "The number is: 0"))
+      assertThat(awaitSnapshot().single()).isEqualTo(TextValue(text = "The number is: 1"))
+    }
+  }
+
+  @Test fun setContentThenAwaitSnapshot() = runTest {
+    TestSchemaTester {
+      var number by mutableIntStateOf(0)
+      setContent {
+        Text("The number is: $number")
+        LaunchedEffect(Unit) {
+          number = 1
+        }
+      }
+
+      // Defer to allow effect to run.
+      delay(10.milliseconds)
+
+      assertThat(awaitSnapshot().single()).isEqualTo(TextValue(text = "The number is: 1"))
+    }
+  }
+
   @Test fun awaitSnapshotCapturesMultipleChanges() = runTest {
     var count = 0
     val tester = TestRedwoodComposition(


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
