### PR TITLE
Don't call invalidateIntrinsicContentSize() unless necessary

### DIFF
--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
@@ -147,11 +147,13 @@ public open class RedwoodUIView : RedwoodView<UIView> {
 
     private var widthForIntrinsicSize = UIViewNoIntrinsicMetric
       set(value) {
+        if (value == field) return // Don't invalidateIntrinsicContentSize() if nothing's changed.
         field = value
         invalidateIntrinsicContentSize()
       }
     private var heightForIntrinsicSize = UIViewNoIntrinsicMetric
       set(value) {
+        if (value == field) return // Don't invalidateIntrinsicContentSize() if nothing's changed.
         field = value
         invalidateIntrinsicContentSize()
       }


### PR DESCRIPTION
I've seen a severe problem where we're triggering
infinite layouts because the frame is reporting
changes when nothing has changed.
