### PR TITLE
Fix missing calls to UIViewBox.setNeedsLayout()

### DIFF
--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v1.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40c4dd0b417ace141bbf261c490670827dc4b2bdc3a09d4de6f21d84f8f571b6
+size 4413

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v2.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a53a7092c73d762a96ea8137c2cd61adb095df0f87f1705c8f8476ed5593a6dc
+size 4401

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutUpdatesWithoutSizeChanges_v1.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutUpdatesWithoutSizeChanges_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:313b1e80befad415ae8affa65de4522d96756fa103961abe5550b7e5c2774557
+size 4129

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutUpdatesWithoutSizeChanges_v2.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiBoxTest_testLayoutUpdatesWithoutSizeChanges_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63acbe4c00f3201f1c97e7cd5dae450cc713f9c289da24da4c15c38dd5f3285d
+size 4104

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
@@ -391,6 +391,34 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
+  fun testLayoutUpdatesWithoutSizeChanges() {
+    val container = widgetFactory.column()
+    val snapshotter = snapshotter(container.value)
+
+    val box = box()
+      .apply {
+        width(Constraint.Fill)
+        height(Constraint.Fill)
+      }
+    container.add(box.value)
+
+    widgetFactory.color().apply {
+      width(100.dp)
+      height(100.dp)
+      color(Blue)
+      modifier = Modifier
+        .then(VerticalAlignmentImpl(CrossAxisAlignment.Start))
+        .then(HorizontalAlignmentImpl(CrossAxisAlignment.Start))
+    }.also { box.children.insert(0, it) }
+
+    box.margin(Margin(start = 10.dp, end = 20.dp))
+    snapshotter.snapshot("v1")
+
+    box.margin(Margin(start = 20.dp, end = 10.dp))
+    snapshotter.snapshot("v2")
+  }
+
+  @Test
   fun testChildExplicitHeight() {
     val container = box()
       .apply {

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testLayoutUpdatesWithoutSizeChanges.v1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testLayoutUpdatesWithoutSizeChanges.v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db3fa0098718c0885119538d68def43060b85c818984f7930b41ebf28ebddb4b
+size 69853

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testLayoutUpdatesWithoutSizeChanges.v2.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewBoxTestHost/testLayoutUpdatesWithoutSizeChanges.v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abf5454bbc3dd9b1b675699d15aac4934289fd0d0e69b6640cfc1572d7d04880
+size 69953

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -110,12 +110,8 @@ internal class UIViewBox :
     )
 
     fun invalidateSize() {
-      val sizeListener = sizeListener
-      if (sizeListener != null) {
-        sizeListener.invalidateSize()
-      } else {
-        setNeedsLayout() // Update layout of subviews.
-      }
+      setNeedsLayout() // Update layout of subviews.
+      sizeListener?.invalidateSize()
     }
 
     override fun intrinsicContentSize() =

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6211e0651da348e2ab1b27aa860ba6a76d22da2864380d99c30f11de2982f84c
+size 4162

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v2.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_RTL_testLayoutUpdatesWithoutSizeChanges_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faa33afdac4b9dd81b6fa6ef834c4a31d0861d8f7a489c665784f968f9ff6190
+size 4169

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutUpdatesWithoutSizeChanges_v1.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutUpdatesWithoutSizeChanges_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d46b92747ef5ec7342e6bdbcb7a3bbda75ac02c7b9fce9ea44081b3811ddf06
+size 4118

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutUpdatesWithoutSizeChanges_v2.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewBoxTest_testLayoutUpdatesWithoutSizeChanges_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:168511de895174e6a0dd25568d653dc13a669e5d022a632b1dc22758dccbd45a
+size 4184


### PR DESCRIPTION
In my previous PR I introduced a regression by adding a SizeListener to the root UIViewBox in a layout. This caused the UIViewBox.invalidateSize() function to stop calling its setNeedsLayout() function, which it needs to do when its size is invalidated.
