### PR TITLE
QuickJS leak reproducer

### DIFF
--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -80,7 +80,6 @@ internal abstract class CodeSession<A : AppService>(
       listener.onStop(this)
     }
 
-    // This code block was never executed because dispatchers.close was already called
     scope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
       ziplineStop()
       scope.cancel()

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -80,6 +80,7 @@ internal abstract class CodeSession<A : AppService>(
       listener.onStop(this)
     }
 
+    // This code block will never be executed because dispatchers.close is already called
     scope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
       ziplineStop()
       scope.cancel()

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -80,7 +80,7 @@ internal abstract class CodeSession<A : AppService>(
       listener.onStop(this)
     }
 
-    // This code block will never be executed because dispatchers.close is already called
+    // This code block was never executed because dispatchers.close was already called
     scope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
       ziplineStop()
       scope.cancel()

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -29,6 +29,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okio.FileSystem
 import okio.Path
 
@@ -181,7 +183,12 @@ internal class RealTreehouseApp<A : AppService> private constructor(
     eventListenerFactory?.close()
     eventListenerFactory = null
     stop()
-    dispatchers.close()
+    // This fixes the leak on Android but doesn't fix on iOS
+    appScope.launch(dispatchers.zipline) {
+      withContext(dispatchers.ui) {
+        dispatchers.close()
+      }
+    }
   }
 
   class Factory internal constructor(

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -183,7 +183,7 @@ internal class RealTreehouseApp<A : AppService> private constructor(
     eventListenerFactory?.close()
     eventListenerFactory = null
     stop()
-    // This fixes the leak on Android but doesn't fix on iOS
+    // This fixes the leak on Android but doesn't fix it on iOS
     appScope.launch(dispatchers.zipline) {
       withContext(dispatchers.ui) {
         dispatchers.close()

--- a/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
+++ b/samples/emoji-search/android-composeui/src/main/kotlin/com/example/redwood/emojisearch/android/composeui/EmojiSearchActivity.kt
@@ -21,13 +21,24 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
 import androidx.compose.material.Scaffold
 import androidx.compose.material.SnackbarDuration.Indefinite
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.Text
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.NoLiveLiterals
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import app.cash.redwood.compose.AndroidUiDispatcher.Companion.Main
 import app.cash.redwood.leaks.LeakDetector
@@ -79,8 +90,6 @@ class EmojiSearchActivity : ComponentActivity() {
     WindowCompat.setDecorFitsSystemWindows(window, false)
 
     val client = OkHttpClient()
-    val treehouseApp = createTreehouseApp(client)
-    val treehouseContentSource = TreehouseContentSource(EmojiSearchPresenter::launch)
 
     val imageLoader = ImageLoader.Builder(this)
       .serviceLoaderEnabled(false)
@@ -94,13 +103,37 @@ class EmojiSearchActivity : ComponentActivity() {
         Scaffold(
           snackbarHost = { SnackbarHost(snackbarHostState) },
         ) { contentPadding ->
-          TreehouseContent(
-            treehouseApp = treehouseApp,
-            widgetSystem = ComposeUiRedwoodUiBasicWidgetSystem(imageLoader),
-            contentSource = treehouseContentSource,
-            modifier = Modifier.padding(contentPadding),
-            dynamicContentWidgetFactory = EmojiSearchDynamicContentWidgetFactory(),
-          )
+          var showed by remember { mutableStateOf(false) }
+          Box(modifier = Modifier.fillMaxSize()) {
+            if (showed) {
+              val treehouseApp = remember { createTreehouseApp(client) }
+              val treehouseContentSource = remember {
+                TreehouseContentSource(EmojiSearchPresenter::launch)
+              }
+              TreehouseContent(
+                treehouseApp = treehouseApp,
+                widgetSystem = remember { ComposeUiRedwoodUiBasicWidgetSystem(imageLoader) },
+                contentSource = treehouseContentSource,
+                modifier = Modifier.padding(contentPadding),
+                dynamicContentWidgetFactory = remember { EmojiSearchDynamicContentWidgetFactory() },
+              )
+              DisposableEffect(treehouseApp) {
+                onDispose {
+                  treehouseApp.close()
+                }
+              }
+            }
+            Button(
+              modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 60.dp),
+              onClick = {
+                showed = !showed
+              },
+            ) {
+              Text(if (showed) "Hide" else "Show")
+            }
+          }
         }
       }
     }

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/Base.lproj/Main.storyboard
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/Base.lproj/Main.storyboard
@@ -1,12 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pkw-d6-OOu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24128" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pkw-d6-OOu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--View Controller-->
+        <scene sceneID="YKu-xE-r9G">
+            <objects>
+                <viewController id="hHI-PR-FuW" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Htr-yx-8NA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dqb-TV-H7P">
+                                <rect key="frame" x="154" y="112" width="66" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Open"/>
+                                <connections>
+                                    <segue destination="BYZ-38-t0r" kind="show" id="aiH-uI-zNP"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6cH-UT-SXQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="A0p-79-X7V"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dIF-Ym-DWv" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="306" y="426"/>
+        </scene>
         <!--Emoji Search View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
@@ -15,24 +44,31 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="839" y="499"/>
+            <point key="canvasLocation" x="1201" y="426"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="O0U-eX-d1Q">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" navigationBarHidden="YES" id="pkw-d6-OOu" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pkw-d6-OOu" sceneMemberID="viewController">
                     <toolbarItems/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vCj-8d-jE2">
+                        <rect key="frame" x="0.0" y="20" width="375" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="SEa-bJ-6k2"/>
+                        <segue destination="hHI-PR-FuW" kind="relationship" relationship="rootViewController" id="FrM-ot-fM4"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="hQw-fp-Ygu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-86" y="499"/>
+            <point key="canvasLocation" x="-562" y="426"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
+++ b/samples/emoji-search/ios-uikit/EmojiSearchApp/EmojiSearchViewController.swift
@@ -22,9 +22,12 @@ import SnackBar
 class EmojiSearchViewController : UIViewController, EmojiSearchEventListener {
     // MARK: - Private Properties
 
-    private let urlSession: URLSession = .init(configuration: .default)
+    private static let urlSession: URLSession = .init(configuration: .default)
+    private static let emojiSearchLauncher = EmojiSearchLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
+
     private var success = true
     private var snackBar: SnackBarPresentable? = nil
+    private var app: TreehouseApp<EmojiSearchPresenter>? = nil
 
     // MARK: - UIViewController
 
@@ -35,8 +38,7 @@ class EmojiSearchViewController : UIViewController, EmojiSearchEventListener {
     }
 
     override func loadView() {
-        let emojiSearchLauncher = EmojiSearchLauncher(nsurlSession: urlSession, hostApi: IosHostApi())
-        let treehouseApp = emojiSearchLauncher.createTreehouseApp(listener: self)
+        let treehouseApp = Self.emojiSearchLauncher.createTreehouseApp(listener: self)
         let treehouseView = TreehouseUIView(
             widgetSystem: ExposedKt.basicWidgetSystem(),
             dynamicContentWidgetFactory: EmojiSearchDynamicContentWidgetFactory()
@@ -45,6 +47,7 @@ class EmojiSearchViewController : UIViewController, EmojiSearchEventListener {
             source: EmojiSearchContent()
         )
         ExposedKt.bindWhenReady(content: content, view: treehouseView)
+        self.app = treehouseApp
         view = treehouseView.value
     }
 
@@ -62,6 +65,10 @@ class EmojiSearchViewController : UIViewController, EmojiSearchEventListener {
     func codeLoadSuccess() {
         success = true
         maybeDismissSnackBar()
+    }
+
+    deinit {
+        app?.close()
     }
 
     private func maybeDismissSnackBar() {


### PR DESCRIPTION
This PR contains a reproducer of QuickJS leak

Issue: https://github.com/cashapp/redwood/issues/2897

It also contains a possible fix of it for Android but even with it it still persists on iOS

<img width="1496" height="937" alt="Screenshot 2025-11-22 at 21 15 38" src="https://github.com/user-attachments/assets/43b9252a-1830-48ed-93fb-6f89930f4b76" />

