### PR TITLE
Honor 'stretch' cross-axis alignment for Compose UI lazy list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Fixed:
 - Don't double insets on insets-aware `UIViews`. Previously we offered the same insets via two mechanisms, which could result in double insets.
 - Don't conflate `CrossAxisAlignment.Stretch` with `Contraint.Fill`. We had a bug where `CrossAxisAlignment.Stretch` would cause children to fill their parent container.
 - Honor the inbound max width for `Row` and `Column` layouts using `Constraint.Wrap` on iOS. This is necessary for child components that can wrap, like text.
+- Using "stretch" cross-axis alignment on a lazy list now works correctly in Compose UI.
 
 
 ## [0.17.0] - 2025-01-30

--- a/redwood-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/lazylayout/composeui/ComposeUiLazyList.kt
+++ b/redwood-lazylayout-composeui/src/commonMain/kotlin/app/cash/redwood/lazylayout/composeui/ComposeUiLazyList.kt
@@ -124,8 +124,14 @@ internal class ComposeUiLazyList : LazyList<@Composable (Modifier) -> Unit> {
   override val value: @Composable (Modifier) -> Unit = { modifier ->
     val content: LazyListScope.() -> Unit = {
       items(items.widgets) { item ->
-        // TODO If CrossAxisAlignment is Stretch, pass Modifier.fillParentMaxWidth() to child widget.
-        item.value.invoke(Modifier)
+        val modifier = if (crossAxisAlignment != CrossAxisAlignment.Stretch) {
+          Modifier
+        } else if (isVertical) {
+          Modifier.fillMaxWidth()
+        } else {
+          Modifier.fillMaxHeight()
+        }
+        item.value.invoke(modifier)
       }
     }
     Box(modifier) {

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6736ae8bb46937be3c189a7e223114aa4c263fa72bb576bc1a052fff55172b9f
-size 4554
+oid sha256:42b3b4cbbdc49e1ae57480170ae7123211a7c3382124464904493c72f310e88e
+size 4027

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testLayoutHandlesChildResizes_v2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c479419f809c174d347ae5c655fb32180f7b5960f48cbde9e8bcd3a54cb5d4f
-size 4526
+oid sha256:26eb384f334000d653501344cf7ecad9766e7c2046d8313e3d98f63aff672072
+size 3992

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v1.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:511453ec5fdefd584856ef97bd17ed9f470dbc9dc9c8e6f957598966823a5dbb
-size 4497
+oid sha256:42b3b4cbbdc49e1ae57480170ae7123211a7c3382124464904493c72f310e88e
+size 4027

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v2.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testLayoutHandlesChildResizes_v2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:097606fafb740546d54780a4d87c12df1dfc2e3b6e280c1d82eee87b2a7621b8
-size 4479
+oid sha256:26eb384f334000d653501344cf7ecad9766e7c2046d8313e3d98f63aff672072
+size 3992


### PR DESCRIPTION
Closes #1283. Reland of stacked #2613 to `trunk`.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
