### PR TITLE
Fix RedwoodUIView measurement using intrinsicContentSize

### DIFF
--- a/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
+++ b/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
@@ -24,6 +24,7 @@ import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIColor
 import platform.UIKit.UIScrollView
 import platform.UIKit.UIView
+import platform.UIKit.UIViewNoIntrinsicMetric
 
 /**
  * Snapshot the subject on a white background.
@@ -89,15 +90,10 @@ class UIViewSnapshotter(
     if (heightConstraint == Constraint.Wrap && !scrolling) {
       val widget = subject.subviews[0] as UIView
 
-      widget.setFrame(
-        CGRectMake(
-          x = 0.0,
-          y = 0.0,
-          width = screenSize.useContents { width },
-          height = 0.0,
-        )
+      widget.setFrame(CGRectMake(0.0, 0.0, 0.0, 0.0))
+      val wrapSize = widget.sizeThatFits(
+        screenSize.useContents { CGSizeMake(width, UIViewNoIntrinsicMetric) },
       )
-      val wrapSize = widget.intrinsicContentSize()
 
       val frame = wrapSize.useContents { CGRectMake(0.0, 0.0, width, height) }
       subject.setFrame(frame)

--- a/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
+++ b/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
@@ -24,7 +24,6 @@ import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIColor
 import platform.UIKit.UIScrollView
 import platform.UIKit.UIView
-import platform.UIKit.UIViewNoIntrinsicMetric
 
 /**
  * Snapshot the subject on a white background.
@@ -90,10 +89,15 @@ class UIViewSnapshotter(
     if (heightConstraint == Constraint.Wrap && !scrolling) {
       val widget = subject.subviews[0] as UIView
 
-      widget.setFrame(CGRectMake(0.0, 0.0, 0.0, 0.0))
-      val wrapSize = widget.sizeThatFits(
-        screenSize.useContents { CGSizeMake(width, UIViewNoIntrinsicMetric) },
+      widget.setFrame(
+        CGRectMake(
+          x = 0.0,
+          y = 0.0,
+          width = screenSize.useContents { width },
+          height = 0.0,
+        )
       )
+      val wrapSize = widget.intrinsicContentSize()
 
       val frame = wrapSize.useContents { CGRectMake(0.0, 0.0, width, height) }
       subject.setFrame(frame)

--- a/redwood-widget-uiview-test/src/commonTest/kotlin/app/cash/redwood/widget/uiview/UIViewRedwoodViewFillWrapTest.kt
+++ b/redwood-widget-uiview-test/src/commonTest/kotlin/app/cash/redwood/widget/uiview/UIViewRedwoodViewFillWrapTest.kt
@@ -36,7 +36,10 @@ class UIViewRedwoodViewFillWrapTest(
 ) : AbstractRedwoodViewTest<UIView, RedwoodUIView>() {
   override val widgetFactory = UIViewTestWidgetFactory
 
-  override fun redwoodView() = RedwoodUIView()
+  override fun redwoodView() = RedwoodUIView().apply {
+    this.fillWidth = true
+    this.fillHeight = false
+  }
 
   override fun snapshotter(redwoodView: RedwoodUIView) =
     UIViewSnapshotter.framed(

--- a/redwood-widget/api/redwood-widget.klib.api
+++ b/redwood-widget/api/redwood-widget.klib.api
@@ -136,6 +136,13 @@ open class app.cash.redwood.widget/RedwoodUIView : app.cash.redwood.widget/Redwo
     open val value // app.cash.redwood.widget/RedwoodUIView.value|{}value[0]
         open fun <get-value>(): platform.UIKit/UIView // app.cash.redwood.widget/RedwoodUIView.value.<get-value>|<get-value>(){}[0]
 
+    final var fillHeight // app.cash.redwood.widget/RedwoodUIView.fillHeight|{}fillHeight[0]
+        final fun <get-fillHeight>(): kotlin/Boolean // app.cash.redwood.widget/RedwoodUIView.fillHeight.<get-fillHeight>|<get-fillHeight>(){}[0]
+        final fun <set-fillHeight>(kotlin/Boolean) // app.cash.redwood.widget/RedwoodUIView.fillHeight.<set-fillHeight>|<set-fillHeight>(kotlin.Boolean){}[0]
+    final var fillWidth // app.cash.redwood.widget/RedwoodUIView.fillWidth|{}fillWidth[0]
+        final fun <get-fillWidth>(): kotlin/Boolean // app.cash.redwood.widget/RedwoodUIView.fillWidth.<get-fillWidth>|<get-fillWidth>(){}[0]
+        final fun <set-fillWidth>(kotlin/Boolean) // app.cash.redwood.widget/RedwoodUIView.fillWidth.<set-fillWidth>|<set-fillWidth>(kotlin.Boolean){}[0]
+
     open fun superviewChanged() // app.cash.redwood.widget/RedwoodUIView.superviewChanged|superviewChanged(){}[0]
 }
 

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
@@ -45,8 +45,14 @@ import platform.UIKit.UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirect
 import platform.UIKit.UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirectionRightToLeft
 import platform.UIKit.UIUserInterfaceStyle
 import platform.UIKit.UIView
+import platform.UIKit.UIViewNoIntrinsicMetric
 import platform.darwin.NSInteger
 
+/**
+ * This view must be explicitly configured to know whether its dimensions are derived by measuring
+ * its contents, or whether they are provided by the superview. Use [fillWidth] and [fillHeight] to
+ * accept the parent's provided width and height respectively.
+ */
 @ObjCName("RedwoodUIView", exact = true)
 public open class RedwoodUIView : RedwoodView<UIView> {
   private val valueRootView: RootUIStackView = RootUIStackView()
@@ -107,6 +113,9 @@ public open class RedwoodUIView : RedwoodView<UIView> {
   override val savedStateRegistry: SavedStateRegistry?
     get() = null
 
+  public var fillWidth: Boolean = false
+  public var fillHeight: Boolean = false
+
   private fun updateUiConfiguration() {
     mutableUiConfiguration.value = computeUiConfiguration(
       density = density,
@@ -131,6 +140,17 @@ public open class RedwoodUIView : RedwoodView<UIView> {
     /** Safe area insets specified by the superview. */
     val incomingSafeAreaInsets: CValue<UIEdgeInsets>
       get() = super.safeAreaInsets
+
+    private var widthForIntrinsicSize = UIViewNoIntrinsicMetric
+      set(value) {
+        field = value
+        invalidateIntrinsicContentSize()
+      }
+    private var heightForIntrinsicSize = UIViewNoIntrinsicMetric
+      set(value) {
+        field = value
+        invalidateIntrinsicContentSize()
+      }
 
     init {
       this.setInsetsLayoutMarginsFromSafeArea(false) // Consume insets internally.
@@ -169,8 +189,60 @@ public open class RedwoodUIView : RedwoodView<UIView> {
       }
     }
 
+    override fun setBounds(bounds: CValue<CGRect>) {
+      updateFrameForIntrinsicSize(bounds)
+      super.setBounds(bounds)
+    }
+
+    override fun setFrame(frame: CValue<CGRect>) {
+      updateFrameForIntrinsicSize(frame)
+      super.setFrame(frame)
+    }
+
+    /**
+     * The intrinsic size is broken by design if any subview's height depends on its width (or
+     * vice-versa). For example, if a subview is UILabel that wraps, we need to know how wide the
+     * label is before we can compute that label's height.
+     *
+     * We work around this by:
+     *
+     *  1. Making [intrinsicContentSize] depend on the mostly-recently applied frame
+     *  2. Invalidating it each time the frame changes
+     *
+     * This will result in an additional layout pass when the superview uses [intrinsicContentSize].
+     */
+    private fun updateFrameForIntrinsicSize(frame: CValue<CGRect>) {
+      val newWidth = frame.useContents { size.width }
+      val newHeight = frame.useContents { size.height }
+
+      if (
+        (fillWidth && newWidth != widthForIntrinsicSize) ||
+        (fillHeight && newHeight != heightForIntrinsicSize)
+      ) {
+        invalidateIntrinsicContentSize()
+      }
+
+      this.widthForIntrinsicSize = when {
+        fillWidth -> newWidth
+        else -> UIViewNoIntrinsicMetric
+      }
+      this.heightForIntrinsicSize = when {
+        fillHeight -> newHeight
+        else -> UIViewNoIntrinsicMetric
+      }
+    }
+
     override fun intrinsicContentSize(): CValue<CGSize> {
-      return maxSizeOfSubviews { it.intrinsicContentSize() }
+      return when {
+        widthForIntrinsicSize == UIViewNoIntrinsicMetric &&
+          heightForIntrinsicSize == UIViewNoIntrinsicMetric -> {
+          maxSizeOfSubviews { it.intrinsicContentSize() }
+        }
+
+        else -> {
+          sizeThatFits(CGSizeMake(widthForIntrinsicSize, heightForIntrinsicSize))
+        }
+      }
     }
 
     private fun maxSizeOfSubviews(


### PR DESCRIPTION
When I recently changed this to not use UIStackView as its parent component, I introduced a regression where measurements made with intrinsicContentSize() didn't honor the frame's dimensions.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
