### PR TITLE
Don't double insets on insets-aware UIViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changed:
 - Nothing yet!
 
 Fixed:
-- Nothing yet!
+- Don't double insets on insets-aware `UIViews`. Previously we offered the same insets via two mechanisms, which could result in double insets.
 
 
 ## [0.17.0] - 2025-01-30

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
@@ -33,6 +33,7 @@ import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIApplication
 import platform.UIKit.UIEdgeInsets
+import platform.UIKit.UIEdgeInsetsZero
 import platform.UIKit.UILayoutConstraintAxisVertical
 import platform.UIKit.UIStackView
 import platform.UIKit.UIStackViewAlignmentFill
@@ -62,7 +63,7 @@ public open class RedwoodUIView : RedwoodView<UIView> {
       computeUiConfiguration(
         density = density,
         traitCollection = valueRootView.traitCollection,
-        viewInsets = valueRootView.safeAreaInsets.toMargin(),
+        viewInsets = valueRootView.incomingSafeAreaInsets.toMargin(),
         layoutDirection = valueRootView.effectiveUserInterfaceLayoutDirection,
         bounds = valueRootView.bounds,
       ),
@@ -86,7 +87,7 @@ public open class RedwoodUIView : RedwoodView<UIView> {
     mutableUiConfiguration.value = computeUiConfiguration(
       density = density,
       traitCollection = valueRootView.traitCollection,
-      viewInsets = valueRootView.safeAreaInsets.toMargin(),
+      viewInsets = valueRootView.incomingSafeAreaInsets.toMargin(),
       layoutDirection = valueRootView.effectiveUserInterfaceLayoutDirection,
       bounds = valueRootView.bounds,
     )
@@ -104,12 +105,22 @@ public open class RedwoodUIView : RedwoodView<UIView> {
    * content resizes.
    */
   private inner class RootUIStackView : UIStackView(cValue { CGRectZero }) {
+    /** Safe area insets specified by the superview. */
+    val incomingSafeAreaInsets: CValue<UIEdgeInsets>
+      get() = super.safeAreaInsets
+
     init {
       this.axis = UILayoutConstraintAxisVertical
       this.alignment = UIStackViewAlignmentFill // Fill horizontal.
       this.distribution = UIStackViewDistributionFillEqually // Fill vertical.
       this.setInsetsLayoutMarginsFromSafeArea(false) // Consume insets internally.
     }
+
+    /**
+     * Safe area insets propagated to subviews is always zero. They consume insets from
+     * [UiConfiguration], and this override prevents doubling insets.
+     */
+    override fun safeAreaInsets() = cValue<UIEdgeInsets> { UIEdgeInsetsZero }
 
     override fun safeAreaInsetsDidChange() {
       super.safeAreaInsetsDidChange()

--- a/redwood-widget/src/iosTest/kotlin/app/cash/redwood/widget/RedwoodUIViewTest.kt
+++ b/redwood-widget/src/iosTest/kotlin/app/cash/redwood/widget/RedwoodUIViewTest.kt
@@ -16,13 +16,17 @@
 package app.cash.redwood.widget
 
 import app.cash.redwood.Modifier
+import app.cash.redwood.ui.Default
+import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.dp
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
+import kotlinx.cinterop.CValue
 import kotlinx.cinterop.cValue
+import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIEdgeInsets
 import platform.UIKit.UIEdgeInsetsMake
@@ -43,7 +47,7 @@ class RedwoodUIViewTest {
 
   /** Confirm we accept and propagates insets through [RedwoodUIView.uiConfiguration]. */
   @Test
-  fun viewInsets() {
+  fun viewInsetsAccessibleAsUiConfiguration() {
     val redwoodUIView = RedwoodUIView()
     val insetsContainer = InsetsContainer()
     insetsContainer.addSubview(redwoodUIView.value)
@@ -55,6 +59,27 @@ class RedwoodUIViewTest {
 
     assertThat(redwoodUIView.uiConfiguration.value.viewInsets)
       .isEqualTo(Margin(top = 10.0.dp, start = 20.0.dp, bottom = 30.0.dp, end = 40.0.dp))
+  }
+
+  @Test
+  fun childViewsDoNotGetDoubleInsets() {
+    val redwoodUIView = RedwoodUIView()
+    val insetsContainer = InsetsContainer()
+    insetsContainer.subviewSafeAreaInsets = UIEdgeInsetsMake(10.0, 20.0, 30.0, 40.0)
+    insetsContainer.addSubview(redwoodUIView.value)
+
+    val label = UILabel()
+    redwoodUIView.children.insert(0, UIViewWidget(label))
+
+    assertThat(label.safeAreaInsets().toMargin()).isEqualTo(Margin.Zero)
+  }
+
+  private fun CValue<UIEdgeInsets>.toMargin(density: Density = Density.Default): Margin {
+    return useContents {
+      with(density) {
+        Margin(top = top.toDp(), start = left.toDp(), bottom = bottom.toDp(), end = right.toDp())
+      }
+    }
   }
 
   class UIViewWidget(


### PR DESCRIPTION
A UIView that's a child of a Treehouse view has two competing sources of insets: its UIView superview, and the Treehouse UIConfiguration. By consuming insets in the Treehouse UIConfiguration we must also zero them out in the UIView hierarchy.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
