### PR TITLE
Use a weird value for the root's children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changed:
 - JVM and Android artifacts now target Java 11 bytecode, as the upstream Compose dependencies now all target Java 11.
 - The host protocol type has been renamed from `ProtocolFactory` to `HostProtocol`. An instance of `HostProtocol` is now required when constructing a `TreehouseAppFactory`.
 - Enforce that event properties declared in your schema always return `Unit`.
+- The root node's children are now identified using the tag 99,999 instead of 1. This attempts to prevent accidentally using the value for non-root nodes. The old value is still supported by the actual root node for compatibility with older guest code.
 
 Fixed:
 - Don't double insets on insets-aware `UIViews`. Previously we offered the same insets via two mechanisms, which could result in double insets.

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -412,6 +412,11 @@ private class RootProtocolNode<W : Any>(
 
   override fun children(tag: ChildrenTag) = when (tag) {
     ChildrenTag.Root -> children
+
+    // This is the old value of ChildrenTag.Root
+    // TODO Remove support for this once 0.18.0 (or newer) is the oldest Redwood supported.
+    ChildrenTag(1) -> children
+
     else -> throw AssertionError("unexpected: $tag")
   }
 

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapterTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapterTest.kt
@@ -36,6 +36,7 @@ import app.cash.redwood.widget.MutableListChildren
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasMessage
+import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.message
@@ -332,5 +333,49 @@ class HostProtocolAdapterTest {
         ),
       ),
     )
+  }
+
+  @Test fun oldRootChildrenTag() {
+    val hostAdapter = HostProtocolAdapter(
+      guestVersion = guestRedwoodVersion,
+      container = MutableListChildren(),
+      protocol = TestSchemaHostProtocol.create(),
+      widgetSystem = TestSchemaWidgetSystem(
+        TestSchema = TestSchemaTestingWidgetFactory(),
+        RedwoodUiBasic = RedwoodUiBasicTestingWidgetFactory(),
+        RedwoodLayout = RedwoodLayoutTestingWidgetFactory(),
+        RedwoodLazyLayout = RedwoodLazyLayoutTestingWidgetFactory(),
+      ),
+      eventSink = ::error,
+      leakDetector = LeakDetector.none(),
+    )
+
+    // Add a button.
+    hostAdapter.sendChanges(
+      listOf(
+        Create(
+          id = Id(1),
+          // Button
+          tag = WidgetTag(4),
+        ),
+        // Set Button's required color property.
+        PropertyChange(
+          id = Id(1),
+          widgetTag = WidgetTag(4),
+          propertyTag = PropertyTag(3),
+          value = JsonPrimitive(0),
+        ),
+        Add(
+          id = Id.Root,
+          // This is the old value for the root's children:
+          tag = ChildrenTag(1),
+          childId = Id(1),
+          index = 0,
+        ),
+      ),
+    )
+
+    val children = hostAdapter.node(Id.Root).children(ChildrenTag.Root)!!.nodes
+    assertThat(children).hasSize(1)
   }
 }

--- a/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/values.kt
+++ b/redwood-protocol/src/commonMain/kotlin/app/cash/redwood/protocol/values.kt
@@ -47,6 +47,7 @@ public value class PropertyTag(public val value: Int)
 @Serializable
 public value class ChildrenTag(public val value: Int) {
   public companion object {
-    public val Root: ChildrenTag = ChildrenTag(1)
+    /** The tag for children on the [Id.Root] node. */
+    public val Root: ChildrenTag = ChildrenTag(99_999)
   }
 }

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/ProtocolTest.kt
@@ -37,7 +37,7 @@ class ProtocolTest {
     // This is otherwise a change-detector test, but since these values are included in
     // the serialized form they must never change.
     assertThat(Id.Root.value).isEqualTo(0)
-    assertThat(ChildrenTag.Root.value).isEqualTo(1)
+    assertThat(ChildrenTag.Root.value).isEqualTo(99_999)
   }
 
   @Test fun eventNonEmptyArgs() {

--- a/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/SnapshotChangeListTest.kt
+++ b/redwood-protocol/src/commonTest/kotlin/app/cash/redwood/protocol/SnapshotChangeListTest.kt
@@ -44,7 +44,7 @@ class SnapshotChangeListTest {
       |{"type":"create","id":1,"tag":1},
       |{"type":"modifier","id":1},
       |{"type":"property","id":1,"widget":1,"tag":1,"value":"Hello"},
-      |{"type":"add","id":0,"tag":1,"childId":1,"index":0}
+      |{"type":"add","id":0,"tag":99999,"childId":1,"index":0}
       |]
       """.trimMargin().replace("\n", ""),
     )
@@ -70,8 +70,8 @@ class SnapshotChangeListTest {
       |Snapshot change list cannot contain move or remove operations
       |
       |Found:
-      | - Move(_id=0, _tag=1, fromIndex=1, toIndex=2, count=3)
-      | - Remove(_id=0, _tag=1, index=1, count=1, detach=false)
+      | - Move(_id=0, _tag=99999, fromIndex=1, toIndex=2, count=3)
+      | - Remove(_id=0, _tag=99999, index=1, count=1, detach=false)
       """.trimMargin(),
     )
   }


### PR DESCRIPTION
This discourages accidental use elsewhere.

Closes #2434 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
