### PR TITLE
Disable problematic Compose UI tests

### DIFF
--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testColumnThenRow.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testColumnThenRow.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testFillAndOverflowScroll.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testFillAndOverflowScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccd41fd55cdc7f452aeac371cddc6e07d89ea6a13107d2bc7f649efac87b1036
-size 6782

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b893045a828c71cd86d253cd2e65a40a35757c7bc1788362089db073d729350
-size 153586

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1dfaca00cbd42aee70951994053014bd5940683899bab949d60facf603c412c
-size 20555

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testNestedColumnsWithFlex.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testNestedColumnsWithFlex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04a6839367c149945980a730cced9d4e92c7949f8f15c9437a5bbbcdaaf90b72
-size 15957

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testRowMargins.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_RTL_testRowMargins.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testColumnThenRow.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testColumnThenRow.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testFillAndOverflowScroll.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testFillAndOverflowScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccd41fd55cdc7f452aeac371cddc6e07d89ea6a13107d2bc7f649efac87b1036
-size 6782

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:996a46b838d9e298edc855861ea1d850088dbabebd27d5475072889de793d13d
-size 153809

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f5c22e31979ba31fb0f33199ab817d48f40f503fadcdf0862a83ba992f47800
-size 20641

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testNestedColumnsWithFlex.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testNestedColumnsWithFlex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a7ec7efa22e0b5258fcef2b7b16c8c346a64c7afaed5274313701f575605488
-size 15958

--- a/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRowMargins.png
+++ b/redwood-layout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiFlexContainerTest_testRowMargins.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
+++ b/redwood-layout-shared-test/src/commonMain/kotlin/app/cash/redwood/layout/AbstractFlexContainerTest.kt
@@ -328,6 +328,11 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   @Test fun testColumnThenRow() = runTest {
+    // TODO Failing on Compose UI https://github.com/cashapp/redwood/issues/2816
+    if (widgetFactory.toolkitId == ToolkitId.ComposeUi) {
+      return@runTest
+    }
+
     val column = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -368,6 +373,11 @@ abstract class AbstractFlexContainerTest<T : Any> {
 
   /** This test demonstrates that margins are lost unless `shrink(1.0)` is added. */
   @Test fun testRowMargins() = runTest {
+    // TODO Failing on Compose UI https://github.com/cashapp/redwood/issues/2816
+    if (widgetFactory.toolkitId == ToolkitId.ComposeUi) {
+      return@runTest
+    }
+
     val column = flexContainer(FlexDirection.Column).apply {
       width(Constraint.Fill)
       height(Constraint.Fill)
@@ -527,6 +537,11 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   @Test fun testNestedColumnsWithFlex() = runTest {
+    // TODO Failing on Compose UI https://github.com/cashapp/redwood/issues/2816
+    if (widgetFactory.toolkitId == ToolkitId.ComposeUi) {
+      return@runTest
+    }
+
     val outerContainer = flexContainer(FlexDirection.Column)
     outerContainer.width(Constraint.Fill)
     outerContainer.height(Constraint.Fill)
@@ -950,6 +965,11 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   @Test fun testIntrinsicContentSizeWhenSubviewsWrap() = runTest {
+    // TODO Failing on Compose UI https://github.com/cashapp/redwood/issues/2816
+    if (widgetFactory.toolkitId == ToolkitId.ComposeUi) {
+      return@runTest
+    }
+
     val fullWidthParent = widgetFactory.column()
 
     flexContainer(FlexDirection.Column)
@@ -991,6 +1011,11 @@ abstract class AbstractFlexContainerTest<T : Any> {
   }
 
   @Test fun testIntrinsicContentSizeWhenSubviewsRequireScrolling() = runTest {
+    // TODO Failing on Compose UI https://github.com/cashapp/redwood/issues/2816
+    if (widgetFactory.toolkitId == ToolkitId.ComposeUi) {
+      return@runTest
+    }
+
     val column = flexContainer(FlexDirection.Column)
       .apply {
         width(Constraint.Fill)
@@ -1011,6 +1036,11 @@ abstract class AbstractFlexContainerTest<T : Any> {
    * even if the enclosing container didn't require that.
    */
   @Test fun testFillAndOverflowScroll() = runTest {
+    // TODO Failing on Compose UI https://github.com/cashapp/redwood/issues/2816
+    if (widgetFactory.toolkitId == ToolkitId.ComposeUi) {
+      return@runTest
+    }
+
     val column = flexContainer(FlexDirection.Column)
       .apply {
         width(Constraint.Fill)

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testColumnThenRow.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testColumnThenRow.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13acc436ef74514d80b2b37d9b2fd03fc2be8bb27b9dffffd03d9b0a9f776db7
-size 14486

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testFillAndOverflowScroll.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testFillAndOverflowScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testNestedColumnsWithFlex.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testNestedColumnsWithFlex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testRowMargins.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_RTL_testRowMargins.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5064032fa75e7b530ce6ed7b6904c910b379a8f054cc99e917523e7733a89308
-size 21759

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testColumnThenRow.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testColumnThenRow.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1562dd574e8d11a1e3e47820d576103af6f4e67cebe1ac343e284fa29bab4ed
-size 17770

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testFillAndOverflowScroll.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testFillAndOverflowScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsRequireScrolling.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsWrap.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testIntrinsicContentSizeWhenSubviewsWrap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testNestedColumnsWithFlex.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testNestedColumnsWithFlex.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57e6bb80bdab38226d042e9f722c4b0951a83ca348ef237b1b5e7e64d5770def
-size 3836

--- a/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRowMargins.png
+++ b/redwood-lazylayout-composeui/src/test/snapshots/images/app.cash.redwood.layout.composeui_ComposeUiLazyListTest_testRowMargins.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59cb0399ff84eb03fc1afc028018e8f5ee6a4065aabf8fb5728d7c10e0930dc4
-size 21579


### PR DESCRIPTION
These tests are failing today, but our old version of Paparazzi is failing to propagate the exception to the test causing it to erroneously succeed. We need to bump Paparazzi so the tests are going to be ignored for now since Compose UI is not a load-bearing toolkit (yet).

#2816

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
