### PR TITLE
Allow building on JDKs newer than 22

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -155,6 +155,12 @@ class RedwoodBuildPlugin : Plugin<Project> {
         it.exceptionFormat = FULL
       }
     }
+    // Paparazzi's ByteBuddy only knows up to JDK 22 and otherwise pessimistically fails on newer.
+    pluginManager.withPlugin("app.cash.paparazzi") {
+      tasks.withType(Test::class.java).configureEach { task ->
+        task.systemProperty("net.bytebuddy.experimental", "true")
+      }
+    }
   }
 
   private fun Project.configureCommonAndroid() {


### PR DESCRIPTION
We can't upgrade Paparazzi without resolving a separate problem, but in general Paparazzi only uses ByteBuddy to process classes whose target is very low (e.g., Java 17)

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
