### PR TITLE
Don't use the nested scroll view in Column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changed:
 - Nothing yet!
 
 Fixed:
-- Nothing yet!
+- Don't use NestedScrollView for Android's Overflow.Scroll. It doesn't implement overscroll as well.
 
 
 ## [0.17.0] - 2025-01-30

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
@@ -22,6 +22,7 @@ import android.view.View
 import android.view.View.OnScrollChangeListener
 import android.view.ViewGroup
 import android.widget.HorizontalScrollView
+import android.widget.ScrollView
 import androidx.core.view.children
 import androidx.core.widget.NestedScrollView
 import androidx.core.widget.NestedScrollView.OnScrollChangeListener as OnScrollChangeListenerCompat
@@ -226,7 +227,7 @@ internal class ViewFlexContainer(
           isFillViewport = true
         }
       } else {
-        NestedScrollView(context).apply {
+        ScrollView(context).apply {
           isFillViewport = true
         }
       }.apply {


### PR DESCRIPTION
This breaks overscroll.

I looked into the PR that added this, which was an attempt to work-around a problem where a RecyclerView was nested in a scrollable column. We shouldn't ever do that, so this work-around should be unnecessary.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
