### PR TITLE
Shuffle where schema tag offsetting occurs

### DIFF
--- a/redwood-tooling-schema/api/redwood-tooling-schema.api
+++ b/redwood-tooling-schema/api/redwood-tooling-schema.api
@@ -99,6 +99,7 @@ public abstract interface class app/cash/redwood/tooling/schema/ProtocolSchema :
 	public abstract fun getTaggedDependencies ()Ljava/util/Map;
 	public abstract fun getWidgets ()Ljava/util/List;
 	public abstract fun toEmbeddedSchema ()Lapp/cash/redwood/tooling/schema/EmbeddedSchema;
+	public abstract fun withTagOffset (I)Lapp/cash/redwood/tooling/schema/ProtocolSchema;
 }
 
 public abstract interface class app/cash/redwood/tooling/schema/ProtocolSchemaSet : app/cash/redwood/tooling/schema/SchemaSet {

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaApi.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaApi.kt
@@ -154,6 +154,9 @@ public interface ProtocolSchema : Schema {
    * This JSON will be read when the schema is used as a dependency.
    */
   public fun toEmbeddedSchema(): EmbeddedSchema
+
+  /** Return a copy of this schema with all widget and modifier tags adjusted by [offset]. */
+  public fun withTagOffset(offset: Int): ProtocolSchema
 }
 
 public interface ProtocolWidget : Widget {

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaImpls.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaImpls.kt
@@ -64,27 +64,24 @@ internal data class ParsedProtocolSchema(
     )
   }
 
+  override fun withTagOffset(offset: Int): ParsedProtocolSchema {
+    return copy(
+      widgets = widgets.map { widget ->
+        widget.copy(tag = offset + widget.tag)
+      },
+      modifiers = modifiers.map { modifier ->
+        modifier.copy(tag = offset + modifier.tag)
+      },
+    )
+  }
+
   companion object {
     fun toEmbeddedPath(type: FqType): String {
       return type.names[0].replace('.', '/') + "/" + type.names.drop(1).joinToString(".") + ".json"
     }
 
-    fun parseEmbeddedJson(json: String, tagOffset: Int = 0): ProtocolSchema {
-      val schema = jsonFormat.decodeFromString(serializer(), json)
-      if (tagOffset == 0) {
-        return schema
-      }
-      // The schema JSON was generated locally from at its source with its normal tag numbers.
-      // If we are consuming it as a tagged dependency, offset the widget and modifier tag numbers
-      // to simplify usage downstream.
-      return schema.copy(
-        widgets = schema.widgets.map { widget ->
-          widget.copy(tag = tagOffset + widget.tag)
-        },
-        modifiers = schema.modifiers.map { modifier ->
-          modifier.copy(tag = tagOffset + modifier.tag)
-        },
-      )
+    fun parseEmbeddedJson(json: String): ProtocolSchema {
+      return jsonFormat.decodeFromString(serializer(), json)
     }
 
     @OptIn(ExperimentalSerializationApi::class) // For custom indent, which is only a nice-to-have.

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
@@ -34,8 +34,18 @@ internal fun loadProtocolSchemaDependencies(
 ): ParsedProtocolSchemaSet {
   val dependencies = schema.taggedDependencies.entries
     .associate { (tag, type) ->
-      require(tag != 0) { "Dependency $type tag must be non-zero" }
-      type to loadProtocolSchema(type, classLoader, tag)
+      require(tag in 1..MAX_SCHEMA_TAG) {
+        "Dependency $type tag must be in range (0, $MAX_SCHEMA_TAG]: $tag"
+      }
+      val dependency = loadProtocolSchema(type, classLoader)
+        .withTagOffset(tag * MAX_MEMBER_TAG)
+
+      require(dependency.dependencies.isEmpty()) {
+        "Schema dependency $type also has its own dependencies. " +
+          "For now, only a single level of dependencies is supported."
+      }
+
+      type to dependency
     }
   return ParsedProtocolSchemaSet(schema, dependencies)
 }
@@ -43,27 +53,14 @@ internal fun loadProtocolSchemaDependencies(
 internal fun loadProtocolSchema(
   type: FqType,
   classLoader: ClassLoader,
-  tag: Int = 0,
 ): ProtocolSchema {
-  require(tag in 0..MAX_SCHEMA_TAG) {
-    "$type tag must be 0 for the root or in range (0, $MAX_SCHEMA_TAG] as a dependency: $tag"
-  }
-  val tagOffset = tag * MAX_MEMBER_TAG
-
   val path = ParsedProtocolSchema.toEmbeddedPath(type)
-  val schema = classLoader
+  return classLoader
     .getResourceAsStream(path)
     ?.use(InputStream::readBytes)
     ?.decodeToString()
-    ?.let { json -> ParsedProtocolSchema.parseEmbeddedJson(json, tagOffset) }
+    ?.let { json -> ParsedProtocolSchema.parseEmbeddedJson(json) }
     ?: throw IllegalArgumentException("Unable to locate JSON for $type at $path")
-
-  require(tag == 0 || schema.dependencies.isEmpty()) {
-    "Schema dependency $type also has its own dependencies. " +
-      "For now, only a single level of dependencies is supported."
-  }
-
-  return schema
 }
 
 /** Returns true if [memberType] is a known special modifier tag and name. */

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -1100,6 +1100,14 @@ class SchemaParserTest {
   )
   object SchemaDependencyTagTooHigh
 
+  @Test fun dependencyTagTooHighThrows() {
+    assertFailure { parseTestSchema(SchemaDependencyTagTooHigh::class) }
+      .isInstanceOf<IllegalArgumentException>()
+      .hasMessage(
+        "Dependency app.cash.redwood.layout.RedwoodLayout tag must be in range (0, 2000]: 2001",
+      )
+  }
+
   @Schema(
     members = [],
     dependencies = [
@@ -1108,17 +1116,11 @@ class SchemaParserTest {
   )
   object SchemaDependencyTagTooLow
 
-  @Test fun dependencyTagTooHighThrows() {
-    assertFailure { parseTestSchema(SchemaDependencyTagTooHigh::class) }
-      .isInstanceOf<IllegalArgumentException>()
-      .hasMessage(
-        "app.cash.redwood.layout.RedwoodLayout tag must be 0 for the root or in range (0, 2000] as a dependency: 2001",
-      )
-
+  @Test fun dependencyTagTooLowThrows() {
     assertFailure { parseTestSchema(SchemaDependencyTagTooLow::class) }
       .isInstanceOf<IllegalArgumentException>()
       .hasMessage(
-        "app.cash.redwood.layout.RedwoodLayout tag must be 0 for the root or in range (0, 2000] as a dependency: -1",
+        "Dependency app.cash.redwood.layout.RedwoodLayout tag must be in range (0, 2000]: -1",
       )
   }
 
@@ -1134,7 +1136,7 @@ class SchemaParserTest {
     assertFailure { parseTestSchema(SchemaDependencyTagZero::class) }
       .isInstanceOf<IllegalArgumentException>()
       .hasMessage(
-        "Dependency app.cash.redwood.layout.RedwoodLayout tag must be non-zero",
+        "Dependency app.cash.redwood.layout.RedwoodLayout tag must be in range (0, 2000]: 0",
       )
   }
 


### PR DESCRIPTION
The old mechanism was based on our now deleted reflection-based parser.

I'm going to add support for transitive schema dependencies, and this is the first step.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
