### PR TITLE
Make Snapshotter.snapshot() suspending

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ paparazzi = "1.3.2"
 zipline = "1.22.0"
 coil = "3.3.0"
 okio = "3.16.0"
-burst = "2.7.1"
+burst = "2.8.1"
 
 [libraries]
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
@@ -79,6 +79,7 @@ coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version
 
 androidGradlePlugin = { module = "com.android.tools.build:gradle", version = "8.13.0" }
 burst = { module = "app.cash.burst:burst", version.ref = "burst" }
+burst-coroutines = { module = "app.cash.burst:burst-coroutines", version.ref = "burst" }
 burst-gradle-plugin = { module = "app.cash.burst:burst-gradle-plugin", version.ref = "burst" }
 kotlinPoet = { module = "com.squareup:kotlinpoet", version = "2.2.0" }
 clikt = "com.github.ajalt.clikt:clikt:5.0.3"

--- a/redwood-layout-shared-test/build.gradle
+++ b/redwood-layout-shared-test/build.gradle
@@ -20,6 +20,8 @@ kotlin {
         api projects.redwoodYoga
         api libs.kotlin.test
         implementation libs.burst
+        implementation libs.burst.coroutines
+        implementation libs.kotlinx.coroutines.test
       }
     }
     jvmMain {

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractBoxTest.kt
@@ -33,6 +33,7 @@ import app.cash.redwood.snapshot.testing.text
 import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.dp
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 @Burst
 abstract class AbstractBoxTest<T : Any> {
@@ -48,7 +49,7 @@ abstract class AbstractBoxTest<T : Any> {
    * Explicitly apply defaults to our Box instance. This is only necessary in tests; in production
    * the framework explicitly sets every property.
    */
-  protected fun Box<T>.applyDefaults() {
+  protected fun Box<T>.applyDefaults() = runTest {
     width(Constraint.Wrap)
     height(Constraint.Wrap)
     margin(Margin.Zero)
@@ -57,13 +58,13 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testEmpty_Defaults() {
+  fun testEmpty_Defaults() = runTest {
     val widget = box()
     snapshotterFactory(widget.value).snapshot()
   }
 
   @Test
-  fun testEmpty_Wrap() {
+  fun testEmpty_Wrap() = runTest {
     val widget = box().apply {
       width(Constraint.Wrap)
       height(Constraint.Wrap)
@@ -72,7 +73,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testEmpty_Fill() {
+  fun testEmpty_Fill() = runTest {
     val widget = box().apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -98,7 +99,7 @@ abstract class AbstractBoxTest<T : Any> {
       CrossAxisAlignment.End,
       CrossAxisAlignment.Stretch,
     ),
-  ) {
+  ) = runTest {
     val widget = box().apply {
       width(constraint)
       height(constraint)
@@ -130,7 +131,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testMargins() {
+  fun testMargins() = runTest {
     // Different margins allow us to know which direction start and end get applied.
     val asymmetric = Margin(start = 10.dp, top = 20.dp, end = 30.dp, bottom = 40.dp)
 
@@ -156,7 +157,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testBoxMeasurementIncludesMargins() {
+  fun testBoxMeasurementIncludesMargins() = runTest {
     val container = widgetFactory.column()
     container.add(
       box().apply {
@@ -199,7 +200,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testMarginsAndAlignment() {
+  fun testMarginsAndAlignment() = runTest {
     val widget = box().apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -242,7 +243,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testMarginsAndStretch() {
+  fun testMarginsAndStretch() = runTest {
     val widget = box().apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -285,7 +286,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testChildrenModifierChanges() {
+  fun testChildrenModifierChanges() = runTest {
     val redColor = widgetFactory.text(
       modifier = MarginImpl(30.dp),
       text = longText(),
@@ -319,7 +320,7 @@ abstract class AbstractBoxTest<T : Any> {
 
   /** The view shouldn't crash if its displayed after being detached. */
   @Test
-  fun testLayoutAfterDetach() {
+  fun testLayoutAfterDetach() = runTest {
     val widget = box().apply {
       width(Constraint.Wrap)
       height(Constraint.Wrap)
@@ -361,7 +362,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testDynamicWidgetResizing() {
+  fun testDynamicWidgetResizing() = runTest {
     val container = box()
       .apply {
         width(Constraint.Fill)
@@ -393,7 +394,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testLayoutUpdatesWithoutSizeChanges() {
+  fun testLayoutUpdatesWithoutSizeChanges() = runTest {
     val container = widgetFactory.column()
     val snapshotter = snapshotterFactory(container.value)
 
@@ -421,7 +422,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testChildExplicitHeight() {
+  fun testChildExplicitHeight() = runTest {
     val container = box()
       .apply {
         width(Constraint.Fill)
@@ -453,7 +454,7 @@ abstract class AbstractBoxTest<T : Any> {
   }
 
   @Test
-  fun testChildExplicitWidth() {
+  fun testChildExplicitWidth() = runTest {
     val container = box()
       .apply {
         width(Constraint.Fill)
@@ -486,7 +487,7 @@ abstract class AbstractBoxTest<T : Any> {
 
   /** We had a bug where stretch alignment impacted measurement. It shouldn't. */
   @Test
-  fun testStretchDoesNotImpactMeasurement() {
+  fun testStretchDoesNotImpactMeasurement() = runTest {
     val container = box()
       .apply {
         width(Constraint.Fill)

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -43,6 +43,7 @@ import app.cash.redwood.yoga.FlexDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 
 @Burst
 abstract class AbstractFlexContainerTest<T : Any> {
@@ -127,7 +128,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun testEmptyLayout(
     flexDirection: FlexDirection = burstValues(FlexDirection.Row, FlexDirection.Column),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     container.crossAxisAlignment(CrossAxisAlignment.Start)
     container.onEndChanges()
@@ -138,7 +139,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     flexDirection: FlexDirection = burstValues(FlexDirection.Row, FlexDirection.Column),
     width: Constraint = burstValues(Constraint.Wrap, Constraint.Fill),
     height: Constraint = burstValues(Constraint.Wrap, Constraint.Fill),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     container.width(width)
     container.height(height)
@@ -156,7 +157,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun testShortLayout(
     flexDirection: FlexDirection = burstValues(FlexDirection.Row, FlexDirection.Column),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     container.crossAxisAlignment(CrossAxisAlignment.Start)
     movies.take(5).forEach { movie ->
@@ -168,7 +169,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun testLongLayout(
     flexDirection: FlexDirection = burstValues(FlexDirection.Row, FlexDirection.Column),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     container.crossAxisAlignment(CrossAxisAlignment.Start)
     movies.forEach { movie ->
@@ -180,7 +181,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun testLayoutWithMarginAndDifferentAlignments(
     flexDirection: FlexDirection = burstValues(FlexDirection.Row, FlexDirection.Column),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -206,7 +207,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       CrossAxisAlignment.End,
       CrossAxisAlignment.Stretch,
     ),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -218,7 +219,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testColumnWithUpdatedCrossAxisAlignment() {
+  @Test fun testColumnWithUpdatedCrossAxisAlignment() = runTest {
     val container = flexContainer(FlexDirection.Column)
     val snapshotter = snapshotterFactory(container.value)
     container.width(Constraint.Fill)
@@ -240,7 +241,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
       MainAxisAlignment.SpaceBetween,
       MainAxisAlignment.SpaceAround,
     ),
-  ) {
+  ) = runTest {
     val container = flexContainer(FlexDirection.Column)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -253,7 +254,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testContainerWithFixedWidthItems() {
+  @Test fun testContainerWithFixedWidthItems() = runTest {
     val container = flexContainer(FlexDirection.Column)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -265,7 +266,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testContainerWithFixedHeightItems() {
+  @Test fun testContainerWithFixedHeightItems() = runTest {
     val container = flexContainer(FlexDirection.Column)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -277,7 +278,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testContainerWithFixedSizeItems() {
+  @Test fun testContainerWithFixedSizeItems() = runTest {
     val container = flexContainer(FlexDirection.Column)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -289,7 +290,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testRowWithFixedWidthHasChildWithFixedHeight() {
+  @Test fun testRowWithFixedWidthHasChildWithFixedHeight() = runTest {
     val container = flexContainer(FlexDirection.Row).apply {
       crossAxisAlignment(CrossAxisAlignment.Start)
       modifier = WidthImpl(200.dp)
@@ -310,7 +311,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testChildWithUpdatedProperty() {
+  @Test fun testChildWithUpdatedProperty() = runTest {
     val container = flexContainer(FlexDirection.Column)
     val snapshotter = snapshotterFactory(container.value)
     container.width(Constraint.Fill)
@@ -325,7 +326,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotter.snapshot("updated")
   }
 
-  @Test fun testColumnThenRow() {
+  @Test fun testColumnThenRow() = runTest {
     val column = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -365,7 +366,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   /** This test demonstrates that margins are lost unless `shrink(1.0)` is added. */
-  @Test fun testRowMargins() {
+  @Test fun testRowMargins() = runTest {
     val column = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -418,7 +419,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(column.value).snapshot()
   }
 
-  @Test fun testDynamicElementUpdates() {
+  @Test fun testDynamicElementUpdates() = runTest {
     val container = flexContainer(FlexDirection.Column)
     val snapshotter = snapshotterFactory(container.value)
     container.width(Constraint.Fill)
@@ -440,7 +441,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotter.snapshot("BCDE")
   }
 
-  @Test fun testDynamicContainerSize() {
+  @Test fun testDynamicContainerSize() = runTest {
     val parent = column().apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -502,7 +503,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotter.snapshot("single")
   }
 
-  @Test fun testFlexDistributesWeightEqually() {
+  @Test fun testFlexDistributesWeightEqually() = runTest {
     val container = flexContainer(FlexDirection.Row)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -513,7 +514,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testFlexDistributesWeightUnequally() {
+  @Test fun testFlexDistributesWeightUnequally() = runTest {
     val container = flexContainer(FlexDirection.Row)
     container.width(Constraint.Fill)
     container.height(Constraint.Fill)
@@ -524,7 +525,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(container.value).snapshot()
   }
 
-  @Test fun testNestedColumnsWithFlex() {
+  @Test fun testNestedColumnsWithFlex() = runTest {
     val outerContainer = flexContainer(FlexDirection.Column)
     outerContainer.width(Constraint.Fill)
     outerContainer.height(Constraint.Fill)
@@ -553,7 +554,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun testContainerWithChildrenModifierChanges(
     flexDirection: FlexDirection = burstValues(FlexDirection.Row, FlexDirection.Column),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     val snapshotter = snapshotterFactory(container.value)
     container.width(Constraint.Fill)
@@ -575,7 +576,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   @Test fun testContainerMarginChanges(
     flexDirection: FlexDirection = burstValues(FlexDirection.Column, FlexDirection.Row),
-  ) {
+  ) = runTest {
     val container = flexContainer(flexDirection)
     val snapshotter = snapshotterFactory(container.value)
 
@@ -596,7 +597,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   /** The view shouldn't crash if its displayed after being detached. */
-  @Test fun testLayoutAfterDetach() {
+  @Test fun testLayoutAfterDetach() = runTest {
     val container = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -616,7 +617,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotter.snapshot("After")
   }
 
-  @Test fun testOnScrollListener() {
+  @Test fun testOnScrollListener() = runTest {
     var scrolled = false
     val container = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
@@ -640,7 +641,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * This creates a 3-element layout where each widgets' dimensions are independent. Then it
    * changes one of the widgets' and confirms that only that widget is measured.
    */
-  @Test fun testLayoutIsIncremental() {
+  @Test fun testLayoutIsIncremental() = runTest {
     val container = flexContainer(FlexDirection.Column)
     val snapshotter = snapshotterFactory(container.value)
     container.width(Constraint.Fill)
@@ -686,7 +687,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     assertEquals(cMeasureCountV2, cMeasureCountV3)
   }
 
-  @Test fun testRecursiveLayoutIsIncremental() {
+  @Test fun testRecursiveLayoutIsIncremental() = runTest {
     val container = flexContainer(FlexDirection.Column)
     val snapshotter = snapshotterFactory(container.value)
     container.width(Constraint.Fill)
@@ -749,7 +750,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   /** Confirm that child element size changes propagate up the view hierarchy. */
-  @Test fun testRecursiveLayoutHandlesResizes() {
+  @Test fun testRecursiveLayoutHandlesResizes() = runTest {
     val column = flexContainer(FlexDirection.Column)
       .apply {
         width(Constraint.Fill)
@@ -794,7 +795,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotter.snapshot("v2")
   }
 
-  @Test fun testLayoutHandlesChildResizes() {
+  @Test fun testLayoutHandlesChildResizes() = runTest {
     val column = flexContainer(FlexDirection.Column)
       .apply {
         width(Constraint.Fill)
@@ -835,7 +836,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * either let it have its requested size anyway (and overrun the available space) or we confine it
    * to the space available.
    */
-  @Test fun testChildIsConstrainedToParentWidth() {
+  @Test fun testChildIsConstrainedToParentWidth() = runTest {
     // Wrap in a parent column to let us configure an exact width for our subject flex container.
     // Otherwise we're relying on the platform-specific snapshot library's unspecified frame width.
     val fullWidthParent = column().apply {
@@ -870,7 +871,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * We were incorrectly collapsing the dimensions of the widget.
    * https://github.com/cashapp/redwood/issues/2018
    */
-  @Test fun testWidgetWithFlexModifierNestedInRowAndColumn() {
+  @Test fun testWidgetWithFlexModifierNestedInRowAndColumn() = runTest {
     val root = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -908,7 +909,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * CrossAxisAlignment.Start forces child to wrap its size on Android
    * https://github.com/cashapp/redwood/issues/2093
    */
-  @Test fun testCrossAxisAlignmentStart() {
+  @Test fun testCrossAxisAlignmentStart() = runTest {
     val root = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       crossAxisAlignment(CrossAxisAlignment.Start)
@@ -930,7 +931,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * Text not wrapping inside a row.
    * https://github.com/cashapp/redwood/issues/2011
    */
-  @Test fun testTextWrapsInsideRow() {
+  @Test fun testTextWrapsInsideRow() = runTest {
     val root = flexContainer(FlexDirection.Row)
 
     root.add(
@@ -942,7 +943,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(root.value).snapshot()
   }
 
-  @Test fun testIntrinsicContentSizeWhenSubviewsWrap() {
+  @Test fun testIntrinsicContentSizeWhenSubviewsWrap() = runTest {
     val fullWidthParent = widgetFactory.column()
 
     flexContainer(FlexDirection.Column)
@@ -983,7 +984,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
     snapshotterFactory(scrollWrapper.value).snapshot(scrolling = true)
   }
 
-  @Test fun testIntrinsicContentSizeWhenSubviewsRequireScrolling() {
+  @Test fun testIntrinsicContentSizeWhenSubviewsRequireScrolling() = runTest {
     val column = flexContainer(FlexDirection.Column)
       .apply {
         width(Constraint.Fill)
@@ -1003,7 +1004,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * We had a bug where content would shrink to its minimum required size with [Overflow.Scroll],
    * even if the enclosing container didn't require that.
    */
-  @Test fun testFillAndOverflowScroll() {
+  @Test fun testFillAndOverflowScroll() = runTest {
     val column = flexContainer(FlexDirection.Column)
       .apply {
         width(Constraint.Fill)
@@ -1034,7 +1035,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   @Test
-  fun testFlexWithWrappingChild() {
+  fun testFlexWithWrappingChild() = runTest {
     val row = row().apply {
       width(Constraint.Fill)
     }
@@ -1060,7 +1061,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   @Test
-  fun testFlexWithChildContainingWrappingChild() {
+  fun testFlexWithChildContainingWrappingChild() = runTest {
     val row = row().apply {
       width(Constraint.Fill)
     }
@@ -1097,7 +1098,7 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * https://github.com/cashapp/redwood/issues/2753
    */
   @Test
-  fun testFlexOnChildOfWrappingColumn() {
+  fun testFlexOnChildOfWrappingColumn() = runTest {
     val root = row().apply {
       width(Constraint.Fill)
       height(Constraint.Fill)

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractSpacerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractSpacerTest.kt
@@ -21,6 +21,7 @@ import app.cash.redwood.snapshot.testing.Snapshotter
 import app.cash.redwood.ui.dp
 import app.cash.redwood.widget.Widget
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 abstract class AbstractSpacerTest<T : Any> {
 
@@ -36,22 +37,22 @@ abstract class AbstractSpacerTest<T : Any> {
     height(height.dp)
   }
 
-  @Test fun testZeroSpacer() {
+  @Test fun testZeroSpacer() = runTest {
     val widget = widget(width = 0, height = 0)
     snapshotterFactory(wrap(widget, horizontal = true)).snapshot()
   }
 
-  @Test fun testWidthOnlySpacer() {
+  @Test fun testWidthOnlySpacer() = runTest {
     val widget = widget(width = 100, height = 0)
     snapshotterFactory(wrap(widget, horizontal = true)).snapshot()
   }
 
-  @Test fun testHeightOnlySpacer() {
+  @Test fun testHeightOnlySpacer() = runTest {
     val widget = widget(width = 0, height = 100)
     snapshotterFactory(wrap(widget, horizontal = false)).snapshot()
   }
 
-  @Test fun testBothSpacer() {
+  @Test fun testBothSpacer() = runTest {
     val widget = widget(width = 100, height = 100)
     snapshotterFactory(wrap(widget, horizontal = false)).snapshot()
   }

--- a/redwood-lazylayout-shared-test/build.gradle
+++ b/redwood-lazylayout-shared-test/build.gradle
@@ -16,6 +16,8 @@ kotlin {
         api projects.redwoodWidget
         api projects.redwoodYoga
         api libs.kotlin.test
+        implementation libs.burst.coroutines
+        implementation libs.kotlinx.coroutines.test
       }
     }
     jvmMain {

--- a/redwood-lazylayout-shared-test/src/commonMain/kotlin/app/cash/redwood/lazylayout/AbstractLazyListTest.kt
+++ b/redwood-lazylayout-shared-test/src/commonMain/kotlin/app/cash/redwood/lazylayout/AbstractLazyListTest.kt
@@ -28,6 +28,7 @@ import app.cash.redwood.ui.Margin
 import app.cash.redwood.ui.dp
 import app.cash.redwood.widget.ChangeListener
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 abstract class AbstractLazyListTest<T : Any> {
   @InterceptTest
@@ -56,7 +57,7 @@ abstract class AbstractLazyListTest<T : Any> {
   }
 
   @Test
-  fun testHappyPath() {
+  fun testHappyPath() = runTest {
     val lazyList = defaultLazyList()
 
     for ((index, value) in movies.take(5).withIndex()) {
@@ -68,7 +69,7 @@ abstract class AbstractLazyListTest<T : Any> {
   }
 
   @Test
-  fun testPlaceholderToLoadedAndLoadedToPlaceholder() {
+  fun testPlaceholderToLoadedAndLoadedToPlaceholder() = runTest {
     val lazyList = defaultLazyList()
     val snapshotter = snapshotterFactory(lazyList.value)
 
@@ -101,7 +102,7 @@ abstract class AbstractLazyListTest<T : Any> {
   }
 
   @Test
-  fun testPlaceholdersExhausted() {
+  fun testPlaceholdersExhausted() = runTest {
     val lazyList = defaultLazyList()
 
     lazyList.itemsBefore(11)

--- a/redwood-snapshot-testing/build.gradle
+++ b/redwood-snapshot-testing/build.gradle
@@ -16,6 +16,7 @@ kotlin {
         api libs.kotlin.test
         api projects.redwoodWidget
         implementation libs.assertk
+        implementation libs.burst.coroutines
       }
     }
     androidMain {

--- a/redwood-snapshot-testing/src/androidMain/kotlin/app/cash/redwood/snapshot/testing/ComposeSnapshotter.kt
+++ b/redwood-snapshot-testing/src/androidMain/kotlin/app/cash/redwood/snapshot/testing/ComposeSnapshotter.kt
@@ -17,14 +17,14 @@ package app.cash.redwood.snapshot.testing
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import app.cash.burst.TestFunction
+import app.cash.burst.coroutines.CoroutineTestFunction
 import app.cash.paparazzi.Paparazzi
 
 class ComposeSnapshotter private constructor(
   private val paparazzi: Paparazzi,
   private val widget: @Composable (Modifier) -> Unit,
 ) : Snapshotter {
-  override fun snapshot(name: String?, scrolling: Boolean) {
+  override suspend fun snapshot(name: String?, scrolling: Boolean) {
     paparazzi.snapshot(name) {
       widget(Modifier)
     }
@@ -36,7 +36,7 @@ class ComposeSnapshotter private constructor(
     override fun invoke(widget: @Composable ((Modifier) -> Unit)) =
       ComposeSnapshotter(paparazzi, widget)
 
-    override fun intercept(testFunction: TestFunction) {
+    override suspend fun intercept(testFunction: CoroutineTestFunction) {
       testFunction()
     }
   }

--- a/redwood-snapshot-testing/src/androidMain/kotlin/app/cash/redwood/snapshot/testing/ViewSnapshotter.kt
+++ b/redwood-snapshot-testing/src/androidMain/kotlin/app/cash/redwood/snapshot/testing/ViewSnapshotter.kt
@@ -16,14 +16,14 @@
 package app.cash.redwood.snapshot.testing
 
 import android.view.View
-import app.cash.burst.TestFunction
+import app.cash.burst.coroutines.CoroutineTestFunction
 import app.cash.paparazzi.Paparazzi
 
 class ViewSnapshotter private constructor(
   private val paparazzi: Paparazzi,
   private val view: View,
 ) : Snapshotter {
-  override fun snapshot(name: String?, scrolling: Boolean) {
+  override suspend fun snapshot(name: String?, scrolling: Boolean) {
     paparazzi.snapshot(view = view, name = name)
 
     if (scrolling) {
@@ -47,7 +47,7 @@ class ViewSnapshotter private constructor(
   ) : Snapshotter.Factory<View> {
     override fun invoke(widget: View) = ViewSnapshotter(paparazzi, widget)
 
-    override fun intercept(testFunction: TestFunction) {
+    override suspend fun intercept(testFunction: CoroutineTestFunction) {
       testFunction()
     }
   }

--- a/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/Snapshotter.kt
+++ b/redwood-snapshot-testing/src/commonMain/kotlin/app/cash/redwood/snapshot/testing/Snapshotter.kt
@@ -16,6 +16,7 @@
 package app.cash.redwood.snapshot.testing
 
 import app.cash.burst.TestInterceptor
+import app.cash.burst.coroutines.CoroutineTestInterceptor
 
 /**
  * Captures snapshots of a subject view.
@@ -25,13 +26,13 @@ import app.cash.burst.TestInterceptor
  * changes.
  */
 interface Snapshotter {
-  fun snapshot(
+  suspend fun snapshot(
     name: String? = null,
     scrolling: Boolean = false,
   )
 
   /** This interface extends [TestInterceptor] for platforms that need it to get test metadata. */
-  interface Factory<T : Any> : TestInterceptor {
+  interface Factory<T : Any> : CoroutineTestInterceptor {
     operator fun invoke(widget: T): Snapshotter
   }
 }

--- a/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
+++ b/redwood-snapshot-testing/src/iosMain/kotlin/app/cash/redwood/snapshot/testing/UIViewSnapshotter.kt
@@ -15,7 +15,7 @@
  */
 package app.cash.redwood.snapshot.testing
 
-import app.cash.burst.TestFunction
+import app.cash.burst.coroutines.CoroutineTestFunction
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
 import kotlinx.cinterop.useContents
@@ -40,7 +40,7 @@ class UIViewSnapshotter private constructor(
   private val heightConstraint: Constraint = Constraint.Fill,
 ) : Snapshotter {
 
-  override fun snapshot(name: String?, scrolling: Boolean) {
+  override suspend fun snapshot(name: String?, scrolling: Boolean) {
     layoutSubject(scrolling)
 
     // Unfortunately even with animations forced off, UITableView's animation system breaks
@@ -126,7 +126,7 @@ class UIViewSnapshotter private constructor(
       return UIViewSnapshotter(callback, frame, widthConstraint, heightConstraint)
     }
 
-    override fun intercept(testFunction: TestFunction) {
+    override suspend fun intercept(testFunction: CoroutineTestFunction) {
       testFunction()
     }
   }

--- a/redwood-widget-shared-test/build.gradle
+++ b/redwood-widget-shared-test/build.gradle
@@ -21,6 +21,8 @@ kotlin {
         api projects.redwoodYoga
         api libs.kotlin.test
         implementation libs.assertk
+        implementation libs.burst.coroutines
+        implementation libs.kotlinx.coroutines.test
       }
     }
     jvmMain {

--- a/redwood-widget-shared-test/src/commonMain/kotlin/app/cash/redwood/widget/AbstractRedwoodViewTest.kt
+++ b/redwood-widget-shared-test/src/commonMain/kotlin/app/cash/redwood/widget/AbstractRedwoodViewTest.kt
@@ -25,6 +25,7 @@ import app.cash.redwood.snapshot.testing.color
 import app.cash.redwood.snapshot.testing.text
 import app.cash.redwood.ui.dp
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 abstract class AbstractRedwoodViewTest<W : Any, R : RedwoodView<W>> {
 
@@ -40,7 +41,7 @@ abstract class AbstractRedwoodViewTest<W : Any, R : RedwoodView<W>> {
    * https://github.com/cashapp/redwood/issues/2128
    */
   @Test
-  fun testSingleChildElement() {
+  fun testSingleChildElement() = runTest {
     val redwoodView = redwoodView()
     redwoodView.children.insert(0, widgetFactory.text("Hello ".repeat(50)))
     snapshotterFactory(redwoodView.value).snapshot()
@@ -48,7 +49,7 @@ abstract class AbstractRedwoodViewTest<W : Any, R : RedwoodView<W>> {
 
   /** RedwoodView is measured by its content. */
   @Test
-  fun testWrapped() {
+  fun testWrapped() = runTest {
     // Green, Blue, Green.
     val rootColumn = widgetFactory.column()
     rootColumn.add(widgetFactory.color(Green, 100.dp, 100.dp).value)
@@ -67,7 +68,7 @@ abstract class AbstractRedwoodViewTest<W : Any, R : RedwoodView<W>> {
 
   /** RedwoodView's height can exceed the height of the screen. */
   @Test
-  fun testExceedsScreenSize() {
+  fun testExceedsScreenSize() = runTest {
     // Green, Blue, Red, Blue, Red, ... Blue, Red, Green.
     val rootColumn = widgetFactory.column()
     rootColumn.add(widgetFactory.color(Green, 100.dp, 100.dp).value)


### PR DESCRIPTION
This makes all of the snapshot-using tests suspending.

This requires an update to Burst, which previously didn't suspend nicely for Kotlin/JS.
