### PR TITLE
Correctly expose Burst Corourtines as API

### DIFF
--- a/redwood-snapshot-testing/build.gradle
+++ b/redwood-snapshot-testing/build.gradle
@@ -12,11 +12,11 @@ kotlin {
     commonMain {
       dependencies {
         api libs.burst
+        api libs.burst.coroutines
         api libs.jetbrains.compose.foundation
         api libs.kotlin.test
         api projects.redwoodWidget
         implementation libs.assertk
-        implementation libs.burst.coroutines
       }
     }
     androidMain {


### PR DESCRIPTION
It contains a supertype of a public type.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
