### PR TITLE
Enforce event lambda types always return Unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 - Compose UI widget type has been changed from `@Composable () -> Unit` to `@Composable (Modifier) -> Unit` to support unscoped modifiers.
 - JVM and Android artifacts now target Java 11 bytecode, as the upstream Compose dependencies now all target Java 11.
 - The host protocol type has been renamed from `ProtocolFactory` to `HostProtocol`. An instance of `HostProtocol` is now required when constructing a `TreehouseAppFactory`.
+- Enforce that event properties declared in your schema always return `Unit`.
 
 Fixed:
 - Don't double insets on insets-aware `UIViews`. Previously we offered the same insets via two mechanisms, which could result in double insets.

--- a/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
+++ b/redwood-tooling-schema/src/main/kotlin/app/cash/redwood/tooling/schema/schemaParserFir.kt
@@ -420,7 +420,12 @@ private fun FirContext.parseWidget(
 
       if (propertyAnnotation != null) {
         if (type.isBasicFunctionType(firSession)) {
-          val arguments = type.typeArguments.dropLast(1) // Drop Unit return type.
+          val typeArguments = type.typeArguments
+          val lastArgument = typeArguments.lastOrNull()?.type?.classId?.asSingleFqName()
+          require(lastArgument == FqNames.Unit) {
+            "@Property $memberType#$name lambda must return 'Unit'"
+          }
+          val arguments = typeArguments.dropLast(1) // Drop Unit return type.
           ParsedProtocolEvent(
             tag = propertyAnnotation.tag,
             name = name,

--- a/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
+++ b/redwood-tooling-schema/src/test/kotlin/app/cash/redwood/tooling/schema/SchemaParserTest.kt
@@ -588,6 +588,25 @@ class SchemaParserTest {
 
   @Schema(
     [
+      InvalidEventLambdaReturnTypeWidget::class,
+    ],
+  )
+  interface InvalidEventLambdaReturnTypeSchema
+
+  @Widget(1)
+  data class InvalidEventLambdaReturnTypeWidget(
+    @Property(1) val event: () -> String,
+  )
+
+  @Test fun eventTypesBad() {
+    assertFailure {
+      parseTestSchema(InvalidEventLambdaReturnTypeSchema::class)
+    }.isInstanceOf<IllegalArgumentException>()
+      .hasMessage("@Property app.cash.redwood.tooling.schema.SchemaParserTest.InvalidEventLambdaReturnTypeWidget#event lambda must return 'Unit'")
+  }
+
+  @Schema(
+    [
       EventArgumentsWidget::class,
     ],
   )


### PR DESCRIPTION
Closes #2656

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
