### PR TITLE
Allow schemas to have transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New:
 - Nothing yet!
 
 Changed:
-- Nothing yet!
+- Schema dependencies can now be a graph (i.e., dependencies can have their own dependencies), but the entire transitive set needs to be redeclared on the root schema (for the protocol to work properly).
 
 Fixed:
 - Don't double insets on insets-aware `UIViews`. Previously we offered the same insets via two mechanisms, which could result in double insets.

--- a/redwood-tooling-schema/build.gradle
+++ b/redwood-tooling-schema/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation libs.kotlin.compilerEmbeddable
   implementation libs.clikt
 
-  testImplementation projects.testApp.schema
+  testImplementation projects.redwoodBasicSchema
   testImplementation libs.junit
   testImplementation libs.assertk
   testImplementation libs.jimfs

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParser.kt
@@ -40,13 +40,25 @@ internal fun loadProtocolSchemaDependencies(
       val dependency = loadProtocolSchema(type, classLoader)
         .withTagOffset(tag * MAX_MEMBER_TAG)
 
-      require(dependency.dependencies.isEmpty()) {
-        "Schema dependency $type also has its own dependencies. " +
-          "For now, only a single level of dependencies is supported."
-      }
-
       type to dependency
     }
+
+  val missingTransitiveDependencies = buildMap {
+    val declaredDependencies = schema.dependencies.toSet()
+    for (dependency in dependencies.values) {
+      val missing = dependency.dependencies.filter { it !in declaredDependencies }
+      if (missing.isNotEmpty()) {
+        this[dependency.type] = missing
+      }
+    }
+  }
+  require(missingTransitiveDependencies.isEmpty()) {
+    "Dependencies contain transitive dependencies which need declared directly:\n\n" +
+      missingTransitiveDependencies.entries.joinToString("\n") { (type, missing) ->
+        "$type depends on:\n - " + missing.joinToString("\n - ")
+      }
+  }
+
   return ParsedProtocolSchemaSet(schema, dependencies)
 }
 

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -15,8 +15,10 @@
  */
 package app.cash.redwood.tooling.schema
 
+import app.cash.redwood.basic.RedwoodBasic
 import app.cash.redwood.layout.RedwoodLayout
 import app.cash.redwood.layout.Row
+import app.cash.redwood.lazylayout.RedwoodLazyLayout
 import app.cash.redwood.schema.Children
 import app.cash.redwood.schema.Modifier
 import app.cash.redwood.schema.Property
@@ -46,7 +48,6 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import assertk.assertions.message
 import assertk.assertions.prop
-import com.example.redwood.testapp.TestSchema
 import kotlin.DeprecationLevel.ERROR
 import kotlin.DeprecationLevel.HIDDEN
 import kotlinx.serialization.Serializable
@@ -1194,7 +1195,7 @@ class SchemaParserTest {
   @Schema(
     members = [],
     dependencies = [
-      Dependency(1, TestSchema::class),
+      Dependency(1, RedwoodBasic::class),
     ],
   )
   object SchemaDependencyHasDependency
@@ -1203,9 +1204,32 @@ class SchemaParserTest {
     assertFailure { parseTestSchema(SchemaDependencyHasDependency::class) }
       .isInstanceOf<IllegalArgumentException>()
       .hasMessage(
-        "Schema dependency com.example.redwood.testapp.TestSchema also has its own dependencies. " +
-          "For now, only a single level of dependencies is supported.",
+        """
+        |Dependencies contain transitive dependencies which need declared directly:
+        |
+        |app.cash.redwood.basic.RedwoodBasic depends on:
+        | - app.cash.redwood.layout.RedwoodLayout
+        | - app.cash.redwood.lazylayout.RedwoodLazyLayout
+        """.trimMargin(),
       )
+  }
+
+  @Schema(
+    members = [],
+    dependencies = [
+      Dependency(1, RedwoodBasic::class),
+      Dependency(2, RedwoodLayout::class),
+      Dependency(3, RedwoodLazyLayout::class),
+    ],
+  )
+  object SchemaDependencyHasDependencyButDeclared
+
+  @Test fun schemaDependencyHasDependencyButDeclared() {
+    val schemaSet = parseTestSchema(SchemaDependencyHasDependencyButDeclared::class)
+    assertThat(schemaSet).all {
+      prop(ProtocolSchemaSet::all).hasSize(4)
+      prop(ProtocolSchemaSet::dependencies).hasSize(3)
+    }
   }
 
   @Test fun schemaTypeMustBeInSource() {


### PR DESCRIPTION
They have to be redeclared, though (for protocol usage).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
