### PR TITLE
New API, Widget.allChildren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Unreleased]: https://github.com/cashapp/redwood/compare/0.18.0...HEAD
 
 New:
-- Nothing yet!
+- Widget has a new `allChildren` property that returns all child widgets for general tree-traversal.
 
 Changed:
 - Nothing yet!

--- a/build-support/src/main/resources/app/cash/redwood/buildsupport/flexboxHelpers.kt
+++ b/build-support/src/main/resources/app/cash/redwood/buildsupport/flexboxHelpers.kt
@@ -31,6 +31,7 @@ import app.cash.redwood.layout.widget.Column
 import app.cash.redwood.layout.widget.Row
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
+import app.cash.redwood.widget.Widget
 import app.cash.redwood.yoga.AlignItems
 import app.cash.redwood.yoga.AlignSelf
 import app.cash.redwood.yoga.JustifyContent
@@ -41,6 +42,8 @@ internal interface YogaFlexContainer<W : Any> :
   Row<W> {
   val rootNode: Node
   val density: Density
+
+  abstract override val allChildren: List<Widget.Children<W>>
 
   override fun margin(margin: Margin) {
     with(rootNode) {

--- a/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChildrenNodeIndexTest.kt
+++ b/redwood-compose/src/commonTest/kotlin/app/cash/redwood/compose/ChildrenNodeIndexTest.kt
@@ -123,6 +123,7 @@ class ChildrenNodeIndexTest {
 
 private class StringWidget(override val value: String) : Widget<String> {
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<String>> get() = listOf()
 }
 
 @OptIn(RedwoodCodegenApi::class)

--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -32,6 +32,7 @@ import app.cash.redwood.layout.widget.Spacer
 import app.cash.redwood.snapshot.testing.ComposeSnapshotter
 import app.cash.redwood.snapshot.testing.ComposeUiTestWidgetFactory
 import app.cash.redwood.ui.Px
+import app.cash.redwood.widget.Widget
 import app.cash.redwood.yoga.FlexDirection
 import com.android.resources.LayoutDirection
 import kotlinx.coroutines.runBlocking
@@ -92,6 +93,8 @@ class ComposeUiFlexContainerTest(
 
     override val value get() = delegate.value
     override var modifier by delegate::modifier
+    override val allChildren: List<Widget.Children<@Composable ((Modifier) -> Unit)>>
+      get() = listOf(children)
 
     override val children get() = delegate.children
 

--- a/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainer.kt
+++ b/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainer.kt
@@ -51,6 +51,7 @@ import app.cash.redwood.layout.widget.Row
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.Px
+import app.cash.redwood.widget.Widget
 import app.cash.redwood.widget.compose.ComposeWidgetChildren
 import app.cash.redwood.yoga.Direction
 import app.cash.redwood.yoga.FlexDirection
@@ -98,6 +99,8 @@ internal class ComposeUiFlexContainer(
   }
   override val children = ComposeWidgetChildren()
   override var modifier: RedwoodModifier = RedwoodModifier
+  override val allChildren: List<Widget.Children<@Composable ((Modifier) -> Unit)>>
+    get() = listOf(children)
 
   private var recomposeTick by mutableIntStateOf(0)
   private var width by mutableStateOf(Constraint.Wrap)

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -30,6 +30,7 @@ import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.ResizableWidget
 import app.cash.redwood.widget.ResizableWidget.SizeListener
 import app.cash.redwood.widget.UIViewChildren
+import app.cash.redwood.widget.Widget
 import app.cash.redwood.yoga.FlexDirection
 import app.cash.redwood.yoga.Node
 import kotlinx.cinterop.convert
@@ -90,6 +91,8 @@ internal class UIViewFlexContainer(
 
   override val value: UIView get() = yogaView
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<UIView>>
+    get() = listOf(children)
 
   override val children: UIViewChildren = UIViewChildren(
     container = value,

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
@@ -136,6 +136,8 @@ class UIViewFlexContainerTest(
     val widget = object : ResizableWidget<UIView> {
       override val value = view
       override var modifier: Modifier = Modifier
+      override val allChildren: List<Widget.Children<UIView>>
+        get() = listOf()
       override var sizeListener: SizeListener? = null
     }
 

--- a/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
+++ b/redwood-layout-view/src/main/kotlin/app/cash/redwood/layout/view/ViewFlexContainer.kt
@@ -37,6 +37,7 @@ import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.Px
 import app.cash.redwood.widget.ChangeListener
 import app.cash.redwood.widget.ViewGroupChildren
+import app.cash.redwood.widget.Widget
 import app.cash.redwood.yoga.Direction
 import app.cash.redwood.yoga.FlexDirection
 import app.cash.redwood.yoga.Node
@@ -121,6 +122,8 @@ internal class ViewFlexContainer(
   internal var onScroll: ((Px) -> Unit)? = null
 
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<View>>
+    get() = listOf(children)
 
   init {
     yogaLayout.rootNode.direction = when (hostView.resources.configuration.layoutDirection) {

--- a/redwood-layout-widget/api/redwood-layout-widget.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.api
@@ -1,4 +1,5 @@
 public abstract interface class app/cash/redwood/layout/widget/Box : app/cash/redwood/widget/Widget {
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun height-DyLkt4w (I)V
 	public abstract fun horizontalAlignment-njEs0f8 (I)V
@@ -8,6 +9,7 @@ public abstract interface class app/cash/redwood/layout/widget/Box : app/cash/re
 }
 
 public abstract interface class app/cash/redwood/layout/widget/Column : app/cash/redwood/widget/Widget {
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun height-DyLkt4w (I)V
 	public abstract fun horizontalAlignment-njEs0f8 (I)V
@@ -37,6 +39,7 @@ public final class app/cash/redwood/layout/widget/RedwoodLayoutWidgetSystem$Comp
 }
 
 public abstract interface class app/cash/redwood/layout/widget/Row : app/cash/redwood/widget/Widget {
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun getChildren ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun height-DyLkt4w (I)V
 	public abstract fun horizontalAlignment-6exqka8 (I)V
@@ -48,6 +51,7 @@ public abstract interface class app/cash/redwood/layout/widget/Row : app/cash/re
 }
 
 public abstract interface class app/cash/redwood/layout/widget/Spacer : app/cash/redwood/widget/Widget {
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun height-mnpKzHI (D)V
 	public abstract fun width-mnpKzHI (D)V
 }

--- a/redwood-layout-widget/api/redwood-layout-widget.klib.api
+++ b/redwood-layout-widget/api/redwood-layout-widget.klib.api
@@ -9,6 +9,8 @@
 abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/Box : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.layout.widget/Box|null[0]
     abstract val children // app.cash.redwood.layout.widget/Box.children|{}children[0]
         abstract fun <get-children>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.layout.widget/Box.children.<get-children>|<get-children>(){}[0]
+    open val allChildren // app.cash.redwood.layout.widget/Box.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.layout.widget/Box.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
 
     abstract fun height(app.cash.redwood.layout.api/Constraint) // app.cash.redwood.layout.widget/Box.height|height(app.cash.redwood.layout.api.Constraint){}[0]
     abstract fun horizontalAlignment(app.cash.redwood.layout.api/CrossAxisAlignment) // app.cash.redwood.layout.widget/Box.horizontalAlignment|horizontalAlignment(app.cash.redwood.layout.api.CrossAxisAlignment){}[0]
@@ -20,6 +22,8 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/Box : app.cas
 abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/Column : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.layout.widget/Column|null[0]
     abstract val children // app.cash.redwood.layout.widget/Column.children|{}children[0]
         abstract fun <get-children>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.layout.widget/Column.children.<get-children>|<get-children>(){}[0]
+    open val allChildren // app.cash.redwood.layout.widget/Column.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.layout.widget/Column.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
 
     abstract fun height(app.cash.redwood.layout.api/Constraint) // app.cash.redwood.layout.widget/Column.height|height(app.cash.redwood.layout.api.Constraint){}[0]
     abstract fun horizontalAlignment(app.cash.redwood.layout.api/CrossAxisAlignment) // app.cash.redwood.layout.widget/Column.horizontalAlignment|horizontalAlignment(app.cash.redwood.layout.api.CrossAxisAlignment){}[0]
@@ -40,6 +44,8 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/RedwoodLayout
 abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/Row : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.layout.widget/Row|null[0]
     abstract val children // app.cash.redwood.layout.widget/Row.children|{}children[0]
         abstract fun <get-children>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.layout.widget/Row.children.<get-children>|<get-children>(){}[0]
+    open val allChildren // app.cash.redwood.layout.widget/Row.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.layout.widget/Row.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
 
     abstract fun height(app.cash.redwood.layout.api/Constraint) // app.cash.redwood.layout.widget/Row.height|height(app.cash.redwood.layout.api.Constraint){}[0]
     abstract fun horizontalAlignment(app.cash.redwood.layout.api/MainAxisAlignment) // app.cash.redwood.layout.widget/Row.horizontalAlignment|horizontalAlignment(app.cash.redwood.layout.api.MainAxisAlignment){}[0]
@@ -51,6 +57,9 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/Row : app.cas
 }
 
 abstract interface <#A: kotlin/Any> app.cash.redwood.layout.widget/Spacer : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.layout.widget/Spacer|null[0]
+    open val allChildren // app.cash.redwood.layout.widget/Spacer.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.layout.widget/Spacer.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
+
     abstract fun height(app.cash.redwood.ui/Dp) // app.cash.redwood.layout.widget/Spacer.height|height(app.cash.redwood.ui.Dp){}[0]
     abstract fun width(app.cash.redwood.ui/Dp) // app.cash.redwood.layout.widget/Spacer.width|width(app.cash.redwood.ui.Dp){}[0]
 }

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.api
@@ -1,5 +1,6 @@
 public abstract interface class app/cash/redwood/lazylayout/widget/LazyList : app/cash/redwood/widget/Widget {
 	public abstract fun crossAxisAlignment-njEs0f8 (I)V
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun getItems ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun getPlaceholder ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun height-DyLkt4w (I)V
@@ -69,6 +70,7 @@ public final class app/cash/redwood/lazylayout/widget/RedwoodLazyLayoutWidgetSys
 
 public abstract interface class app/cash/redwood/lazylayout/widget/RefreshableLazyList : app/cash/redwood/widget/Widget {
 	public abstract fun crossAxisAlignment-njEs0f8 (I)V
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun getItems ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun getPlaceholder ()Lapp/cash/redwood/widget/Widget$Children;
 	public abstract fun height-DyLkt4w (I)V

--- a/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
+++ b/redwood-lazylayout-widget/api/redwood-lazylayout-widget.klib.api
@@ -11,6 +11,8 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.lazylayout.widget/LazyList 
         abstract fun <get-items>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.lazylayout.widget/LazyList.items.<get-items>|<get-items>(){}[0]
     abstract val placeholder // app.cash.redwood.lazylayout.widget/LazyList.placeholder|{}placeholder[0]
         abstract fun <get-placeholder>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.lazylayout.widget/LazyList.placeholder.<get-placeholder>|<get-placeholder>(){}[0]
+    open val allChildren // app.cash.redwood.lazylayout.widget/LazyList.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.lazylayout.widget/LazyList.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
 
     abstract fun crossAxisAlignment(app.cash.redwood.layout.api/CrossAxisAlignment) // app.cash.redwood.lazylayout.widget/LazyList.crossAxisAlignment|crossAxisAlignment(app.cash.redwood.layout.api.CrossAxisAlignment){}[0]
     abstract fun height(app.cash.redwood.layout.api/Constraint) // app.cash.redwood.lazylayout.widget/LazyList.height|height(app.cash.redwood.layout.api.Constraint){}[0]
@@ -33,6 +35,8 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.lazylayout.widget/Refreshab
         abstract fun <get-items>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.lazylayout.widget/RefreshableLazyList.items.<get-items>|<get-items>(){}[0]
     abstract val placeholder // app.cash.redwood.lazylayout.widget/RefreshableLazyList.placeholder|{}placeholder[0]
         abstract fun <get-placeholder>(): app.cash.redwood.widget/Widget.Children<#A> // app.cash.redwood.lazylayout.widget/RefreshableLazyList.placeholder.<get-placeholder>|<get-placeholder>(){}[0]
+    open val allChildren // app.cash.redwood.lazylayout.widget/RefreshableLazyList.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.lazylayout.widget/RefreshableLazyList.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
 
     abstract fun crossAxisAlignment(app.cash.redwood.layout.api/CrossAxisAlignment) // app.cash.redwood.lazylayout.widget/RefreshableLazyList.crossAxisAlignment|crossAxisAlignment(app.cash.redwood.layout.api.CrossAxisAlignment){}[0]
     abstract fun height(app.cash.redwood.layout.api/Constraint) // app.cash.redwood.lazylayout.widget/RefreshableLazyList.height|height(app.cash.redwood.layout.api.Constraint){}[0]

--- a/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
+++ b/redwood-lazylayout-widget/src/commonMain/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessor.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.lazylayout.widget
 
 import app.cash.redwood.Modifier
 import app.cash.redwood.widget.Widget
+import app.cash.redwood.widget.Widget.Children
 
 /**
  * Our lazy layouts can display arbitrarily large datasets. Instead of loading them all eagerly
@@ -541,5 +542,8 @@ public abstract class LazyListUpdateProcessor<V : Any, W : Any> {
   private class SizeOnlyPlaceholderWidget<W : Any>(
     override val value: W,
     override var modifier: Modifier,
-  ) : Widget<W>
+  ) : Widget<W> {
+    override val allChildren: List<Children<W>>
+      get() = listOf()
+  }
 }

--- a/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
+++ b/redwood-lazylayout-widget/src/commonTest/kotlin/app/cash/redwood/lazylayout/widget/LazyListUpdateProcessorTest.kt
@@ -654,6 +654,8 @@ class LazyListUpdateProcessorTest {
     val widget = object : Widget<StringContent> {
       override val value = content
       override var modifier: Modifier = Modifier
+      override val allChildren: List<Widget.Children<StringContent>>
+        get() = listOf()
     }
     insert(index, widget)
   }

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -420,6 +420,9 @@ private class RootProtocolNode<W : Any>(
       throw AssertionError()
     }
 
+  override val allChildren: List<Widget.Children<W>>
+    get() = listOf(children.children)
+
   override fun detach() {
     // Do nothing because 'children' is owned by the host's RedwoodView.
   }

--- a/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ChildrenNodeIndexTest.kt
+++ b/redwood-protocol-host/src/commonTest/kotlin/app/cash/redwood/protocol/host/ChildrenNodeIndexTest.kt
@@ -143,4 +143,6 @@ private class WidgetNode(override val widget: StringWidget) : ProtocolNode<Strin
 
 private class StringWidget(override val value: String) : Widget<String> {
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<String>>
+    get() = listOf()
 }

--- a/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/Color.kt
+++ b/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/Color.kt
@@ -19,6 +19,8 @@ import app.cash.redwood.ui.Dp
 import app.cash.redwood.widget.Widget
 
 interface Color<W : Any> : Widget<W> {
+  override val allChildren: List<Widget.Children<W>>
+    get() = listOf()
   fun width(width: Dp)
   fun height(height: Dp)
   fun color(color: Int)

--- a/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/ScrollWrapper.kt
+++ b/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/ScrollWrapper.kt
@@ -21,5 +21,7 @@ import app.cash.redwood.widget.Widget
  * Wraps a widget in a container that scrolls vertically.
  */
 interface ScrollWrapper<W : Any> : Widget<W> {
+  override val allChildren: List<Widget.Children<W>>
+    get() = listOf()
   var content: W?
 }

--- a/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/SimpleColumn.kt
+++ b/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/SimpleColumn.kt
@@ -21,5 +21,7 @@ import app.cash.redwood.widget.Widget
  * Delegates to the host platform's column-like layout without any other capabilities.
  */
 interface SimpleColumn<W : Any> : Widget<W> {
+  override val allChildren: List<Widget.Children<W>>
+    get() = listOf()
   fun add(child: W)
 }

--- a/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/Text.kt
+++ b/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/Text.kt
@@ -25,6 +25,8 @@ import app.cash.redwood.widget.Widget
  * The text is centered vertically.
  */
 interface Text<W : Any> : Widget<W> {
+  override val allChildren: List<Widget.Children<W>>
+    get() = listOf()
   val measureCount: Int
   fun text(text: String)
   fun bgColor(color: Int)

--- a/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
+++ b/redwood-tooling-codegen/src/main/kotlin/app/cash/redwood/tooling/codegen/widgetGeneration.kt
@@ -283,6 +283,26 @@ internal fun generateWidget(schema: Schema, widget: Widget): FileSpec {
             addKdoc("{tag=${widget.tag}}")
           }
 
+          addProperty(
+            PropertySpec.builder(
+              "allChildren",
+              Stdlib.List.parameterizedBy(RedwoodWidget.WidgetChildrenOfW),
+            )
+              .addModifiers(OVERRIDE)
+              .getter(
+                FunSpec.getterBuilder()
+                  .addCode("return %M(⇥\n", Stdlib.listOf)
+                  .apply {
+                    for (trait in widget.traits.filterIsInstance<Children>()) {
+                      addCode("%N,\n", trait.name)
+                    }
+                  }
+                  .addCode("⇤)")
+                  .build(),
+              )
+              .build(),
+          )
+
           for (trait in widget.traits) {
             when (trait) {
               is Property -> {

--- a/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/EmptyDynamicContentWidgetFactory.kt
+++ b/redwood-treehouse-host-composeui/src/commonMain/kotlin/app/cash/redwood/treehouse/composeui/EmptyDynamicContentWidgetFactory.kt
@@ -21,6 +21,7 @@ import app.cash.redwood.Modifier as RedwoodModifier
 import app.cash.redwood.treehouse.Crashed
 import app.cash.redwood.treehouse.DynamicContentWidgetFactory
 import app.cash.redwood.treehouse.Loading
+import app.cash.redwood.widget.Widget
 
 /** Don't show anything for loading or error screens. */
 internal object EmptyDynamicContentWidgetFactory :
@@ -31,12 +32,16 @@ internal object EmptyDynamicContentWidgetFactory :
 
   internal class EmptyLoading : Loading<@Composable (Modifier) -> Unit> {
     override var modifier: RedwoodModifier = RedwoodModifier
+    override val allChildren: List<Widget.Children<@Composable ((Modifier) -> Unit)>>
+      get() = listOf()
     override val value: @Composable (Modifier) -> Unit = {
     }
   }
 
   internal class EmptyCrashed : Crashed<@Composable (Modifier) -> Unit> {
     override var modifier: RedwoodModifier = RedwoodModifier
+    override val allChildren: List<Widget.Children<@Composable ((Modifier) -> Unit)>>
+      get() = listOf()
     override val value: @Composable (Modifier) -> Unit = {
     }
 

--- a/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/EmptyDynamicContentWidgetFactory.kt
+++ b/redwood-treehouse-host/src/androidMain/kotlin/app/cash/redwood/treehouse/EmptyDynamicContentWidgetFactory.kt
@@ -18,6 +18,7 @@ package app.cash.redwood.treehouse
 import android.content.Context
 import android.view.View
 import app.cash.redwood.Modifier
+import app.cash.redwood.widget.Widget
 
 internal class EmptyDynamicContentWidgetFactory(
   private val context: Context,
@@ -29,11 +30,15 @@ internal class EmptyDynamicContentWidgetFactory(
   class EmptyLoading(context: Context) : Loading<View> {
     override val value = View(context)
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<View>>
+      get() = listOf()
   }
 
   class EmptyCrashed(context: Context) : Crashed<View> {
     override val value = View(context)
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<View>>
+      get() = listOf()
 
     override fun uncaughtException(uncaughtException: Throwable) {
     }

--- a/redwood-treehouse-host/src/androidUnitTest/kotlin/app/cash/redwood/treehouse/TreehouseLayoutTest.kt
+++ b/redwood-treehouse-host/src/androidUnitTest/kotlin/app/cash/redwood/treehouse/TreehouseLayoutTest.kt
@@ -138,6 +138,7 @@ class TreehouseLayoutTest {
     override val value: View,
   ) : Widget<View> {
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<View>> get() = listOf()
   }
 
   private val emptyWidgetSystem = object : WidgetSystem<View> {

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeDynamicContentWidgetFactory.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeDynamicContentWidgetFactory.kt
@@ -17,6 +17,7 @@ package app.cash.redwood.treehouse
 
 import app.cash.redwood.Modifier
 import app.cash.redwood.testing.WidgetValue
+import app.cash.redwood.widget.Widget
 import app.cash.redwood.widget.WidgetSystem
 
 class FakeDynamicContentWidgetFactory : DynamicContentWidgetFactory<WidgetValue> {
@@ -26,6 +27,7 @@ class FakeDynamicContentWidgetFactory : DynamicContentWidgetFactory<WidgetValue>
   private class FakeLoading : Loading<WidgetValue> {
     override val value: WidgetValue = LoadingValue
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<WidgetValue>> get() = listOf()
   }
 
   private data object LoadingValue : WidgetValue {
@@ -37,6 +39,7 @@ class FakeDynamicContentWidgetFactory : DynamicContentWidgetFactory<WidgetValue>
   private class FakeCrashed : Crashed<WidgetValue> {
     private lateinit var uncaughtException: Throwable
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<WidgetValue>> get() = listOf()
     override val value: WidgetValue
       get() = CrashedValue(uncaughtException)
 

--- a/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeWidget.kt
+++ b/redwood-treehouse-host/src/commonTest/kotlin/app/cash/redwood/treehouse/FakeWidget.kt
@@ -21,8 +21,8 @@ import app.cash.redwood.widget.Widget
 class FakeWidget : Widget<FakeWidget> {
   override val value: FakeWidget
     get() = this
-
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<FakeWidget>> get() = listOf()
 
   var label: String? = null
   var onClick: (() -> Unit)? = null

--- a/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/EmptyDynamicContentWidgetFactory.kt
+++ b/redwood-treehouse-host/src/iosMain/kotlin/app/cash/redwood/treehouse/EmptyDynamicContentWidgetFactory.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.treehouse
 
 import app.cash.redwood.Modifier
+import app.cash.redwood.widget.Widget
 import kotlinx.cinterop.cValue
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIView
@@ -28,11 +29,15 @@ internal class EmptyDynamicContentWidgetFactory : DynamicContentWidgetFactory<UI
   class EmptyLoading : Loading<UIView> {
     override val value: UIView = UIView(cValue { CGRectZero })
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<UIView>>
+      get() = listOf()
   }
 
   class EmptyCrashed : Crashed<UIView> {
     override val value: UIView = UIView(cValue { CGRectZero })
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<UIView>>
+      get() = listOf()
     override fun uncaughtException(uncaughtException: Throwable) {
     }
 

--- a/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/UIViews.kt
+++ b/redwood-treehouse-host/src/iosTest/kotlin/app/cash/redwood/treehouse/UIViews.kt
@@ -30,6 +30,8 @@ import platform.UIKit.UIView
 fun viewWidget(view: UIView): Widget<UIView> = object : Widget<UIView>, ResizableWidget<UIView> {
   override val value: UIView get() = view
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<UIView>>
+    get() = listOf()
   override var sizeListener: ResizableWidget.SizeListener? = null
 }
 

--- a/redwood-ui-basic-widget/api/redwood-ui-basic-widget.api
+++ b/redwood-ui-basic-widget/api/redwood-ui-basic-widget.api
@@ -1,10 +1,12 @@
 public abstract interface class app/cash/redwood/ui/basic/widget/Button : app/cash/redwood/widget/Widget {
 	public abstract fun enabled (Z)V
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun onClick (Lkotlin/jvm/functions/Function0;)V
 	public abstract fun text (Ljava/lang/String;)V
 }
 
 public abstract interface class app/cash/redwood/ui/basic/widget/Image : app/cash/redwood/widget/Widget {
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun onClick (Lkotlin/jvm/functions/Function0;)V
 	public abstract fun url (Ljava/lang/String;)V
 }
@@ -31,10 +33,12 @@ public final class app/cash/redwood/ui/basic/widget/RedwoodUiBasicWidgetSystem$C
 }
 
 public abstract interface class app/cash/redwood/ui/basic/widget/Text : app/cash/redwood/widget/Widget {
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun text (Ljava/lang/String;)V
 }
 
 public abstract interface class app/cash/redwood/ui/basic/widget/TextInput : app/cash/redwood/widget/Widget {
+	public fun getAllChildren ()Ljava/util/List;
 	public abstract fun hint (Ljava/lang/String;)V
 	public abstract fun onChange (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun state (Lapp/cash/redwood/ui/basic/api/TextFieldState;)V

--- a/redwood-ui-basic-widget/api/redwood-ui-basic-widget.klib.api
+++ b/redwood-ui-basic-widget/api/redwood-ui-basic-widget.klib.api
@@ -7,12 +7,18 @@
 
 // Library unique name: <app.cash.redwood:redwood-ui-basic-widget>
 abstract interface <#A: kotlin/Any> app.cash.redwood.ui.basic.widget/Button : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.ui.basic.widget/Button|null[0]
+    open val allChildren // app.cash.redwood.ui.basic.widget/Button.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.ui.basic.widget/Button.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
+
     abstract fun enabled(kotlin/Boolean) // app.cash.redwood.ui.basic.widget/Button.enabled|enabled(kotlin.Boolean){}[0]
     abstract fun onClick(kotlin/Function0<kotlin/Unit>?) // app.cash.redwood.ui.basic.widget/Button.onClick|onClick(kotlin.Function0<kotlin.Unit>?){}[0]
     abstract fun text(kotlin/String?) // app.cash.redwood.ui.basic.widget/Button.text|text(kotlin.String?){}[0]
 }
 
 abstract interface <#A: kotlin/Any> app.cash.redwood.ui.basic.widget/Image : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.ui.basic.widget/Image|null[0]
+    open val allChildren // app.cash.redwood.ui.basic.widget/Image.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.ui.basic.widget/Image.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
+
     abstract fun onClick(kotlin/Function0<kotlin/Unit>?) // app.cash.redwood.ui.basic.widget/Image.onClick|onClick(kotlin.Function0<kotlin.Unit>?){}[0]
     abstract fun url(kotlin/String) // app.cash.redwood.ui.basic.widget/Image.url|url(kotlin.String){}[0]
 }
@@ -26,10 +32,16 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.ui.basic.widget/RedwoodUiBa
 }
 
 abstract interface <#A: kotlin/Any> app.cash.redwood.ui.basic.widget/Text : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.ui.basic.widget/Text|null[0]
+    open val allChildren // app.cash.redwood.ui.basic.widget/Text.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.ui.basic.widget/Text.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
+
     abstract fun text(kotlin/String) // app.cash.redwood.ui.basic.widget/Text.text|text(kotlin.String){}[0]
 }
 
 abstract interface <#A: kotlin/Any> app.cash.redwood.ui.basic.widget/TextInput : app.cash.redwood.widget/Widget<#A> { // app.cash.redwood.ui.basic.widget/TextInput|null[0]
+    open val allChildren // app.cash.redwood.ui.basic.widget/TextInput.allChildren|{}allChildren[0]
+        open fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.ui.basic.widget/TextInput.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
+
     abstract fun hint(kotlin/String) // app.cash.redwood.ui.basic.widget/TextInput.hint|hint(kotlin.String){}[0]
     abstract fun onChange(kotlin/Function1<app.cash.redwood.ui.basic.api/TextFieldState, kotlin/Unit>?) // app.cash.redwood.ui.basic.widget/TextInput.onChange|onChange(kotlin.Function1<app.cash.redwood.ui.basic.api.TextFieldState,kotlin.Unit>?){}[0]
     abstract fun state(app.cash.redwood.ui.basic.api/TextFieldState) // app.cash.redwood.ui.basic.widget/TextInput.state|state(app.cash.redwood.ui.basic.api.TextFieldState){}[0]

--- a/redwood-widget-testing/src/commonMain/kotlin/app/cash/redwood/widget/testing/AbstractWidgetChildrenTest.kt
+++ b/redwood-widget-testing/src/commonMain/kotlin/app/cash/redwood/widget/testing/AbstractWidgetChildrenTest.kt
@@ -191,6 +191,8 @@ public abstract class AbstractWidgetChildrenTest<W : Any> {
       widget = object : Widget<W> {
         override val value: W = widget(name)
         override var modifier: Modifier = Modifier
+        override val allChildren: List<Widget.Children<W>>
+          get() = listOf()
       },
     )
   }

--- a/redwood-widget/api/android/redwood-widget.api
+++ b/redwood-widget/api/android/redwood-widget.api
@@ -88,6 +88,7 @@ public final class app/cash/redwood/widget/ViewGroupChildren : app/cash/redwood/
 }
 
 public abstract interface class app/cash/redwood/widget/Widget {
+	public abstract fun getAllChildren ()Ljava/util/List;
 	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
 	public abstract fun getValue ()Ljava/lang/Object;
 	public abstract fun setModifier (Lapp/cash/redwood/Modifier;)V

--- a/redwood-widget/api/jvm/redwood-widget.api
+++ b/redwood-widget/api/jvm/redwood-widget.api
@@ -64,6 +64,7 @@ public abstract interface class app/cash/redwood/widget/SavedStateRegistry {
 }
 
 public abstract interface class app/cash/redwood/widget/Widget {
+	public abstract fun getAllChildren ()Ljava/util/List;
 	public abstract fun getModifier ()Lapp/cash/redwood/Modifier;
 	public abstract fun getValue ()Ljava/lang/Object;
 	public abstract fun setModifier (Lapp/cash/redwood/Modifier;)V

--- a/redwood-widget/api/redwood-widget.klib.api
+++ b/redwood-widget/api/redwood-widget.klib.api
@@ -21,6 +21,8 @@ abstract interface <#A: kotlin/Any> app.cash.redwood.widget/RedwoodView { // app
 }
 
 abstract interface <#A: kotlin/Any> app.cash.redwood.widget/Widget { // app.cash.redwood.widget/Widget|null[0]
+    abstract val allChildren // app.cash.redwood.widget/Widget.allChildren|{}allChildren[0]
+        abstract fun <get-allChildren>(): kotlin.collections/List<app.cash.redwood.widget/Widget.Children<#A>> // app.cash.redwood.widget/Widget.allChildren.<get-allChildren>|<get-allChildren>(){}[0]
     abstract val value // app.cash.redwood.widget/Widget.value|{}value[0]
         abstract fun <get-value>(): #A // app.cash.redwood.widget/Widget.value.<get-value>|<get-value>(){}[0]
 

--- a/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
+++ b/redwood-widget/src/commonMain/kotlin/app/cash/redwood/widget/Widget.kt
@@ -39,6 +39,13 @@ public interface Widget<W : Any> {
   public var modifier: Modifier
 
   /**
+   * Returns all of the [Children] lists owned by this widget. The returned list will be empty if
+   * this widget does not support children. Otherwise each element in the list is a distinct slot
+   * for child widgets. The returned [Children] instances are live instances.
+   */
+  public val allChildren: List<Children<W>>
+
+  /**
    * An interface for manipulating a widget's list of children.
    *
    * Arguments to these methods can be assumed to be validated against the current state of the

--- a/redwood-widget/src/iosTest/kotlin/app/cash/redwood/widget/RedwoodUIViewTest.kt
+++ b/redwood-widget/src/iosTest/kotlin/app/cash/redwood/widget/RedwoodUIViewTest.kt
@@ -86,6 +86,8 @@ class RedwoodUIViewTest {
     override val value: UIView,
   ) : Widget<UIView> {
     override var modifier: Modifier = Modifier
+    override val allChildren: List<Widget.Children<UIView>>
+      get() = listOf()
   }
 
   /** Override [safeAreaInsets] to propagate a test value to subviews on the next layout. */

--- a/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchComposeUiRoot.kt
+++ b/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchComposeUiRoot.kt
@@ -28,6 +28,7 @@ import app.cash.redwood.Modifier as RedwoodModifier
 import app.cash.redwood.treehouse.Crashed
 import app.cash.redwood.treehouse.DynamicContentWidgetFactory
 import app.cash.redwood.treehouse.Loading
+import app.cash.redwood.widget.Widget
 
 internal class EmojiSearchDynamicContentWidgetFactory : DynamicContentWidgetFactory<@Composable (Modifier) -> Unit> {
 
@@ -37,6 +38,8 @@ internal class EmojiSearchDynamicContentWidgetFactory : DynamicContentWidgetFact
 
   internal class RealLoading : Loading<@Composable (Modifier) -> Unit> {
     override var modifier: RedwoodModifier = RedwoodModifier
+    override val allChildren: List<Widget.Children<@Composable ((Modifier) -> Unit)>>
+      get() = listOf()
     override val value: @Composable (Modifier) -> Unit = { modifier ->
       Box(
         modifier = modifier.fillMaxSize(),
@@ -51,6 +54,8 @@ internal class EmojiSearchDynamicContentWidgetFactory : DynamicContentWidgetFact
     private var uncaughtException by mutableStateOf<Throwable?>(null)
 
     override var modifier: RedwoodModifier = RedwoodModifier
+    override val allChildren: List<Widget.Children<@Composable ((Modifier) -> Unit)>>
+      get() = listOf()
     override val value: @Composable (Modifier) -> Unit = { modifier ->
       Box(
         modifier = modifier.fillMaxSize(),

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/ExceptionView.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/ExceptionView.kt
@@ -29,6 +29,7 @@ import app.cash.redwood.Modifier
 import app.cash.redwood.treehouse.Crashed
 import app.cash.redwood.ui.Density
 import app.cash.redwood.ui.dp
+import app.cash.redwood.widget.Widget
 
 /**
  * Renders an emoji, plus the first line of the exception message, centered and wrapped. The view
@@ -48,6 +49,7 @@ internal class ExceptionView(
   Crashed<View> {
   override val value: View = this
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<View>> get() = listOf()
 
   private val skunk = AppCompatTextView(context)
     .apply {

--- a/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/LoadingView.kt
+++ b/samples/emoji-search/android-views/src/main/kotlin/com/example/redwood/emojisearch/android/views/LoadingView.kt
@@ -25,6 +25,7 @@ import android.widget.ProgressBar
 import androidx.appcompat.view.ContextThemeWrapper
 import app.cash.redwood.Modifier
 import app.cash.redwood.treehouse.Loading
+import app.cash.redwood.widget.Widget
 
 @SuppressLint("ViewConstructor")
 internal class LoadingView(
@@ -33,6 +34,7 @@ internal class LoadingView(
   Loading<View> {
   override val value = this
   override var modifier: Modifier = Modifier
+  override val allChildren: List<Widget.Children<View>> get() = listOf()
 
   init {
     addView(

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/CrashedUIView.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/CrashedUIView.swift
@@ -36,6 +36,9 @@ class CrashedUIView : Crashed {
     var value: Any { root }
 
     var modifier: Modifier = ExposedKt.modifier()
+    var allChildren: [any WidgetChildren] {
+        get { return [] }
+    }
 
     required init() {
         emoji.textAlignment = .center

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/LoadingUIView.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/LoadingUIView.swift
@@ -24,6 +24,9 @@ class LoadingUIView : Loading {
     var value: Any { root }
 
     var modifier: Modifier = ExposedKt.modifier()
+    var allChildren: [any WidgetChildren] {
+        get { return [] }
+    }
 
     required init() {
     }

--- a/test-app/ios-uikit/TestApp/ButtonBinding.swift
+++ b/test-app/ios-uikit/TestApp/ButtonBinding.swift
@@ -26,6 +26,9 @@ class ButtonBinding: Button {
     }()
 
     var modifier: Modifier = ExposedKt.modifier()
+    var allChildren: [any WidgetChildren] {
+        get { return [] }
+    }
     var value: Any { root }
     var onClick: (() -> Void)? = nil
 


### PR DESCRIPTION
This interface function exposes the live Widget.Children collections for generic tree-traversal code.

I'd like to use that capability to implement widget focus by searching for a widget with the appropriate modifier.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
