### PR TITLE
Fix nested flex container with a wrapping child on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changed:
 Fixed:
 - Don't double insets on insets-aware `UIViews`. Previously we offered the same insets via two mechanisms, which could result in double insets.
 - Don't conflate `CrossAxisAlignment.Stretch` with `Contraint.Fill`. We had a bug where `CrossAxisAlignment.Stretch` would cause children to fill their parent container.
+- Honor the inbound max width for `Row` and `Column` layouts using `Constraint.Wrap` on iOS. This is necessary for child components that can wrap, like text.
 
 
 ## [0.17.0] - 2025-01-30

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -879,6 +879,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     }
 
     val rootChild0 = row().apply {
+      modifier = FlexImpl(1.0)
       width(Constraint.Fill)
       horizontalAlignment(MainAxisAlignment.Center)
       root.children.insert(0, this)

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testFlexWithChildContainingWrappingChild.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testFlexWithChildContainingWrappingChild.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78628333b54bc57b8f81135ec6e6132e94553cb4143c970806e2484a64f0b796
-size 70622
+oid sha256:369fd83c5a5465e01aa9c0c08fe5bcdf64d9ed6dafbaf62307a91e975c982476
+size 77047

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:935125d0e6af227eedf349e9b908618ebfd5bd1f35893e383e69bba1ed548e29
-size 65804
+oid sha256:465d0586d311bcd7569f2340c809c161dc1be6d4312e44d61c448d5c0f0bc5f6
+size 71441

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/YogaUIView.kt
@@ -94,7 +94,9 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
   override fun intrinsicContentSize(): CValue<CGSize> {
     return calculateLayout(
       width = fillWidth.toYogaWithWidthConstraint(),
+      maxWidth = fillWidth.toYoga(),
       height = fillHeight.toYogaWithWidthConstraint(),
+      maxHeight = fillHeight.toYoga(),
     )
   }
 
@@ -102,7 +104,9 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
     return size.useContents<CGSize, CValue<CGSize>> {
       calculateLayout(
         width = width.toYogaWithWidthConstraint(),
+        maxWidth = width.toYoga(),
         height = height.toYogaWithHeightConstraint(),
+        maxHeight = height.toYoga(),
       )
     }
   }
@@ -156,10 +160,14 @@ internal class YogaUIView : UIScrollView(cValue { CGRectZero }), UIScrollViewDel
 
   private fun calculateLayout(
     width: Float = Size.UNDEFINED,
+    maxWidth: Float = Size.UNDEFINED,
     height: Float = Size.UNDEFINED,
+    maxHeight: Float = Size.UNDEFINED,
   ): CValue<CGSize> {
     rootNode.requestedWidth = width
+    rootNode.requestedMaxWidth = maxWidth
     rootNode.requestedHeight = height
+    rootNode.requestedMaxHeight = maxHeight
 
     rootNode.measureOnly(Size.UNDEFINED, Size.UNDEFINED)
 

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aeff5cb1d11342d549ee6418a60809736bc4b321d573f55a67469bbb064d7e1c
-size 3909
+oid sha256:03e4f17258edf3726c6ea7b0db2199f6ecfd34711a1dfbbaba179e0f54a2447d
+size 3918

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aeff5cb1d11342d549ee6418a60809736bc4b321d573f55a67469bbb064d7e1c
-size 3909
+oid sha256:03e4f17258edf3726c6ea7b0db2199f6ecfd34711a1dfbbaba179e0f54a2447d
+size 3918

--- a/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
+++ b/redwood-lazylayout-uiview/src/commonMain/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyList.kt
@@ -43,6 +43,7 @@ import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
+import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.NSIndexPath
 import platform.Foundation.classForCoder
 import platform.UIKit.UIColor
@@ -62,6 +63,7 @@ import platform.UIKit.UITableViewRowAnimationNone
 import platform.UIKit.UITableViewScrollPosition
 import platform.UIKit.UITableViewStyle
 import platform.UIKit.UIView
+import platform.UIKit.UIViewNoIntrinsicMetric
 import platform.UIKit.indexPathForItem
 import platform.UIKit.item
 import platform.darwin.NSInteger
@@ -402,7 +404,8 @@ internal class LazyListContainerCell(
 
   override fun sizeThatFits(size: CValue<CGSize>): CValue<CGSize> {
     val content = this.content ?: return super.sizeThatFits(size)
-    return content.value.sizeThatFits(size)
+    val sizeNoHeight = size.useContents { CGSizeMake(width, UIViewNoIntrinsicMetric) }
+    return content.value.sizeThatFits(sizeNoHeight)
   }
 
   internal fun setContent(widget: Widget<UIView>?) {


### PR DESCRIPTION
We weren't propagating the max size with Constraint.Wrap.

Unfortunately this was a load-bearing bug for UIViewLazyList, which assumed that a hardcoded max of 0 would be ignored. Now a more appropriate UIViewNoIntrinsicMetric is used.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
