### PR TITLE
Fix RedwoodUIView to implement sizeThatFits correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Changed:
 - Nothing yet!
 
 Fixed:
-- Nothing yet!
+- Don't measure the height of `RedwoodUIView` as zero when measured with `sizeThatFits()` or `intrinsicContentSize()`. We had been using `UIStackView` which doesn't support these functions.
+- Correctly signal `RedwoodUIView` size changes of to callers who measure it with `intrinsicContentSize()`.
 
 
 ## [0.18.0] - 2025-08-01

--- a/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
+++ b/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
@@ -20,18 +20,27 @@ import kotlin.time.DurationUnit
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIColor
 import platform.UIKit.UIScrollView
 import platform.UIKit.UIView
+import platform.UIKit.UIViewNoIntrinsicMetric
 
-/** Snapshot the subject on a white background. */
-class UIViewSnapshotter(
+/**
+ * Snapshot the subject on a white background.
+ *
+ * This either snapshots the view sized to be full-screen, or it uses [heightConstraint] to size the
+ * view to whatever height it requires. Scrolling snapshots are always sized to the screen height.
+ */
+class UIViewSnapshotter private constructor(
   private val callback: UIViewSnapshotCallback,
   private val subject: UIView,
+  private val widthConstraint: Constraint,
+  private val heightConstraint: Constraint,
 ) : Snapshotter {
 
   override fun snapshot(name: String?, scrolling: Boolean) {
-    layoutSubject()
+    layoutSubject(scrolling)
 
     // Unfortunately even with animations forced off, UITableView's animation system breaks
     // synchronous snapshots. The simplest workaround is to delay snapshots one frame.
@@ -73,26 +82,51 @@ class UIViewSnapshotter(
   }
 
   /** Do layout without taking a snapshot. */
-  fun layoutSubject() {
+  private fun layoutSubject(scrolling: Boolean) {
+    require(widthConstraint == Constraint.Fill) {
+      "width wrap not yet implemented"
+    }
+
+    if (heightConstraint == Constraint.Wrap && !scrolling) {
+      val widget = subject.subviews[0] as UIView
+
+      widget.setFrame(CGRectMake(0.0, 0.0, 0.0, 0.0))
+      val wrapSize = widget.sizeThatFits(
+        screenSize.useContents { CGSizeMake(width, UIViewNoIntrinsicMetric) },
+      )
+
+      val frame = wrapSize.useContents { CGRectMake(0.0, 0.0, width, height) }
+      subject.setFrame(frame)
+      widget.setFrame(frame)
+    }
+
     subject.layoutIfNeeded()
   }
 
   companion object {
+    private val screenSize = CGSizeMake(390.0, 844.0) // iPhone 14.
+    private val screenRect = screenSize.useContents { CGRectMake(0.0, 0.0, width, height) }
+
     fun framed(
       callback: UIViewSnapshotCallback,
       widget: UIView,
+      widthConstraint: Constraint = Constraint.Fill,
+      heightConstraint: Constraint = Constraint.Fill,
     ): UIViewSnapshotter {
       val frame = UIView()
         .apply {
-          val screenSize = CGRectMake(0.0, 0.0, 390.0, 844.0) // iPhone 14.
-
           backgroundColor = UIColor.whiteColor
-          setFrame(screenSize)
+          setFrame(screenRect)
 
-          widget.setFrame(screenSize)
+          widget.setFrame(screenRect)
           addSubview(widget)
         }
-      return UIViewSnapshotter(callback, frame)
+      return UIViewSnapshotter(callback, frame, widthConstraint, heightConstraint)
     }
+  }
+
+  enum class Constraint {
+    Fill,
+    Wrap,
   }
 }

--- a/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
+++ b/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
@@ -32,11 +32,11 @@ import platform.UIKit.UIViewNoIntrinsicMetric
  * This either snapshots the view sized to be full-screen, or it uses [heightConstraint] to size the
  * view to whatever height it requires. Scrolling snapshots are always sized to the screen height.
  */
-class UIViewSnapshotter private constructor(
+class UIViewSnapshotter(
   private val callback: UIViewSnapshotCallback,
   private val subject: UIView,
-  private val widthConstraint: Constraint,
-  private val heightConstraint: Constraint,
+  private val widthConstraint: Constraint = Constraint.Fill,
+  private val heightConstraint: Constraint = Constraint.Fill,
 ) : Snapshotter {
 
   override fun snapshot(name: String?, scrolling: Boolean) {

--- a/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
+++ b/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
@@ -82,7 +82,7 @@ class UIViewSnapshotter private constructor(
   }
 
   /** Do layout without taking a snapshot. */
-  private fun layoutSubject(scrolling: Boolean) {
+  fun layoutSubject(scrolling: Boolean = false) {
     require(widthConstraint == Constraint.Fill) {
       "width wrap not yet implemented"
     }

--- a/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewTestWidgetFactory.kt
+++ b/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewTestWidgetFactory.kt
@@ -21,8 +21,10 @@ import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Dp
 import app.cash.redwood.widget.ResizableWidget
 import app.cash.redwood.widget.ResizableWidget.SizeListener
+import kotlin.math.max
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.readValue
+import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
@@ -116,7 +118,20 @@ class UIViewColor :
 class UIViewSimpleColumn : SimpleColumn<UIView> {
   override var modifier: Modifier = Modifier
 
-  override val value = UIStackView(CGRectZero.readValue()).apply {
+  override val value = object : UIStackView(CGRectZero.readValue()) {
+    override fun intrinsicContentSize(): CValue<CGSize> {
+      var totalHeight = 0.0
+      var maxWidth = 0.0
+      for (subview in subviews) {
+        val subviewSize = (subview as UIView).intrinsicContentSize()
+        subviewSize.useContents {
+          totalHeight += height
+          maxWidth = max(maxWidth, width)
+        }
+      }
+      return CGSizeMake(maxWidth, totalHeight)
+    }
+  }.apply {
     this.axis = UILayoutConstraintAxisVertical
     this.alignment = UIStackViewAlignmentFill
     this.distribution = UIStackViewDistributionEqualSpacing

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/LayoutTester.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/LayoutTester.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.redwood.treehouse
 
+import app.cash.redwood.widget.ResizableWidget
 import app.cash.redwood.widget.UIViewChildren
 import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UILayoutConstraintAxisVertical
@@ -60,6 +61,7 @@ class LayoutTester(
   verticalConstraint: Constraint,
 ) {
   private val referenceView = RectangleUIView(60.0, 20.0)
+  private val referenceViewWidget = viewWidget(referenceView)
 
   val top: UIView = RectangleUIView(60.0, 20.0)
 
@@ -69,7 +71,7 @@ class LayoutTester(
 
       Subject.TreehouseView -> TreehouseUIView(emptyWidgetSystem)
         .apply {
-          (this.children as UIViewChildren).insert(0, viewWidget(referenceView))
+          (this.children as UIViewChildren).insert(0, referenceViewWidget)
         }
         .value
     }
@@ -103,11 +105,13 @@ class LayoutTester(
   fun shrinkSubject() {
     referenceView.width = 30.0
     referenceView.height = 10.0
+    (referenceViewWidget as ResizableWidget<*>).sizeListener?.invalidateSize()
   }
 
   fun growSubject() {
     referenceView.width = 90.0
     referenceView.height = 30.0
+    (referenceViewWidget as ResizableWidget<*>).sizeListener?.invalidateSize()
   }
 
   enum class Constraint(

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/UIViews.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/UIViews.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.Modifier
+import app.cash.redwood.widget.ResizableWidget
 import app.cash.redwood.widget.Widget
 import app.cash.redwood.widget.WidgetSystem
 import kotlinx.cinterop.CValue
@@ -26,9 +27,10 @@ import platform.CoreGraphics.CGSize
 import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIView
 
-fun viewWidget(view: UIView): Widget<UIView> = object : Widget<UIView> {
+fun viewWidget(view: UIView): Widget<UIView> = object : Widget<UIView>, ResizableWidget<UIView> {
   override val value: UIView get() = view
   override var modifier: Modifier = Modifier
+  override var sizeListener: ResizableWidget.SizeListener? = null
 }
 
 val emptyWidgetSystem = object : WidgetSystem<UIView> {

--- a/redwood-widget-uiview-test/RedwoodWidgetUIViewTests.xcodeproj/project.pbxproj
+++ b/redwood-widget-uiview-test/RedwoodWidgetUIViewTests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		108501E82CA4B0C3008AAC12 /* UIViewRedwoodViewTestHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108501E72CA4B0C3008AAC12 /* UIViewRedwoodViewTestHost.swift */; };
+		10AB713A2E4D9E5C002C8CD5 /* UIViewRedwoodViewFillWrapTestHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10AB71392E4D9E5C002C8CD5 /* UIViewRedwoodViewFillWrapTestHost.swift */; };
 		CB408CED2AC6549F00E1BA00 /* KotlinHostingXCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB408CEC2AC6549F00E1BA00 /* KotlinHostingXCTestCase.swift */; };
 		CB408CF72AC657EF00E1BA00 /* KotlinHostingXCTestCaseHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CB408CF62AC657EF00E1BA00 /* KotlinHostingXCTestCaseHelper.m */; };
 		CB8A21EF2AC6647F00C104C2 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = CB8A21EE2AC6647F00C104C2 /* SnapshotTesting */; };
@@ -16,6 +17,7 @@
 
 /* Begin PBXFileReference section */
 		108501E72CA4B0C3008AAC12 /* UIViewRedwoodViewTestHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewRedwoodViewTestHost.swift; sourceTree = "<group>"; };
+		10AB71392E4D9E5C002C8CD5 /* UIViewRedwoodViewFillWrapTestHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewRedwoodViewFillWrapTestHost.swift; sourceTree = "<group>"; };
 		63E90CF521FEBBB700449E04 /* RedwoodWidgetUIViewTestKt.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RedwoodWidgetUIViewTestKt.framework; path = "build/xcode-frameworks/RedwoodWidgetUIViewTestKt.framework"; sourceTree = "<group>"; };
 		CB408CE52AC64CEF00E1BA00 /* RedwoodWidgetUIViewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedwoodWidgetUIViewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB408CEC2AC6549F00E1BA00 /* KotlinHostingXCTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinHostingXCTestCase.swift; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 		CB408CE62AC64CEF00E1BA00 /* RedwoodWidgetUIViewTests */ = {
 			isa = PBXGroup;
 			children = (
+				10AB71392E4D9E5C002C8CD5 /* UIViewRedwoodViewFillWrapTestHost.swift */,
 				CB9729D22AD82D0C00804E94 /* SnapshotTestingCallback.swift */,
 				CB408CEC2AC6549F00E1BA00 /* KotlinHostingXCTestCase.swift */,
 				CB408CF62AC657EF00E1BA00 /* KotlinHostingXCTestCaseHelper.m */,
@@ -173,6 +176,7 @@
 			files = (
 				CB408CED2AC6549F00E1BA00 /* KotlinHostingXCTestCase.swift in Sources */,
 				CB408CF72AC657EF00E1BA00 /* KotlinHostingXCTestCaseHelper.m in Sources */,
+				10AB713A2E4D9E5C002C8CD5 /* UIViewRedwoodViewFillWrapTestHost.swift in Sources */,
 				CB9729D32AD82D0C00804E94 /* SnapshotTestingCallback.swift in Sources */,
 				108501E82CA4B0C3008AAC12 /* UIViewRedwoodViewTestHost.swift in Sources */,
 			);

--- a/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/UIViewRedwoodViewFillWrapTestHost.swift
+++ b/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/UIViewRedwoodViewFillWrapTestHost.swift
@@ -1,0 +1,8 @@
+import RedwoodWidgetUIViewTestKt
+import UIKit
+
+final class UIViewRedwoodViewFillWrapTestHost: KotlinHostingXCTestCase<UIViewRedwoodViewFillWrapTest> {
+    override class func initTest(name: String) -> UIViewRedwoodViewFillWrapTest {
+        return UIViewRedwoodViewFillWrapTest(callback: SnapshotTestingCallback(named: name))
+    }
+}

--- a/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testExceedsScreenSize.1.png
+++ b/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testExceedsScreenSize.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9b7b952dc41d9b2fae998cda7338ef3441e4633deab1160abf14ad02a225e0e
+size 68141

--- a/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testExceedsScreenSize._1.png
+++ b/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testExceedsScreenSize._1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7eca4381bcd9fc30536eb2bcb57d7465e6501218c423141d36adc41e029f59e
+size 68807

--- a/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testExceedsScreenSize._2.png
+++ b/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testExceedsScreenSize._2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2023a9195d38536a1dc09c7e8e0b1a8d6dfd09c8bfc6376edfd2394570790d86
+size 68598

--- a/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testSingleChildElement.1.png
+++ b/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testSingleChildElement.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6da41e587b67359ce0f9d5dfbe1ee541a159646d68ad911abcb9115bfe821646
+size 35714

--- a/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testWrapped.1.png
+++ b/redwood-widget-uiview-test/RedwoodWidgetUIViewTests/__Snapshots__/UIViewRedwoodViewFillWrapTestHost/testWrapped.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b11eca15f92c14f0c3220914b92e217eca89c9b53c0043e40ea5ef0cb7436ce0
+size 59948

--- a/redwood-widget-uiview-test/src/commonTest/kotlin/app/cash/redwood/widget/uiview/UIViewRedwoodViewFillWrapTest.kt
+++ b/redwood-widget-uiview-test/src/commonTest/kotlin/app/cash/redwood/widget/uiview/UIViewRedwoodViewFillWrapTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.redwood.widget.uiview
+
+import app.cash.redwood.snapshot.testing.UIViewSnapshotCallback
+import app.cash.redwood.snapshot.testing.UIViewSnapshotter
+import app.cash.redwood.snapshot.testing.UIViewSnapshotter.Constraint.Fill
+import app.cash.redwood.snapshot.testing.UIViewSnapshotter.Constraint.Wrap
+import app.cash.redwood.snapshot.testing.UIViewTestWidgetFactory
+import app.cash.redwood.widget.AbstractRedwoodViewTest
+import app.cash.redwood.widget.RedwoodUIView
+import app.cash.redwood.widget.Widget
+import platform.UIKit.UIView
+
+/**
+ * This is like [UIViewRedwoodViewTest] but it sizes the component differently.
+ *
+ * We had a bug where `RedwoodUIView` incorrectly returned height=0 from [UIView.sizeThatFits]
+ * because its internal [platform.UIKit.UIStackView] didn't implement that operation.
+ */
+class UIViewRedwoodViewFillWrapTest(
+  private val callback: UIViewSnapshotCallback,
+) : AbstractRedwoodViewTest<UIView, RedwoodUIView>() {
+  override val widgetFactory = UIViewTestWidgetFactory
+
+  override fun redwoodView() = RedwoodUIView()
+
+  override fun snapshotter(redwoodView: RedwoodUIView) =
+    UIViewSnapshotter.framed(
+      callback = callback,
+      widget = redwoodView.value,
+      widthConstraint = Fill,
+      heightConstraint = Wrap,
+    )
+
+  override fun snapshotter(widget: Widget<UIView>) =
+    UIViewSnapshotter.framed(
+      callback = callback,
+      widget = widget.value,
+      widthConstraint = Fill,
+      heightConstraint = Wrap,
+    )
+}

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
@@ -26,24 +26,26 @@ import app.cash.redwood.ui.Size
 import app.cash.redwood.ui.UiConfiguration
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.cValue
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import platform.CoreGraphics.CGRect
+import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
+import platform.CoreGraphics.CGSize
+import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIApplication
 import platform.UIKit.UIEdgeInsets
 import platform.UIKit.UIEdgeInsetsZero
-import platform.UIKit.UILayoutConstraintAxisVertical
-import platform.UIKit.UIStackView
-import platform.UIKit.UIStackViewAlignmentFill
-import platform.UIKit.UIStackViewDistributionFillEqually
+import platform.UIKit.UILayoutPriority
 import platform.UIKit.UITraitCollection
 import platform.UIKit.UIUserInterfaceLayoutDirection
 import platform.UIKit.UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirectionLeftToRight
 import platform.UIKit.UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirectionRightToLeft
 import platform.UIKit.UIUserInterfaceStyle
 import platform.UIKit.UIView
+import platform.darwin.NSInteger
 
 @ObjCName("RedwoodUIView", exact = true)
 public open class RedwoodUIView : RedwoodView<UIView> {
@@ -52,7 +54,25 @@ public open class RedwoodUIView : RedwoodView<UIView> {
   override val value: UIView
     get() = valueRootView
 
-  private val _children = UIViewChildren(valueRootView)
+  private val sizeListener = object : ResizableWidget.SizeListener {
+    override fun invalidateSize() {
+      val resized = valueRootView.superview ?: valueRootView
+      resized.setNeedsLayout() // For autolayout.
+      resized.invalidateIntrinsicContentSize() // For SwiftUI.
+    }
+  }
+
+  private val _children = UIViewChildren(
+    container = valueRootView,
+    insert = { index, widget ->
+      if (widget is ResizableWidget<*>) {
+        widget.sizeListener = sizeListener
+      }
+      valueRootView.insertSubview(widget.value, index.convert<NSInteger>())
+    },
+    invalidateSize = sizeListener::invalidateSize,
+  )
+
   override val children: Widget.Children<UIView>
     get() = _children
 
@@ -100,19 +120,15 @@ public open class RedwoodUIView : RedwoodView<UIView> {
    * In practice we expect this to contain either zero child subviews (especially when
    * newly-initialized) or one child subview, which will usually be a layout container.
    *
-   * This could just as easily be a horizontal stack. A box would be even better, but there's no
-   * such built-in component and implementing it manually is difficult if we want to react to
-   * content resizes.
+   * This is a custom layout to best support callers using either SwiftUI (which calls through
+   * [sizeThatFits]) or autolayout (which calls through [intrinsicContentSize]).
    */
-  private inner class RootUIStackView : UIStackView(cValue { CGRectZero }) {
+  private inner class RootUIStackView : UIView(cValue { CGRectZero }) {
     /** Safe area insets specified by the superview. */
     val incomingSafeAreaInsets: CValue<UIEdgeInsets>
       get() = super.safeAreaInsets
 
     init {
-      this.axis = UILayoutConstraintAxisVertical
-      this.alignment = UIStackViewAlignmentFill // Fill horizontal.
-      this.distribution = UIStackViewDistributionFillEqually // Fill vertical.
       this.setInsetsLayoutMarginsFromSafeArea(false) // Consume insets internally.
     }
 
@@ -127,7 +143,57 @@ public open class RedwoodUIView : RedwoodView<UIView> {
       updateUiConfiguration()
     }
 
+    override fun sizeThatFits(size: CValue<CGSize>): CValue<CGSize> {
+      return maxSizeOfSubviews { it.sizeThatFits(size) }
+    }
+
+    override fun systemLayoutSizeFittingSize(targetSize: CValue<CGSize>): CValue<CGSize> {
+      return maxSizeOfSubviews { it.systemLayoutSizeFittingSize(targetSize) }
+    }
+
+    override fun systemLayoutSizeFittingSize(
+      targetSize: CValue<CGSize>,
+      withHorizontalFittingPriority: UILayoutPriority,
+      verticalFittingPriority: UILayoutPriority,
+    ): CValue<CGSize> {
+      return maxSizeOfSubviews {
+        it.systemLayoutSizeFittingSize(
+          targetSize,
+          withHorizontalFittingPriority,
+          verticalFittingPriority,
+        )
+      }
+    }
+
+    override fun intrinsicContentSize(): CValue<CGSize> {
+      return maxSizeOfSubviews { it.intrinsicContentSize() }
+    }
+
+    private fun maxSizeOfSubviews(
+      measure: (UIView) -> CValue<CGSize>,
+    ): CValue<CGSize> {
+      var maxWidth = 0.0
+      var maxHeight = 0.0
+
+      for (subview in subviews) {
+        val subviewSize = measure(subview as UIView)
+        subviewSize.useContents {
+          maxWidth = maxOf(width, maxWidth)
+          maxHeight = maxOf(height, maxHeight)
+        }
+      }
+
+      return CGSizeMake(maxWidth, maxHeight)
+    }
+
     override fun layoutSubviews() {
+      val width = frame.useContents { size.width }
+      val height = frame.useContents { size.height }
+
+      for (subview in subviews) {
+        (subview as UIView).setFrame(CGRectMake(0.0, 0.0, width, height))
+      }
+
       super.layoutSubviews()
 
       // Bounds likely changed. Report new size.

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
@@ -56,9 +56,13 @@ public open class RedwoodUIView : RedwoodView<UIView> {
 
   private val sizeListener = object : ResizableWidget.SizeListener {
     override fun invalidateSize() {
-      val resized = valueRootView.superview ?: valueRootView
-      resized.setNeedsLayout() // For autolayout.
-      resized.invalidateIntrinsicContentSize() // For SwiftUI.
+      // This view's size may have changed.
+      valueRootView.setNeedsLayout() // For autolayout.
+      valueRootView.invalidateIntrinsicContentSize() // For SwiftUI.
+
+      // And the superview should redo its layout also, if it exists.
+      valueRootView.superview?.setNeedsLayout() // For autolayout.
+      valueRootView.superview?.invalidateIntrinsicContentSize() // For SwiftUI.
     }
   }
 


### PR DESCRIPTION
We had delegated to UIStackView which works great if the RedwoodUIView is full screen, but which fails awkwardly if the RedwoodUIView is in a layout that calls through sizeThatFits.

Also fix RedwoodUIView to propagate size changes regardless of which layout system we're using:
 - autolayout, invalidated by setNeedsLayout().
 - SwiftUI, invalidated by invalidateIntrinsicContentSize().

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
