### PR TITLE
Upgrade to AGP 9 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,6 @@ jobs:
           kotlinUpgradeYarnLock
           test
           jvmTest
-          -x testReleaseUnitTest
           -x dokkaHtml
 
   native-tests:

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildExtension.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildExtension.kt
@@ -15,6 +15,10 @@
  */
 package app.cash.redwood.buildsupport
 
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.DeviceTestBuilder
+import com.android.build.api.variant.HasDeviceTestsBuilder
+import org.gradle.api.Project
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
@@ -88,6 +92,24 @@ enum class TargetGroup {
 sealed interface TargetModifier {
   val key: Key<*>
   interface Key<V : Any>
+}
+
+enum class AndroidDeviceTests : TargetModifier {
+  Enable,
+  Disable,
+  ;
+
+  fun applyTo(project: Project) {
+    val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
+    androidComponents.beforeVariants { variant ->
+      if (variant is HasDeviceTestsBuilder) {
+        variant.deviceTests[DeviceTestBuilder.ANDROID_TEST_TYPE]?.enable = this == Enable
+      }
+    }
+  }
+
+  override val key get() = Companion
+  companion object : TargetModifier.Key<AndroidDeviceTests>
 }
 
 enum class JsTests : TargetModifier {

--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -27,8 +27,9 @@ import app.cash.redwood.buildsupport.TargetGroup.ToolkitIos
 import app.cash.redwood.buildsupport.TargetGroup.TreehouseCommon
 import app.cash.redwood.buildsupport.TargetGroup.TreehouseGuest
 import app.cash.redwood.buildsupport.TargetGroup.TreehouseHost
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.gradle.BaseExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import java.io.File
@@ -165,29 +166,31 @@ class RedwoodBuildPlugin : Plugin<Project> {
 
   private fun Project.configureCommonAndroid() {
     plugins.withId("com.android.base") {
-      val android = extensions.getByName("android") as BaseExtension
+      val android = extensions.getByName("android") as CommonExtension
       android.apply {
-        compileSdkVersion(35)
+        compileSdk = 35
         compileOptions {
-          it.sourceCompatibility = JavaVersion.VERSION_11
-          it.targetCompatibility = JavaVersion.VERSION_11
+          sourceCompatibility = JavaVersion.VERSION_11
+          targetCompatibility = JavaVersion.VERSION_11
         }
-        defaultConfig {
-          it.minSdk = 23
-          it.targetSdk = 33
-        }
-        lintOptions {
-          it.isCheckDependencies = true
-          it.isCheckReleaseBuilds = false // Full lint runs as part of 'build' task.
+        defaultConfig.minSdk = 23
+        lint {
+          checkDependencies = true
+          checkReleaseBuilds = false // Full lint runs as part of 'build' task.
         }
       }
     }
 
     plugins.withId("com.android.application") {
-      val android = extensions.getByName("android") as BaseExtension
-      android.packagingOptions.apply {
-        // Keep native symbols for diagnosing sample application crashes.
-        doNotStrip("**/*.so")
+      val android = extensions.getByName("android") as ApplicationExtension
+      android.apply {
+        defaultConfig {
+          targetSdk = 35
+        }
+        packaging.apply {
+          // Keep native symbols for diagnosing sample application crashes.
+          jniLibs.keepDebugSymbols.add("**/*.so")
+        }
       }
       val androidComponents = extensions.getByType(AndroidComponentsExtension::class.java)
       androidComponents.beforeVariants {
@@ -313,7 +316,9 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       Common -> {
         project.applyKotlinMultiplatform {
           iosTargets()
-          modifiedGroup[JsTests, NodeJs].applyTo(js())
+          js {
+            modifiedGroup[JsTests, NodeJs].applyTo(this)
+          }
           jvm()
         }
         // Needed for lint in downstream Android projects to analyze this dependency.
@@ -322,9 +327,13 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       CommonWithAndroid -> {
         project.plugins.apply("com.android.library")
         project.applyKotlinMultiplatform {
-          androidTarget().publishLibraryVariants("release")
+          androidTarget {
+            modifiedGroup[AndroidDeviceTests, AndroidDeviceTests.Disable].applyTo(project)
+          }
           iosTargets()
-          modifiedGroup[JsTests, NodeJs].applyTo(js())
+          js {
+            modifiedGroup[JsTests, NodeJs].applyTo(this)
+          }
           jvm()
         }
       }
@@ -348,6 +357,7 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       ToolkitAndroid -> {
         project.plugins.apply("com.android.library")
         project.plugins.apply("org.jetbrains.kotlin.android")
+        modifiedGroup[AndroidDeviceTests, AndroidDeviceTests.Disable].applyTo(project)
       }
       ToolkitIos -> {
         project.applyKotlinMultiplatform {
@@ -362,7 +372,9 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       ToolkitComposeUi -> {
         project.plugins.apply("com.android.library")
         project.applyKotlinMultiplatform {
-          androidTarget().publishLibraryVariants("release")
+          androidTarget {
+            modifiedGroup[AndroidDeviceTests, AndroidDeviceTests.Disable].applyTo(project)
+          }
           iosTargets()
           jvm()
         }
@@ -370,7 +382,9 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       TreehouseCommon -> {
         project.plugins.apply("com.android.library")
         project.applyKotlinMultiplatform {
-          androidTarget().publishLibraryVariants("release")
+          androidTarget {
+            modifiedGroup[AndroidDeviceTests, AndroidDeviceTests.Disable].applyTo(project)
+          }
           iosTargets()
           js().nodejs()
           jvm()
@@ -385,7 +399,9 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
       TreehouseHost -> {
         project.plugins.apply("com.android.library")
         project.applyKotlinMultiplatform {
-          androidTarget().publishLibraryVariants("release")
+          androidTarget {
+            modifiedGroup[AndroidDeviceTests, AndroidDeviceTests.Disable].applyTo(project)
+          }
           iosTargets()
           jvm()
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,10 @@ android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.library.defaults.buildfeatures.androidresources=false
 
+# Blocked by unreleased Paparazzi changes as of 2025-10-06.
+android.builtInKotlin=false
+android.newDsl=false
+
 kotlin.mpp.enableCInteropCommonization=true
 
 # Work around a Dokka/cinterop/includeBuild problem. https://github.com/Kotlin/dokka/issues/3153

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,7 +76,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "c
 coil-core = { module = "io.coil-kt.coil3:coil-core", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 
-androidGradlePlugin = { module = "com.android.tools.build:gradle", version = "8.13.0" }
+androidGradlePlugin = "com.android.tools.build:gradle:9.0.0-alpha08"
 burst = { module = "app.cash.burst:burst", version.ref = "burst" }
 burst-coroutines = { module = "app.cash.burst:burst-coroutines", version.ref = "burst" }
 burst-gradle-plugin = { module = "app.cash.burst:burst-gradle-plugin", version.ref = "burst" }

--- a/redwood-compose/build.gradle
+++ b/redwood-compose/build.gradle
@@ -1,9 +1,10 @@
+import app.cash.redwood.buildsupport.AndroidDeviceTests
 import app.cash.redwood.buildsupport.JsTests
 
 import static app.cash.redwood.buildsupport.TargetGroup.CommonWithAndroid
 
 redwoodBuild {
-  targets(CommonWithAndroid + JsTests.Browser)
+  targets(CommonWithAndroid + JsTests.Browser + AndroidDeviceTests.Enable)
   publishing()
 }
 

--- a/redwood-treehouse-host/build.gradle
+++ b/redwood-treehouse-host/build.gradle
@@ -1,7 +1,9 @@
+import app.cash.redwood.buildsupport.AndroidDeviceTests
+
 import static app.cash.redwood.buildsupport.TargetGroup.TreehouseHost
 
 redwoodBuild {
-  targets(TreehouseHost)
+  targets(TreehouseHost + AndroidDeviceTests.Enable)
   publishing()
 }
 

--- a/samples/counter/android-tests/build.gradle
+++ b/samples/counter/android-tests/build.gradle
@@ -1,3 +1,5 @@
+import static com.android.build.api.variant.DeviceTestBuilder.ANDROID_TEST_TYPE
+
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
@@ -9,4 +11,10 @@ dependencies {
 
 android {
   namespace = 'com.example.redwood.counter.android.tests'
+}
+
+androidComponents {
+  beforeVariants(selector().all()) { variant ->
+    variant.deviceTests.get(ANDROID_TEST_TYPE).enable = false
+  }
 }


### PR DESCRIPTION
We have to disable all the new hotness because we're stuck on an old Paparazzi for now (although its necessary changes remain unreleased at this time).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
