### PR TITLE
Migrate to AndroidX collections and Compose runtime

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,12 @@
         'org.jetbrains.kotlin:kotlin{/,}**',
       ],
     },
+    {
+      packagePatterns: [
+        '^org.jetbrains.compose.runtime:runtime:',
+      ],
+      enabled: false,
+    },
   ],
   ignorePresets: [
     // Ensure we get the latest version and are not pinned to old versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ New:
 - Focus API. Redwood has a new `FocusRequester` to focus a widget.
 
 Changed:
-- Android libaries now have a minimum SDK level of 23.
+- Android libraries now have a minimum SDK level of 23.
 - iOS x64 targets are no longer supported.
+- Use AndroidX collection and Compose runtime artifacts, which are now fully multiplatform. A dependency constraint to the JetBrains Compose runtime version 1.9.0 has been added, which is the first version that is empty and itself now points to AndroidX.
 
 Fixed:
 - Don't measure the height of `RedwoodUIView` as zero when measured with `sizeThatFits()` or `intrinsicContentSize()`. We had been using `UIStackView` which doesn't support these functions.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,8 @@ buildConfigPlugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-appCompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
+androidx-collection = "androidx.collection:collection:1.5.0"
+androidx-compose-runtime = "androidx.compose.runtime:runtime:1.9.1"
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose-ui" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-ui" }
 androidx-core = { module = "androidx.core:core-ktx", version = "1.16.0" }
@@ -63,11 +65,9 @@ autoService-kspCompiler = "dev.zacsweers.autoservice:auto-service-ksp:1.2.0"
 
 google-material = { module = "com.google.android.material:material", version = "1.13.0" }
 
-jetbrains-compose-collection = { module = "org.jetbrains.compose.collection-internal:collection", version.ref = "jbCompose" }
 jetbrains-compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "jbCompose" }
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "jbCompose" }
 jetbrains-compose-material = { module = "org.jetbrains.compose.material:material", version.ref = "jbCompose" }
-jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jbCompose" }
 jetbrains-compose-runtime-saveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "jbCompose" }
 jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jbCompose" }
 jetbrains-compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "jbCompose" }

--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -29,7 +29,7 @@ kotlin {
         api projects.redwoodUiCoreApi
         api projects.redwoodUiCoreModifiers
         api projects.redwoodWidget
-        api libs.jetbrains.compose.runtime
+        api libs.androidx.compose.runtime
         api libs.jetbrains.compose.runtime.saveable
       }
     }
@@ -54,7 +54,7 @@ kotlin {
     nonJsMain {
       kotlin.srcDir(redwoodBuild.generateComposeHelpers(tasks, 'app.cash.redwood.compose'))
       dependencies {
-        implementation libs.jetbrains.compose.collection
+        implementation libs.androidx.collection
       }
     }
   }

--- a/redwood-gradle-plugin/build.gradle
+++ b/redwood-gradle-plugin/build.gradle
@@ -142,5 +142,5 @@ buildConfig {
 
   packageName('app.cash.redwood.gradle')
   buildConfigField("String", "redwoodVersion", "\"${project.version}\"")
-  buildConfigField("String", "androidxCollectionCoordinates", "\"${libs.jetbrains.compose.collection.get()}\"")
+  buildConfigField("String", "androidxCollectionCoordinates", "\"${libs.androidx.collection.get()}\"")
 }

--- a/redwood-layout-api/build.gradle
+++ b/redwood-layout-api/build.gradle
@@ -13,7 +13,7 @@ kotlin {
     commonMain {
       dependencies {
         api projects.redwoodRuntime
-        api libs.jetbrains.compose.runtime
+        api libs.androidx.compose.runtime
         api libs.kotlinx.serialization.core
       }
     }

--- a/redwood-lazylayout-api/build.gradle
+++ b/redwood-lazylayout-api/build.gradle
@@ -13,7 +13,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
-        api libs.jetbrains.compose.runtime
+        api libs.androidx.compose.runtime
         api libs.kotlinx.serialization.core
       }
     }

--- a/redwood-protocol-host/build.gradle
+++ b/redwood-protocol-host/build.gradle
@@ -16,7 +16,7 @@ kotlin {
         api projects.redwoodProtocol
         api projects.redwoodWidget
         api projects.redwoodLeakDetector
-        implementation libs.jetbrains.compose.collection
+        implementation libs.androidx.collection
       }
     }
     commonTest {

--- a/redwood-runtime/build.gradle
+++ b/redwood-runtime/build.gradle
@@ -13,7 +13,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
-        implementation libs.jetbrains.compose.runtime
+        implementation libs.androidx.compose.runtime
         implementation libs.kotlinx.serialization.core
       }
     }
@@ -22,6 +22,14 @@ kotlin {
         implementation libs.kotlin.test
         implementation libs.assertk
       }
+    }
+  }
+}
+
+dependencies {
+  constraints {
+    commonMainApi("org.jetbrains.compose.runtime:runtime:1.9.0") {
+      because('AndroidX publishes multiplatform version. The JetBrains artifact is now empty.')
     }
   }
 }

--- a/redwood-testing/build.gradle
+++ b/redwood-testing/build.gradle
@@ -11,7 +11,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
-        api libs.jetbrains.compose.runtime
+        api libs.androidx.compose.runtime
         api libs.kotlinx.coroutines.core
         api projects.redwoodProtocolGuest
         api projects.redwoodUiCoreApi

--- a/redwood-treehouse-guest-compose/build.gradle
+++ b/redwood-treehouse-guest-compose/build.gradle
@@ -12,7 +12,7 @@ kotlin {
     commonMain {
       dependencies {
         api projects.redwoodProtocolGuest
-        api libs.jetbrains.compose.runtime
+        api libs.androidx.compose.runtime
       }
     }
   }

--- a/redwood-treehouse-guest/build.gradle
+++ b/redwood-treehouse-guest/build.gradle
@@ -12,7 +12,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
-        api libs.jetbrains.compose.runtime
+        api libs.androidx.compose.runtime
         api libs.kotlinx.coroutines.core
         api libs.okio
         api libs.zipline

--- a/redwood-treehouse-host/build.gradle
+++ b/redwood-treehouse-host/build.gradle
@@ -38,7 +38,7 @@ kotlin {
         implementation libs.kotlinx.coroutines.test
         implementation libs.okio
         implementation libs.turbine
-        implementation libs.jetbrains.compose.collection
+        implementation libs.androidx.collection
         implementation projects.redwoodLayoutTesting
         implementation projects.redwoodLazylayoutTesting
         implementation projects.redwoodUiCoreTesting


### PR DESCRIPTION
Closes #2739

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
