### PR TITLE
Fix Zipline leak after RealTreehouseApp.close call (#2897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Fixed:
 - Fix memory leaks in UIView layout components (`UIViewBox`, `UIViewFlexContainer`, `RedwoodUIView`)
 - Fix memory leak in `HostProtocolAdapter`
+- Fix memory leak in `RealTreehouseApp.close`
 
 These leaks affected some Treehouse-based screens and prevented UI components and their associated memory from being released after dismissal.
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/CodeSession.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.job
@@ -37,6 +38,9 @@ internal abstract class CodeSession<A : AppService>(
   private val listeners = mutableListOf<Listener<A>>()
 
   private var stopped = false
+
+  // Used to wait for zipline closure before shutting down the zipline dispatcher
+  internal var ziplineStopJob: Job? = null
 
   /** This scope is canceled when this session stops. */
   val scope: CoroutineScope = run {
@@ -80,10 +84,11 @@ internal abstract class CodeSession<A : AppService>(
       listener.onStop(this)
     }
 
-    scope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
+    ziplineStopJob = scope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
       ziplineStop()
       scope.cancel()
       eventPublisher.close() // Must be last to prevent lost events.
+      ziplineStopJob = null
     }
   }
 

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -183,7 +183,7 @@ internal class RealTreehouseApp<A : AppService> private constructor(
     eventListenerFactory?.close()
     eventListenerFactory = null
     stop()
-    appScope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
+    appScope.launch(dispatchers.ui, start = CoroutineStart.ATOMIC) {
       // Await zipline closure that must be done on dispatchers.zipline
       codeHost.codeSession?.ziplineStopJob?.join()
       dispatchers.close()

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -26,9 +26,11 @@ import app.cash.zipline.loader.ZiplineHttpClient
 import app.cash.zipline.loader.ZiplineLoader
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
 import okio.FileSystem
 import okio.Path
 
@@ -181,7 +183,11 @@ internal class RealTreehouseApp<A : AppService> private constructor(
     eventListenerFactory?.close()
     eventListenerFactory = null
     stop()
-    dispatchers.close()
+    appScope.launch(dispatchers.zipline, start = CoroutineStart.ATOMIC) {
+      // Await zipline closure that must be done on dispatchers.zipline
+      codeHost.codeSession?.ziplineStopJob?.join()
+      dispatchers.close()
+    }
   }
 
   class Factory internal constructor(

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -182,11 +182,12 @@ internal class RealTreehouseApp<A : AppService> private constructor(
     codeHost.close()
     eventListenerFactory?.close()
     eventListenerFactory = null
+    val session = codeHost.codeSession
     stop()
     appScope.launch(dispatchers.ui, start = CoroutineStart.ATOMIC) {
       try {
         // Await zipline closure that must be done on dispatchers.zipline
-        codeHost.codeSession?.ziplineStopJob?.join()
+        session?.ziplineStopJob?.join()
       } finally {
         dispatchers.close()
       }

--- a/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
+++ b/redwood-treehouse-host/src/commonMain/kotlin/app/cash/redwood/treehouse/RealTreehouseApp.kt
@@ -184,9 +184,12 @@ internal class RealTreehouseApp<A : AppService> private constructor(
     eventListenerFactory = null
     stop()
     appScope.launch(dispatchers.ui, start = CoroutineStart.ATOMIC) {
-      // Await zipline closure that must be done on dispatchers.zipline
-      codeHost.codeSession?.ziplineStopJob?.join()
-      dispatchers.close()
+      try {
+        // Await zipline closure that must be done on dispatchers.zipline
+        codeHost.codeSession?.ziplineStopJob?.join()
+      } finally {
+        dispatchers.close()
+      }
     }
   }
 


### PR DESCRIPTION
Fixes Zipline leak on `RealTreehouseApp` closure (https://github.com/cashapp/redwood/issues/2897).

# Cause of the leak

`RealTreehouseApp.close` indirectly schedules a resource unloading coroutine on `dispatchers.zipline` (`RealTreehouseApp.stop -> CodeHost.stop -> CodeSession.stop`). It starts working because of `CoroutineStart.ATOMIC` strategy but then crashes in `ZiplineScope.close`.

This exception could be seen by adding a breakpoint to `CodeSession.handleUncaughtException`:

```
java.lang.IllegalStateException: Zipline closed
	at app.cash.zipline.Zipline$endpoint$1.call(Zipline.kt:64)
	at app.cash.zipline.internal.bridge.OutboundCallHandler.callInternal$zipline_release(OutboundCallHandler.kt:116)
	at app.cash.zipline.internal.bridge.OutboundCallHandler.call(OutboundCallHandler.kt:75)
	at app.cash.redwood.treehouse.AppLifecycle$Companion$Adapter$GeneratedOutboundService.close(AppLifecycle.kt:26)
	at app.cash.zipline.ZiplineScope.close(ZiplineScope.kt:93)
	at app.cash.redwood.treehouse.ZiplineCodeSession.ziplineStop(ZiplineCodeSession.kt:73)
	at app.cash.redwood.treehouse.CodeSession$stop$1.invokeSuspend(CodeSession.kt:85)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
  	at java.lang.Thread.run(Thread.java:1119)
```

---

- [+] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
