### PR TITLE
Put a white background behind layout snapshots

### DIFF
--- a/redwood-dom-testing/src/commonMain/kotlin/app/cash/redwood/dom/testing/DomSnapshotter.kt
+++ b/redwood-dom-testing/src/commonMain/kotlin/app/cash/redwood/dom/testing/DomSnapshotter.kt
@@ -72,7 +72,6 @@ public class DomSnapshotter @PublishedApi internal constructor(
           this.canvasWidth = this.width
           this.canvasHeight = this.height
           this.pixelRatio = frame.pixelRatio
-          this.backgroundColor = "transparent"
         },
       ).await()
     } finally {

--- a/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testBothSpacer.png
+++ b/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testBothSpacer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a1e2a749823105b65fab82925e8fa521ee75fb56ef5b529a05d8935c0954b97
-size 2162
+oid sha256:105edd044eb4530cbc4ffdb5755f765d0d2aa7985abad1383c2e384e0674fae4
+size 2732

--- a/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testHeightOnlySpacer.png
+++ b/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testHeightOnlySpacer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:685df20a2e132ca6e55c5857e4c94af45782a7613c73129478f615fec2edb554
-size 1426
+oid sha256:3f715be95b5bd947bd2ec3ca1ff8fa4ab6cabb4edd60067393f5fabeecbb005b
+size 1714

--- a/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testWidthOnlySpacer.png
+++ b/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testWidthOnlySpacer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16606d39b1b06ae7cb85cf2a7009fed53e29d7e1ace8c221608ef108172dd30c
-size 1349
+oid sha256:1abdbc2a787ab1b4729a75066b671b387946b5e60fec50f25774fe1af907aed4
+size 1685

--- a/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testZeroSpacer.png
+++ b/redwood-layout-dom/snapshots/app.cash.redwood.layout/AbstractSpacerTest/testZeroSpacer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d09f7e88ea05bc911fad74a9ef190c9dc803919d9a1d6eb692d0cff9bebc5354
-size 1250
+oid sha256:85da8235db2f96df69238cadcf9a79a7613d55e5dc906812633d6040ebc55bfb
+size 1592

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testBothSpacer.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testBothSpacer.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:249396db86efabb8eb76c377fe55eac8319e443a4682a0e10e72fa7ec06b11e6
-size 6470
+oid sha256:b6d508a6b33ee0d8c8544cf1106aef1c33e6eb5afd2a1e17a10ab06003905ea0
+size 8413

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testHeightOnlySpacer.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testHeightOnlySpacer.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55433551b9a12c8054a5d20a8290116947452332f458fc9d0ea776401cad2e97
-size 5083
+oid sha256:0d4e2b0d4e2e25ebd15d375205592d2ade9d1f7d0bd7ce0ea52f7a6f92837202
+size 6709

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testWidthOnlySpacer.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testWidthOnlySpacer.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d49616824c24b84622acc681056b32ea26514cf21a9b0d2aa25076c088392118
-size 3659
+oid sha256:9f6dca3419daecccc9cb168914275cdfca725e79e72898edaee3db642015bb8e
+size 4287

--- a/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testZeroSpacer.1.png
+++ b/redwood-layout-uiview/RedwoodLayoutUIViewTests/__Snapshots__/UIViewSpacerTestHost/testZeroSpacer.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d68be91d9c2492ca6b4aa0490a740fdeeb99a27a23e16c5995a2d592b319637
-size 3085
+oid sha256:d6d6c1d23f108dc3512abee920a43176df7056fcc39d670955a69555e5e27db5
+size 3723

--- a/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSpacerTest.kt
+++ b/redwood-layout-uiview/src/commonTest/kotlin/app/cash/redwood/layout/uiview/UIViewSpacerTest.kt
@@ -22,6 +22,7 @@ import app.cash.redwood.widget.Widget
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIColor
 import platform.UIKit.UILabel
 import platform.UIKit.UILayoutConstraintAxisHorizontal
 import platform.UIKit.UILayoutConstraintAxisVertical
@@ -39,6 +40,7 @@ class UIViewSpacerTest(
 
   override fun wrap(widget: Widget<UIView>, horizontal: Boolean): UIView {
     return UIStackView().apply {
+      backgroundColor = UIColor.whiteColor
       axis = if (horizontal) UILayoutConstraintAxisHorizontal else UILayoutConstraintAxisVertical
       addArrangedSubview(UILabel().apply { text = "Text 1" })
       addArrangedSubview(widget.value)


### PR DESCRIPTION
We're already doing this on Android Views and Compose UI.
