### PR TITLE
Re-add missing `exact=true` on an `ObjCName `annotation

### DIFF
--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
@@ -220,7 +220,7 @@ internal fun generateWidgetFactory(schema: Schema): FileSpec {
       TypeSpec.interfaceBuilder(widgetFactoryType)
         .addTypeVariable(typeVariableW)
         .optIn(Stdlib.ExperimentalObjCName)
-        .objcName(widgetFactoryType.simpleName)
+        .objcName(widgetFactoryType.simpleName, exact = true)
         .maybeAddKDoc(schema.documentation)
         .apply {
           for (widget in schema.widgets) {


### PR DESCRIPTION
Whooooops

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
