### PR TITLE
Update Kotlin Renovate bundle

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,15 +4,11 @@
     'config:recommended',
   ],
   packageRules: [
-    // Compose compilers and Zipline are tightly coupled to Kotlin version.
+    // Zipline is tightly coupled to Kotlin version.
     {
-      groupName: 'Kotlin, Compose, KSP, and Zipline',
+      groupName: 'Kotlin and Zipline',
       matchPackageNames: [
-        'androidx.compose.compiler{/,}**',
         'app.cash.zipline{/,}**',
-        'com.google.devtools.ksp{/,}**',
-        'dev.drewhamilton.poko{/,}**',
-        'org.jetbrains.compose.compiler{/,}**',
         'org.jetbrains.kotlin:kotlin{/,}**',
       ],
     },


### PR DESCRIPTION
KSP is no longer tied to Kotlin version. Poko generally supports N+1 and N-1 versions. The Compose compiler now lives inside the Kotlin repo and is versioned with it.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
