### PR TITLE
Eliminate the test-only modifier on Compose UI `Spacer`

### DIFF
--- a/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
+++ b/redwood-layout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiFlexContainerTest.kt
@@ -72,9 +72,12 @@ class ComposeUiFlexContainerTest(
       applyDefaults()
     }
 
-  override fun spacer(backgroundColor: Int): Spacer<@Composable (Modifier) -> Unit> {
-    return ComposeUiSpacer().apply {
-      testOnlyModifier = Modifier.background(Color(backgroundColor))
+  override fun spacer(): Spacer<@Composable (Modifier) -> Unit> {
+    val spacer = ComposeUiSpacer()
+    return object : Spacer<@Composable (Modifier) -> Unit> by spacer {
+      override val value: @Composable (Modifier) -> Unit = { modifier ->
+        spacer.value(modifier.background(Color(defaultBackgroundColor)))
+      }
     }
   }
 

--- a/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacer.kt
+++ b/redwood-layout-composeui/src/commonMain/kotlin/app/cash/redwood/layout/composeui/ComposeUiSpacer.kt
@@ -30,12 +30,9 @@ import app.cash.redwood.ui.dp
 internal class ComposeUiSpacer : Spacer<@Composable (Modifier) -> Unit> {
   private var width by mutableStateOf(0.dp)
   private var height by mutableStateOf(0.dp)
-  var testOnlyModifier: Modifier? = null
 
   override val value: @Composable (Modifier) -> Unit = { modifier ->
-    var modifier = modifier.defaultMinSize(width.toDp(), height.toDp())
-    testOnlyModifier?.let { modifier = modifier.then(it) }
-    Spacer(modifier)
+    Spacer(modifier.defaultMinSize(width.toDp(), height.toDp()))
   }
 
   override var modifier: RedwoodModifier = RedwoodModifier

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4265096c30d46578c9f8b991878000131cf1d7ea58f67068391e77984200bf0a
-size 3906
+oid sha256:ebe51e041c19cd7a23c564f50c3ddff71e0dba3f5ba60a1930f41f7d595582c7
+size 3908

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4265096c30d46578c9f8b991878000131cf1d7ea58f67068391e77984200bf0a
-size 3906
+oid sha256:ebe51e041c19cd7a23c564f50c3ddff71e0dba3f5ba60a1930f41f7d595582c7
+size 3908

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -119,9 +119,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
   /** Returns a non-lazy flex container column, even if the test is for a LazyList. */
   abstract fun column(): Column<T>
 
-  abstract fun spacer(
-    backgroundColor: Int = argb(17, 0, 0, 0),
-  ): Spacer<T>
+  abstract fun spacer(): Spacer<T>
 
   abstract fun snapshotter(widget: T): Snapshotter
 

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewFlexContainerTestHost/testWidgetWithFlexModifierNestedInRowAndColumn.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:465d0586d311bcd7569f2340c809c161dc1be6d4312e44d61c448d5c0f0bc5f6
-size 71441
+oid sha256:ddc720fb9228f2ea3a43756c972a53f7d3c1996799f94b2ded248aaef7be10a8
+size 71443

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainerTest.kt
@@ -78,10 +78,10 @@ class UIViewFlexContainerTest(
     applyDefaults()
   }
 
-  override fun spacer(backgroundColor: Int): Spacer<UIView> {
+  override fun spacer(): Spacer<UIView> {
     return UIViewRedwoodLayoutWidgetFactory().Spacer()
       .apply {
-        value.backgroundColor = backgroundColor.toUIColor()
+        value.backgroundColor = defaultBackgroundColor.toUIColor()
       }
   }
 

--- a/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
+++ b/redwood-layout-view/src/test/kotlin/app/cash/redwood/layout/view/ViewFlexContainerTest.kt
@@ -71,10 +71,10 @@ class ViewFlexContainerTest(
     applyDefaults()
   }
 
-  override fun spacer(backgroundColor: Int): Spacer<View> {
+  override fun spacer(): Spacer<View> {
     return ViewSpacer(paparazzi.context)
       .apply {
-        value.setBackgroundColor(backgroundColor)
+        value.setBackgroundColor(defaultBackgroundColor)
       }
   }
 

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03e4f17258edf3726c6ea7b0db2199f6ecfd34711a1dfbbaba179e0f54a2447d
-size 3918
+oid sha256:d26b65a23f5f623fa988c57871496eccccfbe1a428e03bbd0893596837f7118c
+size 3906

--- a/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-layout-view/src/test/snapshots/images/app.cash.redwood.layout.view_ViewFlexContainerTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03e4f17258edf3726c6ea7b0db2199f6ecfd34711a1dfbbaba179e0f54a2447d
-size 3918
+oid sha256:d26b65a23f5f623fa988c57871496eccccfbe1a428e03bbd0893596837f7118c
+size 3906

--- a/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
+++ b/redwood-lazylayout-composeui/src/androidUnitTest/kotlin/app/cash/redwood/layout/composeui/ComposeUiLazyListTest.kt
@@ -69,11 +69,12 @@ class ComposeUiLazyListTest(
     return ComposeUiRedwoodLayoutWidgetFactory().Column()
   }
 
-  override fun spacer(backgroundColor: Int): Spacer<@Composable (Modifier) -> Unit> {
-    return ComposeUiRedwoodLayoutWidgetFactory().Spacer().apply {
-      @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
-      (this as ComposeUiSpacer).testOnlyModifier =
-        Modifier.background(Color(backgroundColor))
+  override fun spacer(): Spacer<@Composable (Modifier) -> Unit> {
+    val spacer = ComposeUiRedwoodLayoutWidgetFactory().Spacer()
+    return object : Spacer<@Composable (Modifier) -> Unit> by spacer {
+      override val value: @Composable (Modifier) -> Unit = { modifier ->
+        spacer.value(modifier.background(Color(defaultBackgroundColor)))
+      }
     }
   }
 

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:500df5359bd2f1aba6eb335cbba1acd26584374366ca8565d93c47f1e34a4606
-size 3844
+oid sha256:5fab3a489b64fc4c21bbeed391c04d92655af7848c101b5b48014027849340c9
+size 3896

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testWidgetWithFlexModifierNestedInRowAndColumn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:500df5359bd2f1aba6eb335cbba1acd26584374366ca8565d93c47f1e34a4606
-size 3844
+oid sha256:5fab3a489b64fc4c21bbeed391c04d92655af7848c101b5b48014027849340c9
+size 3896

--- a/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-uiview/src/commonTest/kotlin/app/cash/redwood/lazylayout/uiview/UIViewLazyListAsFlexContainerTest.kt
@@ -51,10 +51,10 @@ class UIViewLazyListAsFlexContainerTest(
 
   override fun column() = UIViewRedwoodLayoutWidgetFactory().Column()
 
-  override fun spacer(backgroundColor: Int): Spacer<UIView> {
+  override fun spacer(): Spacer<UIView> {
     return UIViewRedwoodLayoutWidgetFactory().Spacer()
       .apply {
-        value.backgroundColor = backgroundColor.toUIColor()
+        value.backgroundColor = defaultBackgroundColor.toUIColor()
       }
   }
 

--- a/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
+++ b/redwood-lazylayout-view/src/test/kotlin/app/cash/redwood/lazylayout/view/ViewLazyListAsFlexContainerTest.kt
@@ -69,10 +69,10 @@ class ViewLazyListAsFlexContainerTest(
     return ViewRedwoodLayoutWidgetFactory(paparazzi.context).Column()
   }
 
-  override fun spacer(backgroundColor: Int): Spacer<View> {
+  override fun spacer(): Spacer<View> {
     return ViewRedwoodLayoutWidgetFactory(paparazzi.context).Spacer()
       .apply {
-        value.setBackgroundColor(backgroundColor)
+        value.setBackgroundColor(defaultBackgroundColor)
       }
   }
 


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
