### PR TITLE
Bump to minSdk 23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New:
 - Focus API. Redwood has a new `FocusRequester` to focus a widget.
 
 Changed:
-- Nothing yet!
+- Android libaries now have a minimum SDK level of 23.
 
 Fixed:
 - Don't measure the height of `RedwoodUIView` as zero when measured with `sizeThatFits()` or `intrinsicContentSize()`. We had been using `UIStackView` which doesn't support these functions.

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -173,7 +173,7 @@ class RedwoodBuildPlugin : Plugin<Project> {
           it.targetCompatibility = JavaVersion.VERSION_11
         }
         defaultConfig {
-          it.minSdk = 21
+          it.minSdk = 23
           it.targetSdk = 33
         }
         lintOptions {


### PR DESCRIPTION
AndroidX bumped to this a while ago. Internally we're well above this.

Unblocks https://github.com/JakeWharton/prerelease-testing/pull/131

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
