### PR TITLE
Don't conflate CrossAxisAlignment.Stretch with Contraint.Fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 
 Fixed:
 - Don't double insets on insets-aware `UIViews`. Previously we offered the same insets via two mechanisms, which could result in double insets.
+- Don't conflate `CrossAxisAlignment.Stretch` with `Contraint.Fill`. We had a bug where `CrossAxisAlignment.Stretch` would cause children to fill their parent container.
 
 
 ## [0.17.0] - 2025-01-30

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_RTL_testStretchDoesNotImpactMeasurement.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_RTL_testStretchDoesNotImpactMeasurement.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:052b9f7cdf8c68c95e860d6d02ab68c6c440cffb909a361f70b47725efe44689
+size 6563

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testStretchDoesNotImpactMeasurement.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testStretchDoesNotImpactMeasurement.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebe757d3e08053eba734ad23dc8b0658c064eb9afa8523d001ecd129394eeeab
+size 6443

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
@@ -26,6 +26,7 @@ import app.cash.redwood.snapshot.testing.Green
 import app.cash.redwood.snapshot.testing.Red
 import app.cash.redwood.snapshot.testing.Snapshotter
 import app.cash.redwood.snapshot.testing.TestWidgetFactory
+import app.cash.redwood.snapshot.testing.argb
 import app.cash.redwood.snapshot.testing.color
 import app.cash.redwood.snapshot.testing.text
 import app.cash.redwood.ui.Margin
@@ -449,6 +450,46 @@ abstract class AbstractBoxTest<T : Any> {
     widgetFactory.text(
       text = "foreground",
     ).also { box.children.insert(1, it) }
+
+    snapshotter.snapshot()
+  }
+
+  /** We had a bug where stretch alignment impacted measurement. It shouldn't. */
+  @Test
+  fun testStretchDoesNotImpactMeasurement() {
+    val container = box()
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Fill)
+        horizontalAlignment(CrossAxisAlignment.Start)
+        verticalAlignment(CrossAxisAlignment.Start)
+      }
+    val snapshotter = snapshotter(container.value)
+
+    val box = box()
+      .apply {
+        width(Constraint.Wrap)
+        height(Constraint.Wrap)
+        horizontalAlignment(CrossAxisAlignment.Stretch)
+        verticalAlignment(CrossAxisAlignment.Stretch)
+        modifier = MarginImpl(Margin(all = 5.dp))
+      }
+      .also { container.children.insert(0, it) }
+
+    widgetFactory.text(
+      text = "This text is in a green box",
+      backgroundColor = argb(0, 0, 0, 0),
+    ).apply {
+      modifier = MarginImpl(Margin(all = 20.dp))
+    }.also { box.children.insert(0, it) }
+
+    widgetFactory.color().apply {
+      color(argb(51, 0, 255, 0))
+      modifier = Modifier
+        .then(VerticalAlignmentImpl(CrossAxisAlignment.Stretch))
+        .then(HorizontalAlignmentImpl(CrossAxisAlignment.Stretch))
+        .then(MarginImpl(Margin(all = 5.dp)))
+    }.also { box.children.insert(1, it) }
 
     snapshotter.snapshot()
   }

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testStretchDoesNotImpactMeasurement.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testStretchDoesNotImpactMeasurement.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e739b759d7e448dd9d1f2e0a2daac3ab4ffcc407fdca46ae53b17467b684f51
-size 76745
+oid sha256:a149299e277019cfcce869bfdd02ee8580f3f4416986b549bbe1ce3ba3fabf94
+size 76674

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testStretchDoesNotImpactMeasurement.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testStretchDoesNotImpactMeasurement.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e739b759d7e448dd9d1f2e0a2daac3ab4ffcc407fdca46ae53b17467b684f51
+size 76745

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -125,6 +125,7 @@ internal class UIViewBox :
       super.layoutSubviews()
 
       measurer.box(
+        measureForLayout = true,
         boxDensity = Density.Default,
         boxHorizontalAlignment = horizontalAlignment,
         boxVerticalAlignment = verticalAlignment,
@@ -141,6 +142,7 @@ internal class UIViewBox :
 
     override fun sizeThatFits(size: CValue<CGSize>): CValue<CGSize> {
       measurer.box(
+        measureForLayout = false,
         boxDensity = Density.Default,
         boxHorizontalAlignment = horizontalAlignment,
         boxVerticalAlignment = verticalAlignment,
@@ -172,6 +174,7 @@ internal class UIViewBox :
  */
 private class Measurer {
   // Inputs from the box.
+  var measureForLayout = false
   var boxDensity = Density.Default
   var boxHorizontalAlignment = CrossAxisAlignment.Start
   var boxVerticalAlignment = CrossAxisAlignment.Start
@@ -205,6 +208,7 @@ private class Measurer {
 
   /** Configure the enclosing box. */
   fun box(
+    measureForLayout: Boolean,
     boxDensity: Density,
     boxHorizontalAlignment: CrossAxisAlignment,
     boxVerticalAlignment: CrossAxisAlignment,
@@ -212,6 +216,7 @@ private class Measurer {
     boxWidth: CGFloat,
     boxHeight: CGFloat,
   ) {
+    this.measureForLayout = measureForLayout
     this.boxDensity = boxDensity
     this.boxHorizontalAlignment = boxHorizontalAlignment
     this.boxVerticalAlignment = boxVerticalAlignment
@@ -275,22 +280,23 @@ private class Measurer {
       else -> (frameHeight - marginHeight).coerceAtLeast(0.0)
     }
 
+    val horizontalStretch = measureForLayout && horizontalAlignment == CrossAxisAlignment.Stretch
+    val verticalStretch = measureForLayout && verticalAlignment == CrossAxisAlignment.Stretch
+
     val fitWidth = when {
       !requestedWidth.isNaN() -> requestedWidth
-      horizontalAlignment == CrossAxisAlignment.Stretch -> availableWidth
+      horizontalStretch -> availableWidth
       else -> availableWidth
     }
     val fitHeight = when {
       !requestedHeight.isNaN() -> requestedHeight
-      verticalAlignment == CrossAxisAlignment.Stretch -> availableHeight
+      verticalStretch -> availableHeight
       else -> availableHeight
     }
 
     // Measure the view if don't have an exact width or height.
-    val mustMeasureWidth = requestedWidth.isNaN() &&
-      horizontalAlignment != CrossAxisAlignment.Stretch
-    val mustMeasureHeight = requestedHeight.isNaN() &&
-      verticalAlignment != CrossAxisAlignment.Stretch
+    val mustMeasureWidth = requestedWidth.isNaN() && !horizontalStretch
+    val mustMeasureHeight = requestedHeight.isNaN() && !verticalStretch
 
     if (!mustMeasureWidth && !mustMeasureHeight) {
       this.width = fitWidth
@@ -303,13 +309,13 @@ private class Measurer {
 
     width = when {
       !requestedWidth.isNaN() -> requestedWidth
-      horizontalAlignment == CrossAxisAlignment.Stretch -> availableWidth
+      horizontalStretch -> availableWidth
       else -> measuredSize.useContents { width }
     }
 
     height = when {
       !requestedHeight.isNaN() -> requestedHeight
-      verticalAlignment == CrossAxisAlignment.Stretch -> availableHeight
+      verticalStretch -> availableHeight
       else -> measuredSize.useContents { height }
     }
   }

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewBox.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewBox.kt
@@ -103,6 +103,7 @@ private class BoxViewGroup(
     }
 
     measurer.box(
+      measureForLayout = false,
       layoutDirection = layoutDirection,
       boxDensity = density,
       boxHorizontalAlignment = horizontalAlignment,
@@ -141,6 +142,7 @@ private class BoxViewGroup(
 
   override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
     measurer.box(
+      measureForLayout = true,
       layoutDirection = layoutDirection,
       boxDensity = density,
       boxHorizontalAlignment = horizontalAlignment,
@@ -164,6 +166,7 @@ private class BoxViewGroup(
  */
 private class Measurer {
   // Inputs from the box.
+  var measureForLayout = false
   var layoutDirection = LAYOUT_DIRECTION_LTR
   var boxDensity = Density(1.0)
   var boxHorizontalAlignment = CrossAxisAlignment.Start
@@ -200,6 +203,7 @@ private class Measurer {
 
   /** Configure the enclosing box. */
   fun box(
+    measureForLayout: Boolean,
     layoutDirection: Int,
     boxDensity: Density,
     boxHorizontalAlignment: CrossAxisAlignment,
@@ -210,6 +214,7 @@ private class Measurer {
     boxHeight: Int,
     boxHeightUnspecified: Boolean = false,
   ) {
+    this.measureForLayout = measureForLayout
     this.layoutDirection = layoutDirection
     this.boxDensity = boxDensity
     this.boxHorizontalAlignment = boxHorizontalAlignment
@@ -262,18 +267,19 @@ private class Measurer {
     val availableWidth = (frameWidth - marginWidth).coerceAtLeast(0)
     val availableHeight = (frameHeight - marginHeight).coerceAtLeast(0)
 
+    val verticalStretch = measureForLayout && verticalAlignment == CrossAxisAlignment.Stretch
+    val horizontalStretch = measureForLayout && horizontalAlignment == CrossAxisAlignment.Stretch
+
     val widthMeasureSpec = when {
       requestedWidth != -1 -> makeMeasureSpec(requestedWidth, MeasureSpec.EXACTLY)
-      horizontalAlignment == CrossAxisAlignment.Stretch ->
-        makeMeasureSpec(availableWidth, MeasureSpec.EXACTLY)
+      horizontalStretch -> makeMeasureSpec(availableWidth, MeasureSpec.EXACTLY)
       boxWidthUnspecified -> makeMeasureSpec(availableWidth, MeasureSpec.UNSPECIFIED)
       else -> makeMeasureSpec(availableWidth, MeasureSpec.AT_MOST)
     }
 
     val heightMeasureSpec = when {
       requestedHeight != -1 -> makeMeasureSpec(requestedHeight, MeasureSpec.EXACTLY)
-      verticalAlignment == CrossAxisAlignment.Stretch ->
-        makeMeasureSpec(availableHeight, MeasureSpec.EXACTLY)
+      verticalStretch -> makeMeasureSpec(availableHeight, MeasureSpec.EXACTLY)
       boxHeightUnspecified -> makeMeasureSpec(availableHeight, MeasureSpec.UNSPECIFIED)
       else -> makeMeasureSpec(availableHeight, MeasureSpec.AT_MOST)
     }
@@ -282,13 +288,13 @@ private class Measurer {
 
     width = when {
       requestedWidth != -1 -> requestedWidth
-      horizontalAlignment == CrossAxisAlignment.Stretch -> availableWidth
+      horizontalStretch -> availableWidth
       else -> widget.value.measuredWidth
     }
 
     height = when {
       requestedHeight != -1 -> requestedHeight
-      verticalAlignment == CrossAxisAlignment.Stretch -> availableHeight
+      verticalStretch -> availableHeight
       else -> widget.value.measuredHeight
     }
   }

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_RTL_testStretchDoesNotImpactMeasurement.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_RTL_testStretchDoesNotImpactMeasurement.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b20632358faa27adb69c73c23e9aaa758e83fd7efcb0dd278497adeda1f0294
+size 6618

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testStretchDoesNotImpactMeasurement.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testStretchDoesNotImpactMeasurement.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db9b7febadafab5d893097c12b427e2857f636463849c43580b3c52fa380e5c9
+size 6605


### PR DESCRIPTION
We had a severe bug where CrossAxisAlignment.Stretch would always fill its parent container. This is because during the layout phase we need to fill the available dimensions. But in the measurement phase we don't need to consider the alignment at all.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
