### PR TITLE
Disable Javadoc jars

### DIFF
--- a/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
+++ b/build-support/src/main/kotlin/app/cash/redwood/buildsupport/RedwoodBuildPlugin.kt
@@ -472,6 +472,11 @@ private class RedwoodBuildExtensionImpl(private val project: Project) : RedwoodB
 
     val mavenPublishing = project.extensions.getByName("mavenPublishing") as MavenPublishBaseExtension
     mavenPublishing.apply {
+      // Disable Javadoc jars. They're basically useless relics, but enabling this will also cause
+      // AGP to use an old version of Dokka which fails to run on the latest Java versions.
+      @Suppress("UnstableApiUsage")
+      configureBasedOnAppliedPlugins(javadocJar = false)
+
       publishToMavenCentral(automaticRelease = true)
       if (project.providers.systemProperty("RELEASE_SIGNING_ENABLED").getOrElse("true").toBoolean()) {
         signAllPublications()

--- a/redwood-bom/build.gradle
+++ b/redwood-bom/build.gradle
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.vanniktech.maven.publish.JavaPlatform
-
 apply plugin: 'java-platform'
 
 redwoodBuild {
   publishing()
-}
-
-mavenPublishing {
-  configure(new JavaPlatform())
 }
 
 dependencies {


### PR DESCRIPTION
AGP embeds a version of Dokka that was failing to run on Java 25, but also Javadoc jars are a relic that we collectively should stop using.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
