### PR TITLE
Gradle 9.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changed:
 Fixed:
 - Don't measure the height of `RedwoodUIView` as zero when measured with `sizeThatFits()` or `intrinsicContentSize()`. We had been using `UIStackView` which doesn't support these functions.
 - Correctly signal `RedwoodUIView` size changes of to callers who measure it with `intrinsicContentSize()`.
+- The Redwood Gradle plugin is now compatible with Gradle 9.1.
 
 
 ## [0.18.0] - 2025-08-01

--- a/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintTask.kt
+++ b/redwood-gradle-plugin/src/main/kotlin/app/cash/redwood/gradle/RedwoodLintTask.kt
@@ -19,6 +19,7 @@ import java.io.File
 import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
@@ -40,7 +41,7 @@ internal abstract class RedwoodLintTask @Inject constructor(
   abstract val projectDirectoryPath: Property<String>
 
   @get:Input
-  abstract val sourceDirectories: Property<Collection<File>>
+  abstract val sourceDirectories: ListProperty<File>
 
   @get:Classpath
   abstract val classpath: ConfigurableFileCollection
@@ -60,7 +61,7 @@ internal abstract class RedwoodLintTask @Inject constructor(
 private interface RedwoodLintParameters : WorkParameters {
   val toolClasspath: ConfigurableFileCollection
   val projectDirectoryPath: Property<String>
-  val sourceDirectories: Property<Collection<File>>
+  val sourceDirectories: ListProperty<File>
   val classpath: ConfigurableFileCollection
 }
 


### PR DESCRIPTION
From https://github.com/JakeWharton/prerelease-testing/pull/108

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
