### PR TITLE
Deserialize property changes on Zipline thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 New:
 - Schema `@Widget`s can now set `internalComposable = true` to have their `@Composable` functions generated as internal. This will require that you define a public version in the main sources of the module which generates the functions. This can be used to hide old widgets that should no longer be used, create more complex widget protocols away from callers, and to conditionally split implementation between two bindings, for example.
+- UI changes which come from Treehouse are now converted to their final value on a background thread. Previously JSON deserialization happened on the background thread to an intermediate model, but mapping that model to the final value still occurred on the main thread.
 
 Changed:
 - Schema dependencies can now be a graph (i.e., dependencies can have their own dependencies), but the entire transitive set needs to be redeclared on the root schema (for the protocol to work properly).

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChangeListenerTest.kt
@@ -26,6 +26,7 @@ import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.guest.DefaultGuestProtocolAdapter
 import app.cash.redwood.protocol.guest.guestRedwoodVersion
 import app.cash.redwood.protocol.host.HostProtocolAdapter
+import app.cash.redwood.protocol.host.UiChange
 import app.cash.redwood.protocol.host.hostRedwoodVersion
 import app.cash.redwood.testing.TestRedwoodComposition
 import app.cash.redwood.testing.WidgetValue
@@ -72,15 +73,21 @@ enum class ComposeLauncher {
         hostVersion = hostRedwoodVersion,
         widgetSystemFactory = TestSchemaProtocolWidgetSystemFactory,
       )
+      val hostProtocol = TestSchemaHostProtocol.create()
       val hostAdapter = HostProtocolAdapter(
         guestVersion = guestRedwoodVersion,
         container = MutableListChildren(),
-        protocol = TestSchemaHostProtocol.create(),
+        protocol = hostProtocol,
         widgetSystem = widgetSystem,
         eventSink = { throw AssertionError() },
         leakDetector = LeakDetector.none(),
       )
-      guestAdapter.initChangesSink(hostAdapter)
+      guestAdapter.initChangesSink { changes ->
+        val uiChanges = changes.mapNotNull { change ->
+          UiChange.fromProtocol(hostProtocol, change)
+        }
+        hostAdapter.sendChanges(uiChanges)
+      }
       return TestRedwoodComposition(
         scope = scope,
         widgetSystem = guestAdapter.widgetSystem,

--- a/redwood-protocol-host/api/redwood-protocol-host.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.api
@@ -1,4 +1,6 @@
 public abstract interface class app/cash/redwood/protocol/host/HostProtocol {
+	public abstract fun getJson ()Lkotlinx/serialization/json/Json;
+	public abstract fun getMismatchHandler ()Lapp/cash/redwood/protocol/host/ProtocolMismatchHandler;
 }
 
 public abstract interface class app/cash/redwood/protocol/host/HostProtocol$Factory {
@@ -6,7 +8,7 @@ public abstract interface class app/cash/redwood/protocol/host/HostProtocol$Fact
 	public static synthetic fun create$default (Lapp/cash/redwood/protocol/host/HostProtocol$Factory;Lkotlinx/serialization/json/Json;Lapp/cash/redwood/protocol/host/ProtocolMismatchHandler;ILjava/lang/Object;)Lapp/cash/redwood/protocol/host/HostProtocol;
 }
 
-public final class app/cash/redwood/protocol/host/HostProtocolAdapter : app/cash/redwood/protocol/ChangesSink {
+public final class app/cash/redwood/protocol/host/HostProtocolAdapter : app/cash/redwood/protocol/host/UiChangesSink {
 	public synthetic fun <init> (Ljava/lang/String;Lapp/cash/redwood/widget/Widget$Children;Lapp/cash/redwood/protocol/host/HostProtocol;Lapp/cash/redwood/widget/WidgetSystem;Lapp/cash/redwood/protocol/host/UiEventSink;Lapp/cash/redwood/leaks/LeakDetector;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun close ()V
 	public fun sendChanges (Ljava/util/List;)V
@@ -22,6 +24,19 @@ public abstract interface class app/cash/redwood/protocol/host/ProtocolMismatchH
 }
 
 public final class app/cash/redwood/protocol/host/ProtocolMismatchHandler$Companion {
+}
+
+public abstract interface class app/cash/redwood/protocol/host/UiChange {
+	public static final field Companion Lapp/cash/redwood/protocol/host/UiChange$Companion;
+	public abstract fun getId-0HhLjSo ()I
+}
+
+public final class app/cash/redwood/protocol/host/UiChange$Companion {
+	public final fun fromProtocol (Lapp/cash/redwood/protocol/host/HostProtocol;Lapp/cash/redwood/protocol/Change;)Lapp/cash/redwood/protocol/host/UiChange;
+}
+
+public abstract interface class app/cash/redwood/protocol/host/UiChangesSink {
+	public abstract fun sendChanges (Ljava/util/List;)V
 }
 
 public abstract interface class app/cash/redwood/protocol/host/UiEvent {

--- a/redwood-protocol-host/api/redwood-protocol-host.klib.api
+++ b/redwood-protocol-host/api/redwood-protocol-host.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <app.cash.redwood:redwood-protocol-host>
+abstract fun interface app.cash.redwood.protocol.host/UiChangesSink { // app.cash.redwood.protocol.host/UiChangesSink|null[0]
+    abstract fun sendChanges(kotlin.collections/List<app.cash.redwood.protocol.host/UiChange>) // app.cash.redwood.protocol.host/UiChangesSink.sendChanges|sendChanges(kotlin.collections.List<app.cash.redwood.protocol.host.UiChange>){}[0]
+}
+
 abstract fun interface app.cash.redwood.protocol.host/UiEventSink { // app.cash.redwood.protocol.host/UiEventSink|null[0]
     abstract fun sendEvent(app.cash.redwood.protocol.host/UiEvent) // app.cash.redwood.protocol.host/UiEventSink.sendEvent|sendEvent(app.cash.redwood.protocol.host.UiEvent){}[0]
 }
@@ -27,16 +31,30 @@ abstract interface app.cash.redwood.protocol.host/UiEvent { // app.cash.redwood.
 }
 
 sealed interface app.cash.redwood.protocol.host/HostProtocol { // app.cash.redwood.protocol.host/HostProtocol|null[0]
+    abstract val json // app.cash.redwood.protocol.host/HostProtocol.json|{}json[0]
+        abstract fun <get-json>(): kotlinx.serialization.json/Json // app.cash.redwood.protocol.host/HostProtocol.json.<get-json>|<get-json>(){}[0]
+    abstract val mismatchHandler // app.cash.redwood.protocol.host/HostProtocol.mismatchHandler|{}mismatchHandler[0]
+        abstract fun <get-mismatchHandler>(): app.cash.redwood.protocol.host/ProtocolMismatchHandler // app.cash.redwood.protocol.host/HostProtocol.mismatchHandler.<get-mismatchHandler>|<get-mismatchHandler>(){}[0]
+
     abstract interface Factory { // app.cash.redwood.protocol.host/HostProtocol.Factory|null[0]
         abstract fun create(kotlinx.serialization.json/Json = ..., app.cash.redwood.protocol.host/ProtocolMismatchHandler = ...): app.cash.redwood.protocol.host/HostProtocol // app.cash.redwood.protocol.host/HostProtocol.Factory.create|create(kotlinx.serialization.json.Json;app.cash.redwood.protocol.host.ProtocolMismatchHandler){}[0]
     }
 }
 
-final class <#A: kotlin/Any> app.cash.redwood.protocol.host/HostProtocolAdapter : app.cash.redwood.protocol/ChangesSink { // app.cash.redwood.protocol.host/HostProtocolAdapter|null[0]
+sealed interface app.cash.redwood.protocol.host/UiChange { // app.cash.redwood.protocol.host/UiChange|null[0]
+    abstract val id // app.cash.redwood.protocol.host/UiChange.id|{}id[0]
+        abstract fun <get-id>(): app.cash.redwood.protocol/Id // app.cash.redwood.protocol.host/UiChange.id.<get-id>|<get-id>(){}[0]
+
+    final object Companion { // app.cash.redwood.protocol.host/UiChange.Companion|null[0]
+        final fun fromProtocol(app.cash.redwood.protocol.host/HostProtocol, app.cash.redwood.protocol/Change): app.cash.redwood.protocol.host/UiChange? // app.cash.redwood.protocol.host/UiChange.Companion.fromProtocol|fromProtocol(app.cash.redwood.protocol.host.HostProtocol;app.cash.redwood.protocol.Change){}[0]
+    }
+}
+
+final class <#A: kotlin/Any> app.cash.redwood.protocol.host/HostProtocolAdapter : app.cash.redwood.protocol.host/UiChangesSink { // app.cash.redwood.protocol.host/HostProtocolAdapter|null[0]
     constructor <init>(app.cash.redwood.protocol/RedwoodVersion, app.cash.redwood.widget/Widget.Children<#A>, app.cash.redwood.protocol.host/HostProtocol, app.cash.redwood.widget/WidgetSystem<#A>, app.cash.redwood.protocol.host/UiEventSink, app.cash.redwood.leaks/LeakDetector) // app.cash.redwood.protocol.host/HostProtocolAdapter.<init>|<init>(app.cash.redwood.protocol.RedwoodVersion;app.cash.redwood.widget.Widget.Children<1:0>;app.cash.redwood.protocol.host.HostProtocol;app.cash.redwood.widget.WidgetSystem<1:0>;app.cash.redwood.protocol.host.UiEventSink;app.cash.redwood.leaks.LeakDetector){}[0]
 
     final fun close() // app.cash.redwood.protocol.host/HostProtocolAdapter.close|close(){}[0]
-    final fun sendChanges(kotlin.collections/List<app.cash.redwood.protocol/Change>) // app.cash.redwood.protocol.host/HostProtocolAdapter.sendChanges|sendChanges(kotlin.collections.List<app.cash.redwood.protocol.Change>){}[0]
+    final fun sendChanges(kotlin.collections/List<app.cash.redwood.protocol.host/UiChange>) // app.cash.redwood.protocol.host/HostProtocolAdapter.sendChanges|sendChanges(kotlin.collections.List<app.cash.redwood.protocol.host.UiChange>){}[0]
 }
 
 final val app.cash.redwood.protocol.host/hostRedwoodVersion // app.cash.redwood.protocol.host/hostRedwoodVersion|{}hostRedwoodVersion[0]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocol.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocol.kt
@@ -20,18 +20,23 @@ import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
 import app.cash.redwood.protocol.ModifierElement
+import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.WidgetSystem
 import kotlin.native.ObjCName
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 
 /**
- * A marker interface for the host-side of the protocol.
+ * The host-side of the protocol.
  *
  * @see HostProtocolAdapter
  */
 @ObjCName("HostProtocol", exact = true)
 public sealed interface HostProtocol {
+  public val json: Json
+  public val mismatchHandler: ProtocolMismatchHandler
+
   @ObjCName("HostProtocolFactory", exact = true)
   public interface Factory {
     public fun create(
@@ -75,6 +80,15 @@ public interface GeneratedHostProtocol : HostProtocol {
 public interface WidgetHostProtocol {
   /** Create an instance of this widget wrapped as a [ProtocolNode] with the given [id]. */
   public fun <W : Any> createNode(id: Id, widgetSystem: WidgetSystem<W>): ProtocolNode<W>
+
+  /**
+   * Look up a deserializer for the given property [tag].
+   *
+   * Invalid [tag] values can either produce an exception or result in `null` being returned.
+   * If `null` is returned, the caller should make every effort to ignore this property and
+   * continue executing.
+   */
+  public fun propertyDeserializer(tag: PropertyTag): DeserializationStrategy<Any?>?
 
   /**
    * Look up known children tags for this widget. These are stored as a bare [IntArray]

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -22,16 +22,11 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.Change
-import app.cash.redwood.protocol.ChangesSink
-import app.cash.redwood.protocol.ChildrenChange
 import app.cash.redwood.protocol.ChildrenChange.Add
 import app.cash.redwood.protocol.ChildrenChange.Move
 import app.cash.redwood.protocol.ChildrenChange.Remove
 import app.cash.redwood.protocol.ChildrenTag
-import app.cash.redwood.protocol.Create
 import app.cash.redwood.protocol.Id
-import app.cash.redwood.protocol.ModifierChange
-import app.cash.redwood.protocol.PropertyChange
 import app.cash.redwood.protocol.RedwoodVersion
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.ChangeListener
@@ -57,7 +52,7 @@ public class HostProtocolAdapter<W : Any>(
   private val widgetSystem: WidgetSystem<W>,
   private val eventSink: UiEventSink,
   private val leakDetector: LeakDetector,
-) : ChangesSink {
+) : UiChangesSink {
   private val protocol = when (protocol) {
     is GeneratedHostProtocol -> protocol
   }
@@ -74,7 +69,7 @@ public class HostProtocolAdapter<W : Any>(
 
   private var closed = false
 
-  override fun sendChanges(changes: List<Change>) {
+  override fun sendChanges(changes: List<UiChange>) {
     check(!closed)
 
     @Suppress("NAME_SHADOWING")
@@ -84,7 +79,7 @@ public class HostProtocolAdapter<W : Any>(
       val change = changes[i]
       val id = change.id
       when (change) {
-        is Create -> {
+        is UiCreate -> {
           val widgetProtocol = protocol.widget(change.tag) ?: continue
           val node = widgetProtocol.createNode(id, widgetSystem)
           val old = nodes.put(change.id.value, node)
@@ -93,7 +88,8 @@ public class HostProtocolAdapter<W : Any>(
           }
         }
 
-        is ChildrenChange -> {
+        is UiChildrenChange -> {
+          val change = change.change
           val node = node(id)
           val children = node.children(change.tag) ?: continue
           when (change) {
@@ -126,21 +122,15 @@ public class HostProtocolAdapter<W : Any>(
           }
         }
 
-        is ModifierChange -> {
+        is UiModifierChange -> {
           val node = node(id)
+          node.reuse = change.reuse
 
-          val modifier = change.elements.fold<_, Modifier>(Modifier) { outer, element ->
-            val value = node.widget.value
-            val inner = protocol.createModifier(element)
-            if (element.tag.value == REUSE_MODIFIER_TAG) {
-              node.reuse = true
-            }
-            if (inner is Modifier.UnscopedElement) {
-              widgetSystem.apply(value, inner)
-            }
-            outer.then(inner)
+          change.modifier.forEachUnscoped { element ->
+            widgetSystem.apply(node.widget.value, element)
           }
-          node.updateModifier(modifier)
+
+          node.updateModifier(change.modifier)
 
           val widget = node.widget
           if (widget is ChangeListener) {
@@ -148,7 +138,7 @@ public class HostProtocolAdapter<W : Any>(
           }
         }
 
-        is PropertyChange -> {
+        is UiPropertyChange -> {
           val node = node(change.id)
           node.apply(change, eventSink)
 
@@ -222,21 +212,21 @@ public class HostProtocolAdapter<W : Any>(
    *
    * Returns the updated set of changes that omits any changes that were implemented with reuse.
    */
-  private fun applyReuse(changes: List<Change>): List<Change> {
+  private fun applyReuse(changes: List<UiChange>): List<UiChange> {
     if (pool.isEmpty()) return changes // Short circuit reuse.
 
     // Find nodes that have Modifier.reuse
     val idToNode = mutableIntObjectMapOf<ReuseNode<W>>()
     var lastCreatedId = Id.Root
     for (change in changes) {
-      if (change is Create) {
+      if (change is UiCreate) {
         lastCreatedId = change.id
         continue
       }
-      if (change !is ModifierChange) continue
+      if (change !is UiModifierChange) continue
 
       // Must have a reuse modifier.
-      if (change.elements.none { it.tag.value == REUSE_MODIFIER_TAG }) continue
+      if (!change.reuse) continue
 
       // Must have a Create node that precedes it.
       if (lastCreatedId != change.id) continue
@@ -262,7 +252,7 @@ public class HostProtocolAdapter<W : Any>(
 
     // If the _shape_ of a reuse candidate matches a pooled node, remove the corresponding changes
     // and use the pooled node.
-    val changesAndNulls: Array<Change?> = changes.toTypedArray()
+    val changesAndNulls: Array<UiChange?> = changes.toTypedArray()
     idToNode.forEachValue { reuseNode ->
       // Only look for reuse roots.
       if (reuseNode.changeIndexForAdd != -1) return@forEachValue
@@ -295,11 +285,12 @@ public class HostProtocolAdapter<W : Any>(
    */
   private fun putNodesForChildrenOfNodes(
     idToNode: MutableIntObjectMap<ReuseNode<W>>,
-    changes: List<Change>,
+    uiChanges: List<UiChange>,
   ): Boolean {
     var nodesAddedToMap = false
-    for ((index, change) in changes.withIndex()) {
-      if (change !is Add) continue
+    for ((index, uiChange) in uiChanges.withIndex()) {
+      val change = (uiChange as? UiChildrenChange)?.change as? Add?
+      if (change == null) continue
       val parent = idToNode[change.id.value] ?: continue // Parent isn't reused.
       if (change.childId.value in idToNode) continue // Child already created.
 
@@ -320,12 +311,12 @@ public class HostProtocolAdapter<W : Any>(
   /** Returns true if any nodes were added to the map. */
   private fun populateCreateIndexAndEligibleForReuse(
     idToNode: MutableIntObjectMap<ReuseNode<W>>,
-    changes: List<Change>,
+    uiChanges: List<UiChange>,
   ) {
-    for ((index, change) in changes.withIndex()) {
+    for ((index, change) in uiChanges.withIndex()) {
       when {
         // Track the Create for each node in the reuse nodes.
-        change is Create -> {
+        change is UiCreate -> {
           val node = idToNode[change.id.value]
           if (node != null) {
             node.changeIndexForCreate = index
@@ -334,7 +325,7 @@ public class HostProtocolAdapter<W : Any>(
         }
 
         // Any other children change disqualifies this node from reuse.
-        change !is Add && change is ChildrenChange -> {
+        change is UiChildrenChange && change.change !is Add -> {
           val node = idToNode[change.id.value] ?: continue
           node.eligibleForReuse = false
         }
@@ -367,7 +358,7 @@ public class HostProtocolAdapter<W : Any>(
      */
     fun assignPooledNodeRecursive(
       nodes: MutableIntObjectMap<ProtocolNode<W>>,
-      changesAndNulls: Array<Change?>,
+      changesAndNulls: Array<UiChange?>,
       pooled: ProtocolNode<W>,
     ) {
       // Reuse the node.
@@ -406,7 +397,7 @@ private class RootProtocolNode<W : Any>(
 
   private val children = ProtocolChildren(children)
 
-  override fun apply(change: PropertyChange, eventSink: UiEventSink) {
+  override fun apply(change: UiPropertyChange, eventSink: UiEventSink) {
     throw AssertionError("unexpected: $change")
   }
 
@@ -433,8 +424,6 @@ private class RootProtocolNode<W : Any>(
     // Do nothing because 'children' is owned by the host's RedwoodView.
   }
 }
-
-private const val REUSE_MODIFIER_TAG = -4_543_827
 
 /**
  * Cache a fixed number of recently removed widgets with the 'reuse' modifier. This number balances

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/ProtocolNode.kt
@@ -19,7 +19,6 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
-import app.cash.redwood.protocol.PropertyChange
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.Widget
 import kotlin.math.max
@@ -51,7 +50,7 @@ public abstract class ProtocolNode<W : Any>(
   /** Assigned when the node is added to the pool. */
   internal var shapeHash = 0L
 
-  public abstract fun apply(change: PropertyChange, eventSink: UiEventSink)
+  public abstract fun apply(change: UiPropertyChange, eventSink: UiEventSink)
 
   public fun updateModifier(modifier: Modifier) {
     widget.modifier = modifier

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/UiChange.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/UiChange.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.protocol.host
+
+import app.cash.redwood.Modifier
+import app.cash.redwood.RedwoodCodegenApi
+import app.cash.redwood.protocol.Change
+import app.cash.redwood.protocol.ChangesSink
+import app.cash.redwood.protocol.ChildrenChange
+import app.cash.redwood.protocol.Create
+import app.cash.redwood.protocol.Id
+import app.cash.redwood.protocol.ModifierChange
+import app.cash.redwood.protocol.PropertyChange
+import app.cash.redwood.protocol.PropertyTag
+import app.cash.redwood.protocol.WidgetTag
+
+/**
+ * A version of [Change] whose contents have already been deserialized from JSON and is thus
+ * cheap to apply on the UI thread.
+ */
+public sealed interface UiChange {
+  public val id: Id
+
+  public companion object {
+    private const val REUSE_MODIFIER_TAG = -4_543_827
+
+    /**
+     * Deserialize a [Change] into a [UiChange]
+     *
+     * @return `null` if there was a protocol mismatch and the supplied [protocol]'s mismatch
+     * handler returned `null`.
+     */
+    @OptIn(RedwoodCodegenApi::class)
+    public fun fromProtocol(
+      protocol: HostProtocol,
+      change: Change,
+    ): UiChange? {
+      val factory = when (protocol) {
+        is GeneratedHostProtocol -> protocol
+      }
+
+      return when (change) {
+        is Create -> UiCreate(change.id, change.tag)
+        is ChildrenChange -> UiChildrenChange(change)
+        is PropertyChange -> {
+          val widgetProtocol = factory.widget(change.widgetTag)
+            ?: return null
+          val propertyDeserializer = widgetProtocol.propertyDeserializer(change.propertyTag)
+            ?: return null
+          val value = protocol.json.decodeFromJsonElement(propertyDeserializer, change.value)
+          UiPropertyChange(change.id, change.propertyTag, value)
+        }
+        is ModifierChange -> {
+          var reuse = false
+          val modifier = change.elements.fold<_, Modifier>(Modifier) { outer, element ->
+            if (element.tag.value == REUSE_MODIFIER_TAG) {
+              reuse = true
+            }
+            outer.then(factory.createModifier(element))
+          }
+          UiModifierChange(change.id, reuse, modifier)
+        }
+      }
+    }
+  }
+}
+
+/** A version of [ChangesSink] which consumes [UiChange]s. */
+public fun interface UiChangesSink {
+  public fun sendChanges(changes: List<UiChange>)
+}
+
+/** @suppress */
+@RedwoodCodegenApi
+public class UiCreate(
+  override val id: Id,
+  public val tag: WidgetTag,
+) : UiChange
+
+/** @suppress */
+@RedwoodCodegenApi
+public class UiPropertyChange(
+  override val id: Id,
+  public val tag: PropertyTag,
+  public val value: Any?,
+) : UiChange
+
+/** @suppress */
+@RedwoodCodegenApi
+public class UiModifierChange(
+  override val id: Id,
+  public val reuse: Boolean,
+  public val modifier: Modifier,
+) : UiChange
+
+/** @suppress */
+@RedwoodCodegenApi
+public class UiChildrenChange(
+  public val change: ChildrenChange,
+) : UiChange {
+  override val id: Id get() = change.id
+}

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ChildrenNodeIndexTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ChildrenNodeIndexTest.kt
@@ -19,7 +19,6 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.protocol.ChildrenTag
 import app.cash.redwood.protocol.Id
-import app.cash.redwood.protocol.PropertyChange
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.widget.MutableListChildren
 import app.cash.redwood.widget.Widget
@@ -130,7 +129,7 @@ private class WidgetNode(override val widget: StringWidget) : ProtocolNode<Strin
   override val widgetTag: WidgetTag get() = WidgetTag(1)
   override val widgetName: String get() = "WidgetNode"
 
-  override fun apply(change: PropertyChange, eventSink: UiEventSink) {
+  override fun apply(change: UiPropertyChange, eventSink: UiEventSink) {
     throw UnsupportedOperationException()
   }
 

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapterTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapterTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.protocol.host
 
+import app.cash.redwood.Modifier
 import app.cash.redwood.RedwoodCodegenApi
 import app.cash.redwood.layout.testing.RedwoodLayoutTestingWidgetFactory
 import app.cash.redwood.lazylayout.testing.RedwoodLazyLayoutTestingWidgetFactory
@@ -22,10 +23,7 @@ import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.ChildrenChange.Add
 import app.cash.redwood.protocol.ChildrenChange.Remove
 import app.cash.redwood.protocol.ChildrenTag
-import app.cash.redwood.protocol.Create
 import app.cash.redwood.protocol.Id
-import app.cash.redwood.protocol.ModifierChange
-import app.cash.redwood.protocol.PropertyChange
 import app.cash.redwood.protocol.PropertyTag
 import app.cash.redwood.protocol.WidgetTag
 import app.cash.redwood.protocol.guest.guestRedwoodVersion
@@ -45,7 +43,6 @@ import com.example.redwood.testapp.testing.TestSchemaTestingWidgetFactory
 import com.example.redwood.testapp.widget.TestSchemaWidgetSystem
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlinx.serialization.json.JsonPrimitive
 
 @OptIn(RedwoodCodegenApi::class)
 class HostProtocolAdapterTest {
@@ -64,7 +61,7 @@ class HostProtocolAdapterTest {
       leakDetector = LeakDetector.none(),
     )
     val changes = listOf(
-      Create(
+      UiCreate(
         id = Id.Root,
         // Button
         tag = WidgetTag(4),
@@ -91,7 +88,7 @@ class HostProtocolAdapterTest {
       leakDetector = LeakDetector.none(),
     )
     val changes = listOf(
-      Create(
+      UiCreate(
         id = Id(1),
         // Button
         tag = WidgetTag(4),
@@ -122,23 +119,24 @@ class HostProtocolAdapterTest {
     // Add a button.
     hostAdapter.sendChanges(
       listOf(
-        Create(
+        UiCreate(
           id = Id(1),
           // Button
           tag = WidgetTag(4),
         ),
         // Set Button's required color property.
-        PropertyChange(
+        UiPropertyChange(
           id = Id(1),
-          widgetTag = WidgetTag(4),
-          propertyTag = PropertyTag(3),
-          value = JsonPrimitive(0),
+          tag = PropertyTag(3),
+          value = 0U,
         ),
-        Add(
-          id = Id.Root,
-          tag = ChildrenTag.Root,
-          childId = Id(1),
-          index = 0,
+        UiChildrenChange(
+          change = Add(
+            id = Id.Root,
+            tag = ChildrenTag.Root,
+            childId = Id(1),
+            index = 0,
+          ),
         ),
       ),
     )
@@ -146,23 +144,24 @@ class HostProtocolAdapterTest {
     // Remove the button.
     hostAdapter.sendChanges(
       listOf(
-        Remove(
-          id = Id.Root,
-          tag = ChildrenTag.Root,
-          index = 0,
-          detach = false,
+        UiChildrenChange(
+          change = Remove(
+            id = Id.Root,
+            tag = ChildrenTag.Root,
+            index = 0,
+            detach = false,
+          ),
         ),
       ),
     )
 
     // Ensure targeting the button fails.
     val updateButtonText = listOf(
-      PropertyChange(
+      UiPropertyChange(
         id = Id(1),
-        widgetTag = WidgetTag(4),
         // text
-        propertyTag = PropertyTag(1),
-        value = JsonPrimitive("hello"),
+        tag = PropertyTag(1),
+        value = "hello",
       ),
     )
     val t = assertFailsWith<IllegalStateException> {
@@ -191,9 +190,9 @@ class HostProtocolAdapterTest {
     hostAdapter.sendChanges(
       listOf(
         // Button
-        Create(Id(1), WidgetTag(4)),
-        ModifierChange(Id(1)),
-        Add(Id.Root, ChildrenTag.Root, Id(1), 0),
+        UiCreate(Id(1), WidgetTag(4)),
+        UiModifierChange(Id(1), false, Modifier),
+        UiChildrenChange(Add(Id.Root, ChildrenTag.Root, Id(1), 0)),
       ),
     )
     assertThat(modifierUpdateCount).isEqualTo(0)
@@ -201,7 +200,7 @@ class HostProtocolAdapterTest {
     // Future modifier changes trigger the callback.
     hostAdapter.sendChanges(
       listOf(
-        ModifierChange(Id(1)),
+        UiModifierChange(Id(1), false, Modifier),
       ),
     )
     assertThat(modifierUpdateCount).isEqualTo(1)
@@ -229,39 +228,39 @@ class HostProtocolAdapterTest {
     host.sendChanges(
       listOf(
         // TestRow
-        Create(Id(1), WidgetTag(1)),
-        ModifierChange(Id(1)),
+        UiCreate(Id(1), WidgetTag(1)),
+        UiModifierChange(Id(1), false, Modifier),
         // TestRow
-        Create(Id(2), WidgetTag(1)),
-        ModifierChange(Id(2)),
+        UiCreate(Id(2), WidgetTag(1)),
+        UiModifierChange(Id(2), false, Modifier),
         // Text
-        Create(Id(3), WidgetTag(1_000_003)),
-        PropertyChange(Id(3), WidgetTag(1_000_003), PropertyTag(1), JsonPrimitive("hello")),
-        ModifierChange(Id(3)),
-        Add(Id(2), ChildrenTag(1), Id(3), 0),
-        Add(Id(1), ChildrenTag(1), Id(2), 0),
-        Add(Id.Root, ChildrenTag.Root, Id(1), 0),
+        UiCreate(Id(3), WidgetTag(1_000_003)),
+        UiPropertyChange(Id(3), PropertyTag(1), "hello"),
+        UiModifierChange(Id(3), false, Modifier),
+        UiChildrenChange(Add(Id(2), ChildrenTag(1), Id(3), 0)),
+        UiChildrenChange(Add(Id(1), ChildrenTag(1), Id(2), 0)),
+        UiChildrenChange(Add(Id.Root, ChildrenTag.Root, Id(1), 0)),
       ),
     )
 
     // Validate we're tracking ID=3.
     host.sendChanges(
       listOf(
-        PropertyChange(Id(3), WidgetTag(3), PropertyTag(1), JsonPrimitive("hey")),
+        UiPropertyChange(Id(3), PropertyTag(1), "hey"),
       ),
     )
 
     // Remove root TestRow.
     host.sendChanges(
       listOf(
-        Remove(Id.Root, ChildrenTag.Root, 0, false),
+        UiChildrenChange(Remove(Id.Root, ChildrenTag.Root, 0, false)),
       ),
     )
 
     assertFailure {
       host.sendChanges(
         listOf(
-          PropertyChange(Id(3), WidgetTag(3), PropertyTag(1), JsonPrimitive("sup")),
+          UiPropertyChange(Id(3), PropertyTag(1), "sup"),
         ),
       )
     }.isInstanceOf<IllegalStateException>()
@@ -291,33 +290,33 @@ class HostProtocolAdapterTest {
     host.sendChanges(
       listOf(
         // TestRow
-        Create(Id(1), WidgetTag(1)),
-        ModifierChange(Id(1)),
+        UiCreate(Id(1), WidgetTag(1)),
+        UiModifierChange(Id(1), false, Modifier),
         // TestRow
-        Create(Id(2), WidgetTag(1)),
-        ModifierChange(Id(2)),
+        UiCreate(Id(2), WidgetTag(1)),
+        UiModifierChange(Id(2), false, Modifier),
         // Text
-        Create(Id(3), WidgetTag(1_000_002)),
-        PropertyChange(Id(3), WidgetTag(1_000_002), PropertyTag(1), JsonPrimitive("hello")),
-        ModifierChange(Id(3)),
-        Add(Id(2), ChildrenTag(1), Id(3), 0),
-        Add(Id(1), ChildrenTag(1), Id(2), 0),
-        Add(Id.Root, ChildrenTag.Root, Id(1), 0),
+        UiCreate(Id(3), WidgetTag(1_000_002)),
+        UiPropertyChange(Id(3), PropertyTag(1), "hello"),
+        UiModifierChange(Id(3), false, Modifier),
+        UiChildrenChange(Add(Id(2), ChildrenTag(1), Id(3), 0)),
+        UiChildrenChange(Add(Id(1), ChildrenTag(1), Id(2), 0)),
+        UiChildrenChange(Add(Id.Root, ChildrenTag.Root, Id(1), 0)),
       ),
     )
 
     host.sendChanges(
       listOf(
         // Detach inner TestRow.
-        Remove(Id(1), ChildrenTag(1), 0, detach = true),
+        UiChildrenChange(Remove(Id(1), ChildrenTag(1), 0, detach = true)),
         // Remove outer TestRow.
-        Remove(Id.Root, ChildrenTag.Root, 0, detach = false),
+        UiChildrenChange(Remove(Id.Root, ChildrenTag.Root, 0, detach = false)),
         // New outer TestRow.
-        Create(Id(4), WidgetTag(1)),
-        ModifierChange(Id(4)),
-        Add(Id.Root, ChildrenTag.Root, Id(4), 0),
+        UiCreate(Id(4), WidgetTag(1)),
+        UiModifierChange(Id(4), false, Modifier),
+        UiChildrenChange(Add(Id.Root, ChildrenTag.Root, Id(4), 0)),
         // Re-attach inner TestRow.
-        Add(Id(4), ChildrenTag(1), Id(2), 0),
+        UiChildrenChange(Add(Id(4), ChildrenTag(1), Id(2), 0)),
       ),
     )
 

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolTest.kt
@@ -228,7 +228,10 @@ class HostProtocolTest {
     val textInput = protocol.widget(WidgetTag(5))!!.createNode(Id(1), widgetSystem)
 
     val throwingEventSink = UiEventSink { error(it) }
-    textInput.apply(PropertyChange(Id(1), WidgetTag(5), PropertyTag(2), JsonPrimitive("PT10S")), throwingEventSink)
+
+    val change = PropertyChange(Id(1), WidgetTag(5), PropertyTag(2), JsonPrimitive("PT10S"))
+    val uiChange = UiChange.fromProtocol(protocol, change) as UiPropertyChange
+    textInput.apply(uiChange, throwingEventSink)
 
     assertThat((textInput.widget.value as TextInputValue).customType).isEqualTo(10.seconds)
   }
@@ -243,7 +246,7 @@ class HostProtocolTest {
     )
     val button = protocol.widget(WidgetTag(4))!!.createNode(Id(1), widgetSystem)
 
-    val change = PropertyChange(Id(1), WidgetTag(4), PropertyTag(345432))
+    val change = UiPropertyChange(Id(1), PropertyTag(345432), "sup")
     val eventSink = UiEventSink { throw UnsupportedOperationException() }
     val t = assertFailsWith<IllegalArgumentException> {
       button.apply(change, eventSink)
@@ -264,7 +267,9 @@ class HostProtocolTest {
     )
     val button = protocol.widget(WidgetTag(4))!!.createNode(Id(1), widgetSystem)
 
-    button.apply(PropertyChange(Id(1), WidgetTag(4), PropertyTag(345432))) { throw UnsupportedOperationException() }
+    val change = UiPropertyChange(Id(1), PropertyTag(345432), "sup")
+
+    button.apply(change) { throw UnsupportedOperationException() }
 
     assertThat(handler.events.single()).isEqualTo("Unknown property 345432 for 4")
   }
@@ -287,7 +292,9 @@ class HostProtocolTest {
     val textInput = protocol.widget(WidgetTag(5))!!.createNode(Id(1), widgetSystem)
 
     val eventSink = RecordingUiEventSink()
-    textInput.apply(PropertyChange(Id(1), WidgetTag(5), PropertyTag(4), JsonPrimitive(true)), eventSink)
+    val change = PropertyChange(Id(1), WidgetTag(5), PropertyTag(4), JsonPrimitive(true))
+    val uiChange = UiChange.fromProtocol(protocol, change) as UiPropertyChange
+    textInput.apply(uiChange, eventSink)
 
     (textInput.widget.value as TextInputValue).onChangeCustomType!!.invoke(10.seconds)
 

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewRecyclingTester.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewRecyclingTester.kt
@@ -26,6 +26,7 @@ import app.cash.redwood.protocol.guest.DefaultGuestProtocolAdapter
 import app.cash.redwood.protocol.guest.GuestProtocolAdapter
 import app.cash.redwood.protocol.guest.guestRedwoodVersion
 import app.cash.redwood.protocol.host.HostProtocolAdapter
+import app.cash.redwood.protocol.host.UiChange
 import app.cash.redwood.protocol.host.hostRedwoodVersion
 import app.cash.redwood.ui.basic.testing.RedwoodUiBasicTestingWidgetFactory
 import app.cash.redwood.widget.MutableListChildren
@@ -51,10 +52,11 @@ class ViewRecyclingTester(
 ) {
   private val widgetContainer = MutableListChildren<WidgetValue>()
 
+  private val protocol = TestSchemaHostProtocol.create()
   val hostAdapter: HostProtocolAdapter<WidgetValue> = HostProtocolAdapter(
     guestVersion = guestRedwoodVersion,
     container = widgetContainer,
-    protocol = TestSchemaHostProtocol.create(),
+    protocol = protocol,
     widgetSystem = TestSchemaWidgetSystem(
       TestSchema = TestSchemaTestingWidgetFactory(),
       RedwoodUiBasic = RedwoodUiBasicTestingWidgetFactory(),
@@ -71,7 +73,12 @@ class ViewRecyclingTester(
     hostVersion = hostRedwoodVersion,
     widgetSystemFactory = TestSchemaProtocolWidgetSystemFactory,
   ).apply {
-    initChangesSink(hostAdapter)
+    initChangesSink { changes ->
+      val uiChanges = changes.mapNotNull { change ->
+        UiChange.fromProtocol(protocol, change)
+      }
+      hostAdapter.sendChanges(uiChanges)
+    }
   }
 
   internal val composition = TestRedwoodComposition(

--- a/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
+++ b/redwood-testing/src/commonTest/kotlin/app/cash/redwood/testing/ViewTreesTest.kt
@@ -34,6 +34,7 @@ import app.cash.redwood.protocol.guest.DefaultGuestProtocolAdapter
 import app.cash.redwood.protocol.guest.ProtocolRedwoodComposition
 import app.cash.redwood.protocol.guest.guestRedwoodVersion
 import app.cash.redwood.protocol.host.HostProtocolAdapter
+import app.cash.redwood.protocol.host.UiChange
 import app.cash.redwood.protocol.host.hostRedwoodVersion
 import app.cash.redwood.ui.Cancellable
 import app.cash.redwood.ui.OnBackPressedCallback
@@ -146,15 +147,19 @@ class ViewTreesTest {
       RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
     )
     val widgetContainer = MutableListChildren<WidgetValue>()
+    val protocol = TestSchemaHostProtocol.create()
     val hostAdapter = HostProtocolAdapter(
       guestVersion = guestRedwoodVersion,
       container = widgetContainer,
-      protocol = TestSchemaHostProtocol.create(),
+      protocol = protocol,
       widgetSystem = widgetSystem,
       eventSink = { throw AssertionError() },
       leakDetector = LeakDetector.none(),
     )
-    hostAdapter.sendChanges(expected)
+    val uiChanges = expected.mapNotNull { change ->
+      UiChange.fromProtocol(protocol, change)
+    }
+    hostAdapter.sendChanges(uiChanges)
 
     assertThat(widgetContainer.map { it.value }).isEqualTo(snapshot)
   }

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/protocolHostGeneration.kt
@@ -28,6 +28,7 @@ import app.cash.redwood.tooling.schema.Schema
 import app.cash.redwood.tooling.schema.Widget
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -50,8 +51,8 @@ import com.squareup.kotlinpoet.jvm.jvmField
 /*
 @ObjCName("ExampleProtocolFactory", exact = true)
 public class ExampleProtocolFactory(
-  private val json: Json = Json.Default,
-  private val mismatchHandler: ProtocolMismatchHandler = ProtocolMismatchHandler.Throwing,
+  override val json: Json = Json.Default,
+  override val mismatchHandler: ProtocolMismatchHandler = ProtocolMismatchHandler.Throwing,
 ) : GeneratedHostProtocol {
   private val widgets: IntObjectMap<WidgetHostProtocol> =
       MutableIntObjectMap(4).apply {
@@ -104,12 +105,12 @@ internal fun generateHostProtocol(
             .build(),
         )
         .addProperty(
-          PropertySpec.builder("json", KotlinxSerialization.Json, PRIVATE)
+          PropertySpec.builder("json", KotlinxSerialization.Json, OVERRIDE)
             .initializer("json")
             .build(),
         )
         .addProperty(
-          PropertySpec.builder("mismatchHandler", ProtocolHost.ProtocolMismatchHandler, PRIVATE)
+          PropertySpec.builder("mismatchHandler", ProtocolHost.ProtocolMismatchHandler, OVERRIDE)
             .initializer("mismatchHandler")
             .build(),
         )
@@ -286,6 +287,9 @@ internal fun generateProtocolNode(
         }
       }
       is ProtocolEvent -> {
+        serializerIds.computeIfAbsent(BOOLEAN) {
+          nextSerializerId++
+        }
         for (parameter in trait.parameters) {
           serializerIds.computeIfAbsent(parameter.type.asTypeName()) {
             nextSerializerId++
@@ -370,6 +374,34 @@ internal fun generateProtocolNode(
             .addStatement("return %T(id, widget, this)", widgetNodeType)
             .build(),
         )
+        .addFunction(
+          FunSpec.builder("propertyDeserializer")
+            .addModifiers(OVERRIDE)
+            .addParameter("tag", Protocol.PropertyTag)
+            .returns(KotlinxSerialization.DeserializationStrategy.parameterizedBy(ANY.copy(nullable = true)).copy(nullable = true))
+            .beginControlFlow("return when (tag.value)")
+            .apply {
+              for (trait in widget.traits) {
+                val traitType = when (trait) {
+                  is ProtocolProperty -> trait.type.asTypeName()
+                  is ProtocolEvent -> BOOLEAN
+                  is ProtocolChildren -> continue
+                }
+                val serializerId = serializerIds.getValue(traitType)
+                addStatement("%L -> serializer_%L", trait.tag, serializerId)
+              }
+            }
+            .beginControlFlow("else ->")
+            .addStatement(
+              "mismatchHandler.onUnknownProperty(%T(%L), tag)",
+              Protocol.WidgetTag,
+              widget.tag,
+            )
+            .addStatement("null")
+            .endControlFlow()
+            .endControlFlow()
+            .build(),
+        )
         .build(),
     )
     addType(
@@ -434,35 +466,31 @@ internal fun generateProtocolNode(
           addFunction(
             FunSpec.builder("apply")
               .addModifiers(OVERRIDE)
-              .addParameter("change", Protocol.PropertyChange)
+              .addParameter("change", ProtocolHost.UiPropertyChange)
               .addParameter("eventSink", ProtocolHost.UiEventSink)
               .apply {
                 if (properties.isNotEmpty()) {
                   addStatement("val widget = _widget ?: error(%S)", "detached")
                 }
-                beginControlFlow("when (change.propertyTag.value)")
+                beginControlFlow("when (change.tag.value)")
                 for (trait in properties) {
                   when (trait) {
                     is ProtocolProperty -> {
-                      val propertyType = trait.type.asTypeName()
-                      val serializerId = serializerIds.getValue(propertyType)
-
                       addStatement(
-                        "%L -> widget.%N(protocol.json.decodeFromJsonElement(protocol.serializer_%L, change.value))",
+                        "%L -> widget.%N(change.value as %T)",
                         trait.tag,
                         trait.name,
-                        serializerId,
+                        trait.type.asTypeName(),
                       )
                     }
 
                     is ProtocolEvent -> {
                       beginControlFlow("%L ->", trait.tag)
                       beginControlFlow(
-                        "val %N: %T = if (change.value.%M.%M)",
+                        "val %N: %T = if (change.value as %T)",
                         trait.name,
                         trait.lambdaType,
-                        KotlinxSerialization.jsonPrimitive,
-                        KotlinxSerialization.jsonBoolean,
+                        BOOLEAN,
                       )
                       if (trait.parameters.isEmpty()) {
                         addStatement(
@@ -492,7 +520,7 @@ internal fun generateProtocolNode(
                 }
               }
               .addStatement(
-                "else -> protocol.mismatchHandler.onUnknownProperty(%T(%L), change.propertyTag)",
+                "else -> protocol.mismatchHandler.onUnknownProperty(%T(%L), change.tag)",
                 Protocol.WidgetTag,
                 widget.tag,
               )

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/types.kt
@@ -59,6 +59,7 @@ internal object ProtocolHost {
   val ProtocolNode = ClassName("app.cash.redwood.protocol.host", "ProtocolNode")
   val ProtocolChildren = ClassName("app.cash.redwood.protocol.host", "ProtocolChildren")
   val UiEventSink = ClassName("app.cash.redwood.protocol.host", "UiEventSink")
+  val UiPropertyChange = ClassName("app.cash.redwood.protocol.host", "UiPropertyChange")
   val WidgetHostProtocol = ClassName("app.cash.redwood.protocol.host", "WidgetHostProtocol")
 }
 
@@ -131,6 +132,7 @@ internal val typeVariableW = TypeVariableName("W", listOf(ANY))
 internal object KotlinxSerialization {
   val Contextual = ClassName("kotlinx.serialization", "Contextual")
   val ContextualSerializer = ClassName("kotlinx.serialization", "ContextualSerializer")
+  val DeserializationStrategy = ClassName("kotlinx.serialization", "DeserializationStrategy")
   val ExperimentalSerializationApi = ClassName("kotlinx.serialization", "ExperimentalSerializationApi")
   val KSerializer = ClassName("kotlinx.serialization", "KSerializer")
   val Serializable = ClassName("kotlinx.serialization", "Serializable")
@@ -146,10 +148,6 @@ internal object KotlinxSerialization {
 
   val Json = ClassName("kotlinx.serialization.json", "Json")
   val JsonDefault = Json.nestedClass("Default")
-  val JsonPrimitive = MemberName("kotlinx.serialization.json", "JsonPrimitive")
-  val jsonBoolean = MemberName("kotlinx.serialization.json", "boolean")
-
-  @JvmField val jsonPrimitive = MemberName("kotlinx.serialization.json", "jsonPrimitive")
 }
 
 internal object KotlinxCoroutines {

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ChangeListRenderer.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/ChangeListRenderer.kt
@@ -19,6 +19,7 @@ import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.SnapshotChangeList
 import app.cash.redwood.protocol.host.HostProtocol
 import app.cash.redwood.protocol.host.HostProtocolAdapter
+import app.cash.redwood.protocol.host.UiChange
 import app.cash.redwood.protocol.host.UiEventSink
 import app.cash.redwood.protocol.host.hostRedwoodVersion
 
@@ -50,6 +51,9 @@ public class ChangeListRenderer<W : Any>(
       eventSink = refuseAllEvents,
       leakDetector = LeakDetector.none(),
     )
-    hostAdapter.sendChanges(changeList.changes)
+    val uiChanges = changeList.changes.mapNotNull { change ->
+      UiChange.fromProtocol(protocol, change)
+    }
+    hostAdapter.sendChanges(uiChanges)
   }
 }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/TreehouseAppContent.kt
@@ -19,6 +19,7 @@ import app.cash.redwood.leaks.LeakDetector
 import app.cash.redwood.protocol.Change
 import app.cash.redwood.protocol.EventSink
 import app.cash.redwood.protocol.host.HostProtocolAdapter
+import app.cash.redwood.protocol.host.UiChange
 import app.cash.redwood.protocol.host.UiEvent
 import app.cash.redwood.protocol.host.UiEventSink
 import app.cash.redwood.treehouse.Content.State
@@ -370,7 +371,7 @@ private class ViewContentCodeBinding<A : AppService>(
   private val eventBridge = EventBridge(dispatchers.zipline, bindingScope)
 
   /** Only accessed on [TreehouseDispatchers.ui]. Empty after [initView]. */
-  private val changesAwaitingInitView = ArrayDeque<List<Change>>()
+  private val changesAwaitingInitView = ArrayDeque<List<UiChange>>()
 
   /** Changes applied to the UI. Only accessed on [TreehouseDispatchers.ui]. */
   private var deliveredChangeCount = 0
@@ -416,13 +417,20 @@ private class ViewContentCodeBinding<A : AppService>(
 
   /** Send changes from Zipline to the UI. */
   override fun sendChanges(changes: List<Change>) {
+    val uiChanges = changes.mapNotNull { change ->
+      UiChange.fromProtocol(
+        protocol = codeSession.hostProtocol,
+        change = change,
+      )
+    }
+
     // Receive UI updates on the UI dispatcher.
     bindingScope.launch(dispatchers.ui) {
-      receiveChangesOnUiDispatcher(changes)
+      receiveChangesOnUiDispatcher(uiChanges)
     }
   }
 
-  private fun receiveChangesOnUiDispatcher(changes: List<Change>) {
+  private fun receiveChangesOnUiDispatcher(changes: List<UiChange>) {
     if (canceled) {
       return
     }


### PR DESCRIPTION
A UiChange can be created from a protocol Change using the host protocol. This performs the expensive deserialization on a background thread, while leaving the main thread to only do a cast.

Closes #2145 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
