### PR TITLE
Install UI core modifiers for Gradle plugin tests

### DIFF
--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -128,6 +128,7 @@ test {
   dependsOn(':redwood-tooling-lint:publishAllPublicationsToLocalMavenRepository')
   dependsOn(':redwood-tooling-schema:publishAllPublicationsToLocalMavenRepository')
   dependsOn(':redwood-ui-core-api:publishAllPublicationsToLocalMavenRepository')
+  dependsOn(':redwood-ui-core-modifiers:publishAllPublicationsToLocalMavenRepository')
   dependsOn(':redwood-widget:publishAllPublicationsToLocalMavenRepository')
   dependsOn(':redwood-widget-composeui:publishAllPublicationsToLocalMavenRepository')
 


### PR DESCRIPTION
The generator plugin adds a dependency on redwood-compose which depends on redwood-ui-core-modifiers.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
