### PR TITLE
Run plain test for JVM job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,8 +68,10 @@ jobs:
           ./gradlew
           -PredwoodNoApps
           kotlinUpgradeYarnLock
+          test
           jvmTest
-          testDebugUnitTest
+          -x testReleaseUnitTest
+          -x dokkaHtml
 
   native-tests:
     runs-on: macos-latest


### PR DESCRIPTION
This covers the JVM modules. Unfortunately this will run both variants of Android JVM tests, so we explicitly exclude the release version.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
