### PR TITLE
Switch back to `IntObjectMap` to avoid boxing

### DIFF
--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -62,9 +62,8 @@ public class HostProtocolAdapter<W : Any>(
     is GeneratedHostProtocol -> protocol
   }
 
-  // TODO Use MutableIntObjectMap once https://issuetracker.google.com/issues/378077858 is fixed.
   private val nodes =
-    mutableMapOf<Int, ProtocolNode<W>>(Id.Root.value to RootProtocolNode(container))
+    mutableIntObjectMapOf<ProtocolNode<W>>(Id.Root.value, RootProtocolNode(container))
 
   private val removeNodeById = IdVisitor { nodes.remove(it.value) }
 
@@ -180,7 +179,7 @@ public class HostProtocolAdapter<W : Any>(
   public fun close() {
     closed = true
 
-    nodes.values.forEach { node ->
+    nodes.forEachValue { node ->
       node.detach()
     }
     nodes.clear()
@@ -367,7 +366,7 @@ public class HostProtocolAdapter<W : Any>(
      * descendants into the nodes map.
      */
     fun assignPooledNodeRecursive(
-      nodes: MutableMap<Int, ProtocolNode<W>>,
+      nodes: MutableIntObjectMap<ProtocolNode<W>>,
       changesAndNulls: Array<Change?>,
       pooled: ProtocolNode<W>,
     ) {


### PR DESCRIPTION
We are on collection 1.5 now which contains a fix for the bug we found in its 1.4 version.

Closes #2439

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
