### PR TITLE
Initialize host protocol once with Zipline instance

### DIFF
--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -24,13 +24,8 @@ public abstract interface class app/cash/redwood/protocol/host/ProtocolMismatchH
 public final class app/cash/redwood/protocol/host/ProtocolMismatchHandler$Companion {
 }
 
-public final class app/cash/redwood/protocol/host/UiEvent {
-	public synthetic fun <init> (II[Ljava/lang/Object;[Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getArgs ()[Ljava/lang/Object;
-	public final fun getId-0HhLjSo ()I
-	public final fun getSerializationStrategies ()[Lkotlinx/serialization/SerializationStrategy;
-	public final fun getTag-RNF89mI ()I
-	public final fun toProtocol (Lkotlinx/serialization/json/Json;)Lapp/cash/redwood/protocol/Event;
+public abstract interface class app/cash/redwood/protocol/host/UiEvent {
+	public abstract fun toProtocol ()Lapp/cash/redwood/protocol/Event;
 }
 
 public abstract interface class app/cash/redwood/protocol/host/UiEventSink {

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -22,6 +22,10 @@ abstract interface app.cash.redwood.protocol.host/ProtocolMismatchHandler { // a
     }
 }
 
+abstract interface app.cash.redwood.protocol.host/UiEvent { // app.cash.redwood.protocol.host/UiEvent|null[0]
+    abstract fun toProtocol(): app.cash.redwood.protocol/Event // app.cash.redwood.protocol.host/UiEvent.toProtocol|toProtocol(){}[0]
+}
+
 sealed interface app.cash.redwood.protocol.host/HostProtocol { // app.cash.redwood.protocol.host/HostProtocol|null[0]
     abstract interface Factory { // app.cash.redwood.protocol.host/HostProtocol.Factory|null[0]
         abstract fun create(kotlinx.serialization.json/Json = ..., app.cash.redwood.protocol.host/ProtocolMismatchHandler = ...): app.cash.redwood.protocol.host/HostProtocol // app.cash.redwood.protocol.host/HostProtocol.Factory.create|create(kotlinx.serialization.json.Json;app.cash.redwood.protocol.host.ProtocolMismatchHandler){}[0]
@@ -33,21 +37,6 @@ final class <#A: kotlin/Any> app.cash.redwood.protocol.host/HostProtocolAdapter 
 
     final fun close() // app.cash.redwood.protocol.host/HostProtocolAdapter.close|close(){}[0]
     final fun sendChanges(kotlin.collections/List<app.cash.redwood.protocol/Change>) // app.cash.redwood.protocol.host/HostProtocolAdapter.sendChanges|sendChanges(kotlin.collections.List<app.cash.redwood.protocol.Change>){}[0]
-}
-
-final class app.cash.redwood.protocol.host/UiEvent { // app.cash.redwood.protocol.host/UiEvent|null[0]
-    constructor <init>(app.cash.redwood.protocol/Id, app.cash.redwood.protocol/EventTag, kotlin/Array<kotlin/Any?>?, kotlin/Array<out kotlinx.serialization/SerializationStrategy<kotlin/Any?>>?) // app.cash.redwood.protocol.host/UiEvent.<init>|<init>(app.cash.redwood.protocol.Id;app.cash.redwood.protocol.EventTag;kotlin.Array<kotlin.Any?>?;kotlin.Array<out|kotlinx.serialization.SerializationStrategy<kotlin.Any?>>?){}[0]
-
-    final val args // app.cash.redwood.protocol.host/UiEvent.args|{}args[0]
-        final fun <get-args>(): kotlin/Array<kotlin/Any?>? // app.cash.redwood.protocol.host/UiEvent.args.<get-args>|<get-args>(){}[0]
-    final val id // app.cash.redwood.protocol.host/UiEvent.id|{}id[0]
-        final fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.host/UiEvent.id.<get-id>|<get-id>(){}[0]
-    final val serializationStrategies // app.cash.redwood.protocol.host/UiEvent.serializationStrategies|{}serializationStrategies[0]
-        final fun <get-serializationStrategies>(): kotlin/Array<out kotlinx.serialization/SerializationStrategy<kotlin/Any?>>? // app.cash.redwood.protocol.host/UiEvent.serializationStrategies.<get-serializationStrategies>|<get-serializationStrategies>(){}[0]
-    final val tag // app.cash.redwood.protocol.host/UiEvent.tag|{}tag[0]
-        final fun <get-tag>(): app.cash.redwood.protocol/EventTag // app.cash.redwood.protocol.host/UiEvent.tag.<get-tag>|<get-tag>(){}[0]
-
-    final fun toProtocol(kotlinx.serialization.json/Json): app.cash.redwood.protocol/Event // app.cash.redwood.protocol.host/UiEvent.toProtocol|toProtocol(kotlinx.serialization.json.Json){}[0]
 }
 
 final val app.cash.redwood.protocol.host/hostRedwoodVersion // app.cash.redwood.protocol.host/hostRedwoodVersion|{}hostRedwoodVersion[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/UiEvent.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/UiEvent.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.protocol.host
 
+import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.Event
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.EventTag
@@ -26,20 +27,33 @@ import kotlinx.serialization.json.Json
  * A version of [Event] whose arguments have not yet been serialized to JSON and is thus
  * cheap to create on the UI thread.
  */
-public class UiEvent(
-  public val id: Id,
-  public val tag: EventTag,
-  public val args: Array<Any?>?,
-  public val serializationStrategies: Array<out SerializationStrategy<Any?>>?,
-) {
-  /** Serialize [args] into a JSON model using [serializationStrategies] into an [Event]. */
-  public fun toProtocol(json: Json): Event {
+public interface UiEvent {
+  /** Serialize this UI event into its protocol representation. */
+  public fun toProtocol(): Event
+}
+
+/** A version of [EventSink] which consumes [UiEvent]s. */
+public fun interface UiEventSink {
+  public fun sendEvent(uiEvent: UiEvent)
+}
+
+/** @suppress For generated code use only. */
+@RedwoodCodegenApi
+public class GeneratedUiEvent(
+  private val id: Id,
+  private val tag: EventTag,
+  private val json: Json?,
+  private val args: Array<Any?>?,
+  private val serializationStrategies: Array<out SerializationStrategy<Any?>>?,
+) : UiEvent {
+  override fun toProtocol(): Event {
     return Event(
       id = id,
       tag = tag,
       args = if (args == null) {
         emptyList()
       } else {
+        val json = json!!
         val serializationStrategies = serializationStrategies!!
         List(args.size) { i ->
           json.encodeToJsonElement(serializationStrategies[i], args[i])
@@ -47,9 +61,4 @@ public class UiEvent(
       },
     )
   }
-}
-
-/** A version of [EventSink] which consumes [UiEvent]s. */
-public fun interface UiEventSink {
-  public fun sendEvent(uiEvent: UiEvent)
 }

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolTest.kt
@@ -291,7 +291,7 @@ class HostProtocolTest {
 
     (textInput.widget.value as TextInputValue).onChangeCustomType!!.invoke(10.seconds)
 
-    assertThat(eventSink.events.single().toProtocol(json))
+    assertThat(eventSink.events.single().toProtocol())
       .isEqualTo(Event(Id(1), EventTag(4), listOf(JsonPrimitive("PT10S"))))
   }
 }

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewRecyclingTester.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewRecyclingTester.kt
@@ -41,7 +41,6 @@ import com.example.redwood.testapp.testing.TestSchemaTestingWidgetFactory
 import com.example.redwood.testapp.widget.TestSchemaWidgetSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
-import kotlinx.serialization.json.Json
 
 /**
  * Like [TestSchemaTester], but this also hooks up Redwood's protocol mechanism. That's necessary
@@ -63,7 +62,7 @@ class ViewRecyclingTester(
       RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     ),
     eventSink = { event ->
-      guestAdapter.sendEvent(event.toProtocol(Json.Default))
+      guestAdapter.sendEvent(event.toProtocol())
     },
     leakDetector = LeakDetector.none(),
   )

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -593,9 +593,10 @@ private class OnClick(
 ) : (Int, String) -> Unit {
   override fun invoke(arg0: Int, arg1: String) {
     eventSink.sendEvent(
-      UiEvent(
+      GeneratedUiEvent(
         id,
         EventTag(3),
+        protocol.json,
         arrayOf(
           arg0,
           arg1,
@@ -651,15 +652,15 @@ private fun generateEventHandler(
 
   if (serializers.isEmpty()) {
     invoke.addCode(
-      "eventSink.sendEvent(%T(id, %T(%L), null, null))",
-      ProtocolHost.UiEvent,
+      "eventSink.sendEvent(%T(id, %T(%L), null, null, null))",
+      ProtocolHost.GeneratedUiEvent,
       Protocol.EventTag,
       trait.tag,
     )
   } else {
     invoke.addCode(
-      "eventSink.sendEvent(⇥\n%T(⇥\nid,\n%T(%L),\narrayOf(⇥\n%L,\n⇤),\narrayOf(⇥\n%L,\n⇤),\n⇤),\n⇤)",
-      ProtocolHost.UiEvent,
+      "eventSink.sendEvent(⇥\n%T(⇥\nid,\n%T(%L),\nprotocol.json,\narrayOf(⇥\n%L,\n⇤),\narrayOf(⇥\n%L,\n⇤),\n⇤),\n⇤)",
+      ProtocolHost.GeneratedUiEvent,
       Protocol.EventTag,
       trait.tag,
       arguments.joinToCode(separator = ",\n"),

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -49,6 +49,8 @@ internal object ProtocolGuest {
 }
 
 internal object ProtocolHost {
+  val GeneratedHostProtocol = ClassName("app.cash.redwood.protocol.host", "GeneratedHostProtocol")
+  val GeneratedUiEvent = ClassName("app.cash.redwood.protocol.host", "GeneratedUiEvent")
   val HostProtocol = ClassName("app.cash.redwood.protocol.host", "HostProtocol")
   val HostProtocolFactory = HostProtocol.nestedClass("Factory")
   val IdVisitor = ClassName("app.cash.redwood.protocol.host", "IdVisitor")
@@ -56,8 +58,6 @@ internal object ProtocolHost {
     ClassName("app.cash.redwood.protocol.host", "ProtocolMismatchHandler")
   val ProtocolNode = ClassName("app.cash.redwood.protocol.host", "ProtocolNode")
   val ProtocolChildren = ClassName("app.cash.redwood.protocol.host", "ProtocolChildren")
-  val GeneratedHostProtocol = ClassName("app.cash.redwood.protocol.host", "GeneratedHostProtocol")
-  val UiEvent = ClassName("app.cash.redwood.protocol.host", "UiEvent")
   val UiEventSink = ClassName("app.cash.redwood.protocol.host", "UiEventSink")
   val WidgetHostProtocol = ClassName("app.cash.redwood.protocol.host", "WidgetHostProtocol")
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.protocol.RedwoodVersion
+import app.cash.redwood.protocol.host.HostProtocol
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -25,7 +26,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 
 /** The host state for a single code load. We get a new session each time we get new code. */
 internal abstract class CodeSession<A : AppService>(
@@ -54,7 +54,7 @@ internal abstract class CodeSession<A : AppService>(
     )
   }
 
-  abstract val json: Json
+  abstract val hostProtocol: HostProtocol
 
   abstract val guestProtocolVersion: RedwoodVersion
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -85,7 +85,6 @@ internal class RealTreehouseApp<A : AppService> private constructor(
       dispatchers = dispatchers,
       source = source,
       leakDetector = leakDetector,
-      hostProtocolFactory = hostProtocolFactory,
     )
   }
 
@@ -156,6 +155,11 @@ internal class RealTreehouseApp<A : AppService> private constructor(
     val eventListener = zipline.eventListener as RealEventPublisher.ZiplineEventListener
     val eventPublisher = eventListener.eventPublisher
 
+    val hostProtocol = hostProtocolFactory.create(
+      json = zipline.json,
+      mismatchHandler = eventPublisher.widgetProtocolMismatchHandler,
+    )
+
     return ZiplineCodeSession(
       dispatchers = dispatchers,
       eventPublisher = eventPublisher,
@@ -164,6 +168,7 @@ internal class RealTreehouseApp<A : AppService> private constructor(
       zipline = zipline,
       appScope = appScope,
       leakDetector = leakDetector,
+      hostProtocol = hostProtocol,
     )
   }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -18,7 +18,6 @@ package app.cash.redwood.treehouse
 import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.EventSink
-import app.cash.redwood.protocol.host.HostProtocol
 import app.cash.redwood.protocol.host.HostProtocolAdapter
 import app.cash.redwood.protocol.host.UiEvent
 import app.cash.redwood.protocol.host.UiEventSink
@@ -38,7 +37,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.serialization.json.Json
 
 private class InternalState<A : AppService>(
   val viewState: ViewState,
@@ -92,7 +90,6 @@ internal class TreehouseAppContent<A : AppService>(
   private val dispatchers: TreehouseDispatchers,
   private val source: TreehouseContentSource<A>,
   private val leakDetector: LeakDetector,
-  private val hostProtocolFactory: HostProtocol.Factory,
 ) : Content,
   CodeHost.Listener<A>,
   CodeSession.Listener<A> {
@@ -301,7 +298,6 @@ internal class TreehouseAppContent<A : AppService>(
     return ViewContentCodeBinding(
       codeHost = codeHost,
       dispatchers = dispatchers,
-      eventPublisher = codeSession.eventPublisher,
       contentSource = source,
       internalStateFlow = internalStateFlow,
       externalStateFlow = externalStateFlow,
@@ -309,7 +305,6 @@ internal class TreehouseAppContent<A : AppService>(
       onBackPressedDispatcher = onBackPressedDispatcher,
       firstUiConfiguration = firstUiConfiguration,
       leakDetector = leakDetector,
-      hostProtocolFactory = hostProtocolFactory,
     ).apply {
       start()
     }
@@ -331,12 +326,10 @@ internal class TreehouseAppContent<A : AppService>(
 private class ViewContentCodeBinding<A : AppService>(
   codeHost: CodeHost<A>,
   val dispatchers: TreehouseDispatchers,
-  val eventPublisher: EventPublisher,
   contentSource: TreehouseContentSource<A>,
   val internalStateFlow: MutableStateFlow<InternalState<A>>,
   val externalStateFlow: MutableStateFlow<State>,
   val codeSession: CodeSession<A>,
-  val hostProtocolFactory: HostProtocol.Factory,
   private val onBackPressedDispatcher: OnBackPressedDispatcher,
   firstUiConfiguration: StateFlow<UiConfiguration>,
   private val leakDetector: LeakDetector,
@@ -374,7 +367,7 @@ private class ViewContentCodeBinding<A : AppService>(
   private var treehouseUiOrNull: ZiplineTreehouseUi? = null
 
   /** Note that this is necessary to break the retain cycle between host and guest. */
-  private val eventBridge = EventBridge(codeSession.json, dispatchers.zipline, bindingScope)
+  private val eventBridge = EventBridge(dispatchers.zipline, bindingScope)
 
   /** Only accessed on [TreehouseDispatchers.ui]. Empty after [initView]. */
   private val changesAwaitingInitView = ArrayDeque<List<Change>>()
@@ -458,14 +451,10 @@ private class ViewContentCodeBinding<A : AppService>(
   }
 
   private fun <W : Any> createHostProtocolAdapter(view: TreehouseView<W>): HostProtocolAdapter<W> {
-    val hostProtocol = hostProtocolFactory.create(
-      json = codeSession.json,
-      mismatchHandler = eventPublisher.widgetProtocolMismatchHandler,
-    )
     return HostProtocolAdapter(
       guestVersion = codeSession.guestProtocolVersion,
       container = view.children,
-      protocol = hostProtocol,
+      protocol = codeSession.hostProtocol,
       widgetSystem = view.widgetSystem,
       eventSink = eventBridge,
       leakDetector = leakDetector,
@@ -607,7 +596,6 @@ private fun <W : Any> TreehouseView<W>.showCrashed(
  * problems when mixing garbage-collected Kotlin objects with reference-counted Swift objects.
  */
 private class EventBridge(
-  private val json: Json,
   // Both properties are only accessed on the UI dispatcher and null after cancel().
   var ziplineDispatcher: CoroutineDispatcher?,
   var bindingScope: CoroutineScope?,
@@ -622,7 +610,7 @@ private class EventBridge(
     val bindingScope = this.bindingScope ?: return
     bindingScope.launch(dispatcher) {
       // Perform initial serialization of event arguments into JSON model after the thread hop.
-      val event = uiEvent.toProtocol(json)
+      val event = uiEvent.toProtocol()
 
       delegate?.sendEvent(event)
     }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ZiplineCodeSession.kt
@@ -17,13 +17,13 @@ package app.cash.redwood.treehouse
 
 import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.RedwoodVersion
+import app.cash.redwood.protocol.host.HostProtocol
 import app.cash.zipline.Zipline
 import app.cash.zipline.ZiplineApiMismatchException
 import app.cash.zipline.ZiplineScope
 import app.cash.zipline.withScope
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.serialization.json.Json
 
 internal class ZiplineCodeSession<A : AppService>(
   dispatchers: TreehouseDispatchers,
@@ -33,6 +33,7 @@ internal class ZiplineCodeSession<A : AppService>(
   private val frameClockFactory: FrameClock.Factory,
   val zipline: Zipline,
   private val leakDetector: LeakDetector,
+  override val hostProtocol: HostProtocol,
 ) : CodeSession<A>(
   dispatchers = dispatchers,
   eventPublisher = eventPublisher,
@@ -40,9 +41,6 @@ internal class ZiplineCodeSession<A : AppService>(
   appService = appService,
 ) {
   private val ziplineScope = ZiplineScope()
-
-  override val json: Json
-    get() = zipline.json
 
   @Volatile
   private var _guestProtocolVersion: RedwoodVersion? = null

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/CodeHostTest.kt
@@ -16,7 +16,6 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.leaks.LeakDetector
-import com.example.redwood.testapp.protocol.host.TestSchemaHostProtocol
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -299,7 +298,6 @@ class CodeHostTest {
       dispatchers = dispatchers,
       source = { app -> app.newUi() },
       leakDetector = LeakDetector.none(),
-      hostProtocolFactory = TestSchemaHostProtocol,
     )
   }
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeCodeSession.kt
@@ -16,9 +16,10 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.protocol.RedwoodVersion
+import app.cash.redwood.protocol.host.HostProtocol
 import app.cash.redwood.protocol.host.hostRedwoodVersion
+import com.example.redwood.testapp.protocol.host.TestSchemaHostProtocol
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.serialization.json.Json
 
 internal class FakeCodeSession(
   dispatchers: TreehouseDispatchers,
@@ -32,8 +33,7 @@ internal class FakeCodeSession(
   appScope = appScope,
   appService = FakeAppService("$name.app", eventLog),
 ) {
-  override val json: Json
-    get() = Json
+  override val hostProtocol: HostProtocol = TestSchemaHostProtocol.create()
 
   override val guestProtocolVersion: RedwoodVersion
     // Use latest host version as the guest version to avoid any compatibility behavior.

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/TreehouseAppContentTest.kt
@@ -22,7 +22,6 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEmpty
-import com.example.redwood.testapp.protocol.host.TestSchemaHostProtocol
 import com.example.redwood.testapp.testing.ButtonValue
 import com.example.redwood.testapp.widget.Button
 import kotlin.coroutines.EmptyCoroutineContext
@@ -540,7 +539,6 @@ class TreehouseAppContentTest {
       dispatchers = dispatchers,
       source = { app -> app.newUi() },
       leakDetector = LeakDetector.none(),
-      hostProtocolFactory = TestSchemaHostProtocol,
     )
   }
 


### PR DESCRIPTION
This moves the serializer lookups and initialization to occur on the zipline thread, as well.

This also makes the protocol the sole source of the Json object for UI events (and the forthcoming UI changes).

Towards #2145 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
