### PR TITLE
Fix memory leaks in Redwood UIView components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+Fixed:
+- Fix memory leaks in UIView layout components (`UIViewBox`, `UIViewFlexContainer`, `RedwoodUIView`)
+- Fix memory leak in `HostProtocolAdapter`
+
+These leaks affected some Treehouse-based screens and prevented UI components and their associated memory from being released after dismissal.
+
 ## [0.19.0]
 [0.19.0]: https://github.com/cashapp/redwood/releases/tag/0.19.0
 

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewBox.kt
@@ -31,6 +31,8 @@ import app.cash.redwood.ui.Margin
 import app.cash.redwood.widget.ResizableWidget
 import app.cash.redwood.widget.UIViewChildren
 import app.cash.redwood.widget.Widget
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.WeakReference
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.readValue
@@ -89,13 +91,15 @@ internal class UIViewBox :
     var sizeListener: ResizableWidget.SizeListener? = null
     private val measurer = Measurer()
 
+    @OptIn(ExperimentalNativeApi::class)
     val children = UIViewChildren(
       container = this,
       insert = { index, widget ->
         if (widget is ResizableWidget<*>) {
+          val weakView = WeakReference(this@View)
           widget.sizeListener = object : ResizableWidget.SizeListener {
             override fun invalidateSize() {
-              this@View.invalidateSize()
+              weakView.get()?.invalidateSize()
             }
           }
         }

--- a/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
+++ b/redwood-layout-uiview/src/commonMain/kotlin/app/cash/redwood/layout/uiview/UIViewFlexContainer.kt
@@ -27,6 +27,8 @@ import app.cash.redwood.widget.ResizableWidget.SizeListener
 import app.cash.redwood.widget.UIViewChildren
 import app.cash.redwood.yoga.FlexDirection
 import app.cash.redwood.yoga.Node
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.WeakReference
 import kotlinx.cinterop.convert
 import platform.UIKit.UIView
 import platform.darwin.NSInteger
@@ -119,15 +121,18 @@ private fun Node(view: UIView): Node {
   return result
 }
 
+@OptIn(ExperimentalNativeApi::class)
 private class NodeSizeListener(
   private val node: Node,
   private val view: UIView,
-  private val enclosing: UIViewFlexContainer,
+  enclosing: UIViewFlexContainer,
 ) : SizeListener {
+  private val weakEnclosing = WeakReference(enclosing)
+
   override fun invalidateSize() {
     if (node.markDirty()) {
       view.setNeedsLayout()
-      enclosing.invalidateSize()
+      weakEnclosing.get()?.invalidateSize()
     }
   }
 }

--- a/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
+++ b/redwood-protocol-host/src/commonMain/kotlin/app/cash/redwood/protocol/host/HostProtocolAdapter.kt
@@ -49,7 +49,7 @@ public class HostProtocolAdapter<W : Any>(
   guestVersion: RedwoodVersion,
   container: Widget.Children<W>,
   protocol: HostProtocol,
-  private val widgetSystem: WidgetSystem<W>,
+  widgetSystem: WidgetSystem<W>,
   private val eventSink: UiEventSink,
   private val leakDetector: LeakDetector,
 ) : UiChangesSink {
@@ -67,6 +67,8 @@ public class HostProtocolAdapter<W : Any>(
   /** Nodes available for reuse. */
   private val pool = ArrayDeque<ProtocolNode<W>>()
 
+  private var widgetSystem: WidgetSystem<W>? = widgetSystem
+
   private var closed = false
 
   override fun sendChanges(changes: List<UiChange>) {
@@ -81,6 +83,7 @@ public class HostProtocolAdapter<W : Any>(
       when (change) {
         is UiCreate -> {
           val widgetProtocol = protocol.widget(change.tag) ?: continue
+          val widgetSystem = this.widgetSystem ?: return
           val node = widgetProtocol.createNode(id, widgetSystem)
           val old = nodes.put(change.id.value, node)
           require(old == null) {
@@ -126,6 +129,7 @@ public class HostProtocolAdapter<W : Any>(
           val node = node(id)
           node.reuse = change.reuse
 
+          val widgetSystem = this.widgetSystem ?: return
           change.modifier.forEachUnscoped { element ->
             widgetSystem.apply(node.widget.value, element)
           }
@@ -178,6 +182,9 @@ public class HostProtocolAdapter<W : Any>(
       node.detach()
     }
     pool.clear()
+
+    // Clear the widget system to break the reference to Swift objects.
+    widgetSystem = null
   }
 
   private fun poolOrDetach(removedNode: ProtocolNode<W>) {

--- a/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
+++ b/redwood-widget/src/iosMain/kotlin/app/cash/redwood/widget/RedwoodUIView.kt
@@ -24,6 +24,8 @@ import app.cash.redwood.ui.OnBackPressedCallback
 import app.cash.redwood.ui.OnBackPressedDispatcher
 import app.cash.redwood.ui.Size
 import app.cash.redwood.ui.UiConfiguration
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.WeakReference
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.cValue
 import kotlinx.cinterop.convert
@@ -60,15 +62,19 @@ public open class RedwoodUIView : RedwoodView<UIView> {
   override val value: UIView
     get() = valueRootView
 
+  @OptIn(ExperimentalNativeApi::class)
   private val sizeListener = object : ResizableWidget.SizeListener {
+    private val weakRootView = WeakReference(valueRootView)
+
     override fun invalidateSize() {
+      val rootView = weakRootView.get() ?: return
       // This view's size may have changed.
-      valueRootView.setNeedsLayout() // For autolayout.
-      valueRootView.invalidateIntrinsicContentSize() // For SwiftUI.
+      rootView.setNeedsLayout() // For autolayout.
+      rootView.invalidateIntrinsicContentSize() // For SwiftUI.
 
       // And the superview should redo its layout also, if it exists.
-      valueRootView.superview?.setNeedsLayout() // For autolayout.
-      valueRootView.superview?.invalidateIntrinsicContentSize() // For SwiftUI.
+      rootView.superview?.setNeedsLayout() // For autolayout.
+      rootView.superview?.invalidateIntrinsicContentSize() // For SwiftUI.
     }
   }
 


### PR DESCRIPTION
This PR fixes multiple memory leaks in Redwood's iOS/UIView implementation that prevented UI components from being deallocated after they were removed from the view hierarchy (e.g., after logout).

I am _not_ a Kotlin, GC, or Treehouse expert. This is the result of a local redwood -> cash-ios build, a test case of opening several receipts, and a conversation with an LLM that can see both sets of source about the references to leaked objects I can see using the iOS memory graph.

This _does_ get rid of a large number of leaked objects on the iOS side.

Root Cause
Kotlin/Native uses reference counting similar to ARC, but lambdas and anonymous objects create strong references by default. Several components were creating retain cycles that prevented proper cleanup.

Fixes
1. UIViewBox and UIViewFlexContainer - Used WeakReference to break retain cycles in SizeListener callbacks that were capturing parent containers strongly.

2. RedwoodUIView - Used WeakReference in the sizeListener to prevent capturing valueRootView strongly.

3. HostProtocolAdapter - The widgetSystem was being retained even after close() was called, creating a Kotlin→Swift reference chain that kept Swift objects alive. Made widgetSystem nullable and cleared it in close() to break this chain.

Impact
These leaks affected all Treehouse-based screens in Cash iOS. After logout, UI components and their associated graphics memory (VM: Memory Tag objects) remained in memory indefinitely. With these fixes, all components are now properly deallocated when screens are dismissed.

This was tested with Receipts on the activity tab.